### PR TITLE
dcache-view: ensure proper display of empty and error page

### DIFF
--- a/src/elements/dv-elements/directory-ls-message/directory-ls-error.html
+++ b/src/elements/dv-elements/directory-ls-message/directory-ls-error.html
@@ -56,7 +56,6 @@
                 }
             },
 
-            //Element Constructor
             factoryImpl: function(message, code)
             {
                 this.code = code;
@@ -65,8 +64,15 @@
 
             attached: function ()
             {
-                /*var c = this.code;
-                 var msg = this.message;*/
+                if (this.parentNode == (app.$.homedir.querySelector('view-file')).querySelector('#content')) {
+                    app.$.listTableHeader.querySelector('list-row-header').classList.add('hidden');
+                }
+            },
+            detached: function ()
+            {
+                if (this.parentNode == (app.$.homedir.querySelector('view-file')).querySelector('#content')) {
+                    app.$.listTableHeader.querySelector('list-row-header').classList.remove('hidden');
+                }
             }
         });
     </script>

--- a/src/elements/dv-elements/directory-ls-message/empty-directory.html
+++ b/src/elements/dv-elements/directory-ls-message/empty-directory.html
@@ -38,9 +38,15 @@
     <script>
         EmptyDirectory = Polymer({
             is: 'empty-directory',
-
-            //Element Constructor
-            factoryImpl: function() {}
+            factoryImpl: function() {},
+            attached: function ()
+            {
+                app.$.listTableHeader.querySelector('list-row-header').classList.add('hidden');
+            },
+            detached: function ()
+            {
+                app.$.listTableHeader.querySelector('list-row-header').classList.remove('hidden');
+            }
         });
     </script>
 </dom-module>

--- a/src/elements/dv-elements/hover-contextual/hover-contextual.html
+++ b/src/elements/dv-elements/hover-contextual/hover-contextual.html
@@ -166,6 +166,12 @@
                     break;
                 }
             }
+
+            if (len == 1) {
+                var ed = document.createElement('empty-directory');
+                var vf = document.querySelector('view-file');
+                vf.querySelector('#content').appendChild(ed);
+            }
           }
         ).catch(
           function(err) {

--- a/src/elements/dv-elements/selected-title/selected-title.html
+++ b/src/elements/dv-elements/selected-title/selected-title.html
@@ -231,26 +231,27 @@
 								dialogBox.close();
 								dialogBox.removeChild(mkdir);
 
-								var list = vf.querySelector('iron-list');
+                                var ed = vf.querySelector('empty-directory');
+                                if (ed != null) {
+                                    vf.querySelector('#content').removeChild(ed);
+                                }
 
-								//FIX: below is a temporary fix
-								//TODO: for an empty directory return an empty item (view-file)
+                                var list = vf.querySelector('iron-list');
 								//TODO: CODE-DUPLICATION - make this a utility: shared-behaviour
-								if (list != null) {
-									list.unshift('items',
-											{
-												"fileName" : name,
-												"fileMimeType" : "application/octet-stream",
-												"fileLocality" : "",
-												"size" : "--",
-												"fileType" : "DIR",
-												"mtime" : "--",
-												"creationTime" : Date.now() //Assumption
-												//TODO: add creation time to the return object of the ajax response
-											}
-									);
-									vf.querySelector('iron-list').fire('iron-resize');
-								}
+								list.unshift('items',
+									{
+										"fileName" : name,
+										"fileMimeType" : "application/octet-stream",
+										"fileLocality" : "",
+										"size" : "--",
+										"fileType" : "DIR",
+										"mtime" : "--",
+										"creationTime" : Date.now() //Assumption
+										//TODO: add creation time to the return object of the ajax response
+									}
+								);
+								vf.querySelector('iron-list').fire('iron-resize');
+
 								app.$.toast.text = req.response.status + ". ";
 								app.$.toast.show();
 							}

--- a/src/elements/dv-elements/upload-files/upload-files-button.html
+++ b/src/elements/dv-elements/upload-files/upload-files-button.html
@@ -95,7 +95,12 @@
                             upLs.hasError = false;
                             upLs.isComplete = true;
                             upLs.message = "Uploaded";
-                            var list = document.querySelector('iron-list');
+                            var vf = document.querySelector('view-file');
+                            var ed = vf.querySelector('empty-directory');
+                            if (ed != null) {
+                                vf.querySelector('#content').removeChild(ed);
+                            }
+                            var list = vf.querySelector('iron-list');
                             list.unshift('items',
                                     {
                                         "fileName" : data.name,

--- a/src/elements/dv-elements/user-authentication/user-login-page.html
+++ b/src/elements/dv-elements/user-authentication/user-login-page.html
@@ -76,14 +76,6 @@
         <div>
             <div id="info"><p style="padding-left: 5px; padding-right: 5px;">{{loginInformation}}</p></div>
             <div id="content">
-                <!--<div id="logo">
-                    <div>
-                        <iron-icon icon="icons:lock"
-                                   style="color: #1ef53e; height:3em; width:3em;">
-                        </iron-icon>
-                    </div>
-                    <span>dCache View</span>
-                </div>-->
                 <div id="innerContent">
                     <div>
                         <input id="username" class="child" is="iron-input" value="{{username::input}}"
@@ -138,11 +130,17 @@
                 this.loginInformation = message;
             },
 
-            attached: function () {
+            attached: function ()
+            {
+                app.$.listTableHeader.querySelector('list-row-header').classList.add('hidden');
                 this.$.username.focus();
                 if (sessionStorage.upauth != null) {
                     sessionStorage.removeItem('upauth');
                 }
+            },
+            detached: function ()
+            {
+                app.$.listTableHeader.querySelector('list-row-header').classList.remove('hidden');
             },
 
             _login: function()

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -182,14 +182,10 @@
 			{
 				var x = request.xhr.response.children;
 
-				if ( x.length == 0 ){
+				if ( x.length == 0 ) {
 					var content = this.$.content;
-					content.innerHTML = "";
 					var el1 = new EmptyDirectory();
 					content.appendChild(el1);
-					app.$.listTableHeader.querySelector('list-row-header').classList.add('hidden');
-				} else {
-					app.$.listTableHeader.querySelector('list-row-header').classList.remove('hidden');
 				}
 
 				Polymer.dom.flush();
@@ -205,8 +201,6 @@
 				var code;
 				var content = this.$.content;
 
-				app.$.listTableHeader.querySelector('list-row-header').classList.add('hidden');
-
 				try {
 					x = request.request.__data__.xhr.response.errors[0];
 					msg = x.message;
@@ -214,7 +208,6 @@
 					switch (code) {
 						case 401:
 							var moreMessage = "If you have an account, enter your User Name and Password.";
-							content.innerHTML = "";
 							var ulp = new UserLoginPage(moreMessage);
 							content.appendChild(ulp);
 							Polymer.dom.flush();
@@ -235,7 +228,6 @@
 					code = 500;
 				}
 
-				content.innerHTML = "";
 				var el1 = new DirectoryLsError(msg, code);
 				content.appendChild(el1);
 


### PR DESCRIPTION
Motivation:

When a new file is uploaded or a new folder is created into an empty directory,
this will not be display to the end user immediately. An end User will need to
reload the page to see the new file or any new modification.

Also, when a directory contain one file and this file was deleted; an empty
directory is not display to the user to reflect the new changes. This applies
to when an error occured during the listing of a directory as well.

Modification & Result:

1. Add the appropriate class to the list-table-header element at the attached
and detached function of:
    a. directory-ls-error;
    b. empty-directory; and
    c. user-login-page
2. Make create, upload and delete features to be more response and display
proper new information on the fly without refreshing the page.

Target: trunk
Request: 1.1
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10038/

(cherry picked from commit 03d6a3375323320b9aa39469d3387878fa35783c)