### PR TITLE
dcache-view: move delete endpoint to restful service

### DIFF
--- a/src/elements/dv-elements/hover-contextual/hover-contextual.html
+++ b/src/elements/dv-elements/hover-contextual/hover-contextual.html
@@ -126,7 +126,7 @@
           Polymer.dom.flush();
         } else {
           //Download a file
-          path = this._fileWebdavPath();
+          path = this._fileUrl("webdav");
           window.open(path);
         }
         e.stopPropagation();
@@ -145,7 +145,7 @@
       },
       _delete: function ()
       {
-        var url = this._fileWebdavPath();
+        var url = this._fileUrl("rest");
         var name = this.name;
 
         if (sessionStorage.upauth == null || sessionStorage.upauth === undefined){
@@ -179,18 +179,24 @@
         });
       },
 
-      _fileWebdavPath: function ()
+      _fileUrl: function (serviceEndpoint)
       {
-          var webdav = window.CONFIG.webdavEndpoint;
-          if (webdav == "") {
-              return window.location.protocol + "//" + window.location.hostname + ":2880" + this.path;
-          } else {
-              if (webdav.endsWith("/")) {
-                  return webdav.substring(0, webdav.length-1) + this.path;
-              } else {
-                  return webdav + this.path;
-              }
+          switch (serviceEndpoint) {
+              case "webdav":
+                  var webdav = window.CONFIG.webdavEndpoint;
+                  if (webdav == "") {
+                      return window.location.protocol + "//" + window.location.hostname + ":2880" + this.path;
+                  } else {
+                      if (webdav.endsWith("/")) {
+                          return webdav.substring(0, webdav.length-1) + this.path;
+                      } else {
+                          return webdav + this.path;
+                      }
+                  }
+              case "rest":
+                  return window.CONFIG.webapiEndpoint + "namespace" + this.path;
           }
+
       }
     });
   </script>


### PR DESCRIPTION
Motivation:

Currently, dcache-view interface use the webdav to delete a file. Since the
restful api now have this implementation, this patch update dcache-view to
use the restful service.

Result:

Delete calls from dcache-view is now sent to the restful service.

Target: trunk
Request: 1.1
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/9875/

(cherry picked from commit 08064acd994daeb7509d015d07d82d20b3bbc347)