### PR TITLE
dcache-view: fix styling problem in view-file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "polymer": "Polymer/polymer#1.7.1",
-    "iron-list": "PolymerElements/iron-list#1.3.9",
+    "iron-list": "PolymerElements/iron-list#1.4.0",
     "iron-input": "PolymerElements/iron-input#1.0.10",
     "iron-label": "PolymerElements/iron-label#1.0.2",
     "iron-a11y-keys": "PolymerElements/iron-a11y-keys#1.0.6",

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -1,12 +1,10 @@
 <link rel="import" href="../../../../bower_components/polymer/polymer.html">
 
 <link rel="import" href="../../../../bower_components/iron-ajax/iron-ajax.html">
-<link rel="import" href="../../../../bower_components/iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../../../../bower_components/iron-list/iron-list.html">
 <link rel="import" href="../../../../bower_components/iron-selector/iron-selector.html">
 
 <link rel="import" href="../../../../bower_components/paper-card/paper-card.html">
-
 
 <link rel="import" href="../../list-view/list-row.html">
 <link rel="import" href="../../directory-ls-message/empty-directory.html">
@@ -16,36 +14,41 @@
 
 
 <dom-module id="view-file">
-	<style>
-		:host {
-			@apply(--layout-fit);
-			@apply(--layout-vertical);
-			margin: 0px 30px;
-			/*Prevent text selection after double click*/
-			-webkit-user-select: none; /* webkit (safari, chrome) browsers */
-			-moz-user-select: none; /* mozilla browsers */
-			-khtml-user-select: none; /* webkit (konqueror) browsers */
-			-ms-user-select: none; /* IE10+ */
-		}
-		.fit {
-			@apply(--layout-fit);
-		}
-		.item {
-			text-decoration: none !important;
-			background-color: white;
-			@apply(--layout-flex);
-			cursor:pointer;
-		}
-		.item:hover {
-			background-color: #e9e9e9;
-		}
-		.item.selected {
-			background-color: #2196F3;
-			color: #fafafa;
-			outline: 0;
-		}
-	</style>
 	<template>
+		<style>
+			:host {
+				display: block;
+				max-height: 100vh;
+				display: flex;
+				flex-direction: column;
+				margin: 0px 30px;
+				/*Prevent text selection after double click*/
+				-webkit-user-select: none; /* webkit (safari, chrome) browsers */
+				-moz-user-select: none; /* mozilla browsers */
+				-khtml-user-select: none; /* webkit (konqueror) browsers */
+				-ms-user-select: none; /* IE10+ */
+			}
+			.fit {
+				@apply(--layout-fit);
+			}
+			.item {
+				text-decoration: none !important;
+				background-color: white;
+				@apply(--layout-flex);
+				cursor:pointer;
+			}
+			.item:hover {
+				background-color: #e9e9e9;
+			}
+			.item.selected {
+				background-color: #2196F3;
+				color: #fafafa;
+				outline: 0;
+			}
+			iron-list {
+				flex: 1 1 auto;
+			}
+		</style>
 		<iron-ajax id="ajax"
 				   auto
 				   url="{{url}}"
@@ -57,7 +60,7 @@
 		</iron-ajax>
 		<paper-material id="content" elevation="1">
 			<iron-list id="abc" items="[[data.children]]"
-					   style="min-height:50px;" selected-item="{{selectedItem}}"
+					   selected-item="{{selectedItem}}"
 					   selected-items="{{selectedItems}}" selection-enabled>
 				<template>
 					<div>


### PR DESCRIPTION
Updating the iron-list to the latest version in dcache-view causes
the rendered list of file to be distorted.

Since the move-file element uses the latest version of the iron-list,
it become necessary to update dcache-view dependencies as well.

By simply adjusting the stlying of the iron-list and its host element
rectified the problem.

Target: trunk
Request: 1.0
Request: 1.1
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10034/

(cherry picked from commit ce6008163286a30382e72639ab30cb73c6e81cd1)