### PR TITLE
dcache-view: prevent web robots from traversing dcache-view

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,6 +21,15 @@ gulp.task('copy-index', function() {
         .pipe(gulp.dest('./target'));
 });
 
+gulp.task('copy-robots', function() {
+    return gulp.src([
+        'src/robots.txt'
+    ], {
+        base: ''
+    })
+        .pipe(gulp.dest('./target'));
+});
+
 gulp.task('copy-webcomponents', function() {
     return gulp.src([
         './src/bower_components/webcomponentsjs/webcomponents-lite.min.js'
@@ -79,7 +88,7 @@ gulp.task('deploy-local', function(){
         }))
 });*/
 
-gulp.task('build', ['copy-index', 'copy-css', 'copy-script', 'copy-webcomponents', 'vulcanize']);
+gulp.task('build', ['copy-index', 'copy-robots', 'copy-css', 'copy-script', 'copy-webcomponents', 'vulcanize']);
 
 gulp.task('default', ['bower', 'build'], function () {
     gulp.start('deploy-local');

--- a/src/robots.txt
+++ b/src/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
Disallow all web robots from crawling dcache-view web application.

Target: trunk
Request: 1.0
Require-notes: no
Require-book: no
Acked-by: Paul Millar<paul.millar@desy.de>
Worked-with: 2.16

Reviewed at https://rb.dcache.org/r/9563/

(cherry picked from commit 90ee130423102113db722c00a2ff7953b575ee23)