### PR TITLE
dcache-view: make release more standardise

### DIFF
--- a/dv.xml
+++ b/dv.xml
@@ -1,0 +1,17 @@
+<assembly>
+    <id>dcache-view</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>target</directory>
+            <outputDirectory>/</outputDirectory>
+            <excludes>
+                <exclude>*:jar</exclude>
+                <exclude>archive-tmp</exclude>
+            </excludes>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -2,12 +2,6 @@ var gulp = require('gulp');
 var vulcanize = require('gulp-vulcanize');
 var bower = require('gulp-bower');
 
-var maven = require('gulp-maven-deploy');
-var zip = require('gulp-zip');
-var cheerio = require('cheerio');
-var fs = require('fs');
-var version;
-
 gulp.task('bower', function() {
     return bower();
 });
@@ -76,22 +70,9 @@ gulp.task('vulcanize', function() {
         .pipe(gulp.dest('./target/elements'));
 });
 
-gulp.task('read-pom', function () {
-    var pom = fs.readFileSync('./pom.xml');
-    var $ = cheerio.load(pom, { xmlMode: true });
-    version = $('project').children('version').text();
-});
-
-gulp.task('jar', function() {
-    var dvname = "dcache-view-" + version + ".jar";
-    return gulp.src('./target/**')
-        .pipe(zip(dvname))
-        .pipe(gulp.dest('./target'));
-});
-
 gulp.task('build', ['copy-favicons', 'copy-index', 'copy-robots', 'copy-css', 'copy-script',
-    'copy-webcomponents', 'vulcanize', 'read-pom']);
+    'copy-webcomponents']);
 
 gulp.task('default', ['bower', 'build'], function () {
-    gulp.start('jar');
+    gulp.start('vulcanize');
 });

--- a/package.json
+++ b/package.json
@@ -6,10 +6,7 @@
     "bower": "~1.7.2",
     "gulp": "^3.9.0",
     "gulp-bower": "~0.0.13",
-    "gulp-vulcanize": "~6.1.0",
-    "gulp-maven-deploy": "~1.0.0-beta.5",
-    "gulp-zip": "~3.2.0",
-    "cheerio": "~0.22.0"
+    "gulp-vulcanize": "~6.1.0"
   },
   "scripts": {
     "prebuild": "npm install",

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,24 @@
 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptor>dv.xml</descriptor>
+                    <finalName>${project.artifactId}-${project.version}</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-install-plugin</artifactId>
                 <version>2.5.2</version>
                 <executions>


### PR DESCRIPTION
Motivation:

Most part of dcache-view releases is done manually and this
can introduce some errors if not done properly. This release,
include creation of the jar file and its deployment to nexus.

Modification:

1. pom.xml - add a maven assembly plugin with the assembly file
(dv.xml) to generate the jar file.
2. gulpfile.js - remove jar file generation task and all it
dependencies.
3. package.json - remove all unnecessary dependencies.

Result:

Better release and deployment.

Target: trunk
Request: 1.0
Request: 1.1
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10004/

(cherry picked from commit 446c85e9adeaf2444650ab4530cc2aeb315dd8fa)