### PR TITLE
dcache-view: implement lazy-loading of data in view-file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -52,6 +52,8 @@
     "create-directory": "dcache-elements/create-directory#^0.0.3",
     "dcache-namespace": "dcache-elements/dcache-namespace#^0.0.2",
     "admin-page": "dcache-elements/admin-page#^0.0.5",
-    "file-icon": "dcache-elements/file-icon#^0.0.3"
+    "file-icon": "dcache-elements/file-icon#^0.0.3",
+    "iron-scroll-threshold": "PolymerElements/iron-scroll-threshold#^1.0.3",
+    "paper-spinner": "PolymerElements/paper-spinner#^1.2.1"
   }
 }

--- a/src/elements/dv-elements/selected-title/selected-title.html
+++ b/src/elements/dv-elements/selected-title/selected-title.html
@@ -173,7 +173,7 @@
 
 				var el1;
 				var z = app.$.homedir.querySelector('view-file');
-				var x = app.$.homedir.querySelector("#abc");
+				var x = app.$.homedir.querySelector("#feList");
 
 				var path = z.path;
 

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -3,15 +3,15 @@
 <link rel="import" href="../../../../bower_components/iron-ajax/iron-ajax.html">
 <link rel="import" href="../../../../bower_components/iron-list/iron-list.html">
 <link rel="import" href="../../../../bower_components/iron-selector/iron-selector.html">
+<link rel="import" href="../../../../bower_components/iron-scroll-threshold/iron-scroll-threshold.html">
 
-<link rel="import" href="../../../../bower_components/paper-card/paper-card.html">
+<link rel="import" href="../../../../bower_components/paper-spinner/paper-spinner.html">
 
 <link rel="import" href="../../list-view/list-row.html">
 <link rel="import" href="../../directory-ls-message/empty-directory.html">
 <link rel="import" href="../../directory-ls-message/directory-ls-error.html">
 <link rel="import" href="../../user-authentication/user-login-page.html">
 <link rel="import" href="../../user-authentication/switch-user-credential-dialog-box.html">
-
 
 <dom-module id="view-file">
 	<template>
@@ -27,9 +27,6 @@
 				-moz-user-select: none; /* mozilla browsers */
 				-khtml-user-select: none; /* webkit (konqueror) browsers */
 				-ms-user-select: none; /* IE10+ */
-			}
-			.fit {
-				@apply(--layout-fit);
 			}
 			.item {
 				text-decoration: none !important;
@@ -48,18 +45,26 @@
 			iron-list {
 				flex: 1 1 auto;
 			}
+			.loading {
+				text-align: center;
+				height: 40px;
+			}
+			.loading paper-spinner {
+				width: 20px;
+				height: 20px;
+				margin-right: 10px;
+			}
 		</style>
 		<iron-ajax id="ajax"
-				   auto
 				   url="{{url}}"
 				   method="GET"
 				   content-type="application/json"
 				   headers$='[[_computeHeaders(upw)]]'
 				   handle-as="json" on-response="handleResponse"
-				   last-response="{{data}}" on-error="handleError">
+				   on-error="handleError" loading="{{loading}}">
 		</iron-ajax>
 		<paper-material id="content" elevation="1">
-			<iron-list id="abc" items="[[data.children]]"
+			<iron-list id="feList" items="[]"
 					   selected-item="{{selectedItem}}"
 					   selected-items="{{selectedItems}}" selection-enabled>
 				<template>
@@ -75,6 +80,15 @@
 				</template>
 			</iron-list>
 		</paper-material>
+
+		<div class="loading">
+			<paper-spinner alt="Loading data" active="{{loading}}"></paper-spinner>
+		</div>
+
+		<iron-scroll-threshold id="threshold"
+							   lower-threshold="500"
+							   on-lower-threshold="_loadNamespaceData">
+		</iron-scroll-threshold>
 	</template>
 
 	<script>
@@ -118,6 +132,28 @@
 					type: Object,
 					notify: true,
 					computed: '_url(path)'
+				},
+
+                name: {
+				    type:String,
+					notify: true
+				},
+                target: {
+                    type: Object,
+                    value: function() {
+                        return this.$.input;
+                    }
+                },
+
+				__counter__: {
+				    type: Number,
+					value: 0,
+					notify: true
+				},
+				loading: {
+				    type: Boolean,
+					value: true,
+					notify: true
 				}
 			},
 
@@ -125,9 +161,17 @@
 					'changedItems(items.*)'
 			],
 
-			factoryImpl: function(path) {
+			factoryImpl: function(path)
+            {
 				this.path = path;
 			},
+
+			ready: function ()
+			{
+                var target = app.$.homedir.parentNode;
+                this.$.feList.scrollTarget = target;
+                this.$.threshold.scrollTarget = target;
+            },
 
 			_computedUpw: function(path)
 			{
@@ -178,14 +222,21 @@
 				return '{"Authorization":"Basic ' + window.btoa(upw) + '", "Accept":"application/json"}';
 			},
 
-			handleResponse: function(e, request)
+			handleResponse: function(e)
 			{
-				var x = request.xhr.response.children;
+                var children = e.detail.response.children;
+				var d = this;
 
-				if ( x.length == 0 ) {
+				if ( children.length == 0 && this.__counter__ == 0 ) {
 					var content = this.$.content;
 					var el1 = new EmptyDirectory();
 					content.appendChild(el1);
+				} else {
+                    children.forEach(function (child) {
+						d.$.feList.push('items', child)
+                    });
+                    this.$.threshold.clearTriggers();
+                    this.__counter__++;
 				}
 
 				Polymer.dom.flush();
@@ -237,11 +288,20 @@
 				e.stopPropagation();
 			},
 
-			changedItems: function (changedRecord) {
+			changedItems: function (changedRecord)
+            {
 				if (changedRecord.path) {
 					this.querySelector('iron-list').fire('iron-resize');
 				}
-			}
+			},
+
+            _loadNamespaceData: function ()
+			{
+			    const limit = 100;
+                var offset = this.__counter__ * limit;
+                this.$.ajax.params = {"limit":limit, "offset": offset};
+                this.$.ajax.generateRequest();
+            }
 		});
 	</script>
 </dom-module>


### PR DESCRIPTION
Motivation:

At the moment, all the children of a directory is listed inside
dcache-view. If the number of children is very large, this will
slow down the loadiing time of dcache-view.

Modification:

Implement lazy-loading by requesting for more data as the user
scroll down the page.

Result:

Reduce the loading time of directory listing.

Target: trunk
Request: 1.1
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10041/

(cherry picked from commit dd087b46b8d64ac884094e16ca32a21fd2dc722e)