### PR TITLE
dcache-view: move username+password logic in view-file and file-metadata element

### DIFF
--- a/src/elements/dv-elements/utils/ajax-ls/file-metadata.html
+++ b/src/elements/dv-elements/utils/ajax-ls/file-metadata.html
@@ -163,8 +163,8 @@
 
 				upw: {
 					type: String,
-					value: "anonymous:nopassword",
-					notify: true
+					notify: true,
+                    computed: '_computedUpw(path)'
 				},
 
 				url: {
@@ -190,11 +190,14 @@
 				} else { this.isNotDir = true; }
 			},
 
-			attached: function()
-			{
-				if (!(sessionStorage.upauth === undefined || sessionStorage.upauth == null))
-					this.upw = window.atob(sessionStorage.upauth);
-			},
+            _computedUpw: function(path)
+            {
+                if (!(sessionStorage.upauth === undefined || sessionStorage.upauth == null)) {
+                    return window.atob(sessionStorage.upauth);
+                } else {
+                    return "anonymous:nopassword";
+                }
+            },
 
 			//EventListener
 			listeners: {

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -106,8 +106,8 @@
 
 				upw: {
 					type: String,
-					value: "anonymous:nopassword",
-					notify: true
+					notify: true,
+					computed: '_computedUpw(path)'
 				},
 
 				url: {
@@ -117,10 +117,13 @@
 				}
 			},
 
-			attached: function()
+			_computedUpw: function(path)
 			{
-				if (!(sessionStorage.upauth === undefined || sessionStorage.upauth == null))
-					this.upw = window.atob(sessionStorage.upauth);
+				if (!(sessionStorage.upauth === undefined || sessionStorage.upauth == null)) {
+					return window.atob(sessionStorage.upauth);
+				} else {
+					return "anonymous:nopassword";
+				}
 			},
 
 			_computedClass: function(isSelected)


### PR DESCRIPTION
Motivation:

The attached function in Polymer is called whenever an element is attached
to the document. The view-file and file-metadata element (these are custom
dcache-view elements) makes use of this attached function to setup username
and password.

Unfornately, some browsers seem not to call the attached function when
attaching the view-file and file-metadata element to the DOM. This can be
traced down to the fact that those browsers seem not to catch-up with
mutiple creation and deletion of element (especially view-file) dynamically.
The side-effect of this is that user is never authenticated by dcache-view.

Modification:

Removed attached function and used the computed function to set the value
of the upw property for view-file and file-metadata element.

Result:

All browsers are happy

Target: trunk
Target: 1.0
Require-note: no
Require-book: no
Acked-by: Paul Millar<paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9550/

(cherry picked from commit 4b7a56c43b7581674cce41289c3eee2e0da43721)