### PR TITLE
dcache-view: fix the thrown Uncaught TypeError

### DIFF
--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -31,14 +31,16 @@
     //Ensure that paper-input in the dialog box is always focused
     window.addEventListener('iron-overlay-opened', function(event) {
         var input = event.target.querySelector('[autofocus]');
-        switch(input.tagName.toLowerCase()) {
-            case 'input':
-                input.focus();
-                break;
-            case 'paper-textarea':
-            case 'paper-input':
-                input.$.input.focus();
-                break;
+        if (input != null) {
+            switch(input.tagName.toLowerCase()) {
+                case 'input':
+                    input.focus();
+                    break;
+                case 'paper-textarea':
+                case 'paper-input':
+                    input.$.input.focus();
+                    break;
+            }
         }
     });
 })(document);


### PR DESCRIPTION
Motivation:

dcache-view (dv) listen to an event called `iron-overlay-opened`.
When this event is triggered, dv use it to ensure that paper-input
is always focused. Unfornately paper-input is not the only element
that trigger `iron-overlay-event`. Hence, wheneveran element with
no autofocus attribute trigger this event, it cause an error that
reads:
>`Uncaught TypeError: Cannot read property 'tagName' of null`.

Modification:

By ensuring that only focusable element can be focused, this error
will not be thrown anymore.

Result:

No visible changes to the end user.

Target: trunk
Request: 1.1
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10037/

(cherry picked from commit 5bdc74bfa1159677ea7e4ac582e827f0f841b075)