### PR TITLE
dcache-view: update create-directory element

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -49,7 +49,7 @@
     "paper-input": "PolymerElements/paper-input#1.1.22",
     "paper-scroll-header-panel": "PolymerElements/paper-scroll-header-panel#1.0.16",
     "page": "visionmedia/page.js#1.6.4",
-    "create-directory": "dcache-elements/create-directory#^0.0.2",
+    "create-directory": "dcache-elements/create-directory#^0.0.3",
     "dcache-namespace": "dcache-elements/dcache-namespace#^0.0.2",
     "admin-page": "dcache-elements/admin-page#^0.0.5",
     "file-icon": "dcache-elements/file-icon#^0.0.3"

--- a/src/elements/dv-elements/selected-title/selected-title.html
+++ b/src/elements/dv-elements/selected-title/selected-title.html
@@ -213,6 +213,7 @@
 				var vf = home.querySelector('view-file');
 				var path = vf.path;
 				var dialogBox = document.getElementById('centralDialogBox');
+                dialogBox.innerHTML = "";
 
 				//TODO: Lazy load create-directory and dcache-namespace
 				var mkdir = document.createElement('create-directory');
@@ -266,6 +267,10 @@
 						url: url,
 						name: name
 					});
+				});
+                mkdir.addEventListener('close',function() {
+                    dialogBox.close();
+                    dialogBox.removeChild(mkdir);
 				});
 				dialogBox.appendChild(mkdir);
 				dialogBox.open();


### PR DESCRIPTION
The new version of create-directory element now have a close
event. Updated dcache-view to reflect the new version
implementation.

Target: trunk
Request: 1.0
Request: 1.1
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10024/

(cherry picked from commit 9242c916350ea5f816a5eb795004103272b5bc90)