### PR TITLE
dcache-view: enable multiple selection for move op.

### DIFF
--- a/src/elements/dv-elements/selected-title/selected-title.html
+++ b/src/elements/dv-elements/selected-title/selected-title.html
@@ -89,6 +89,9 @@
         .create {
             color: #2196F3;
         }
+        #move {
+            visibility: hidden;
+        }
     </style>
     <template>
         <template is="dom-if" if="{{isHome}}">
@@ -108,6 +111,10 @@
                             <paper-tooltip>move the selected file to another directory</paper-tooltip>
                         </div>
                     </template>
+                    <div>
+                        <paper-toggle-button on-change="_multiselection" noink></paper-toggle-button>
+                        <paper-tooltip>toggle multiple selection</paper-tooltip>
+                    </div>
                     <div>
                         <paper-icon-button class="create"
                                            icon="create-new-folder"
@@ -298,24 +305,25 @@
                 dialogBox.innerHTML = "";
                 var mv = document.createElement('move-file');
                 mv.currentPath = currentPath;
-                /**
-                 * FIXME:
-                 * This is a temp solution, readjust when the
-                 * multiple selection is enable - >
-                 * code: mv.mvFiles = [vf.selectedItems] & mv.addEventListener();
-                 */
-                mv.mvFiles = [vf.selectedItems];
+
+                if (vf.selectedItems.constructor === Array) {
+                    mv.mvFiles = vf.selectedItems;
+                } else {
+                    mv.mvFiles = [vf.selectedItems];
+                }
                 mv.addEventListener('move', function (e) {
                     var list = vf.querySelector('iron-list');
                     var arr = list.items;
                     const len = arr.length;
                     var i;
-                    for (i=0; i<len; i++) {
-                        if (arr[i].fileName == vf.selectedItems.fileName) {
-                            list.splice('items', i, 1);
-                            break;
+                    this.mvFiles.forEach(function (file) {
+                        for (i=0; i < len; i++) {
+                            if (arr[i].fileName == file.fileName) {
+                                list.splice('items', i, 1);
+                                break;
+                            }
                         }
-                    }
+                    });
                     dialogBox.close();
                     app.$.toast.text = e.detail.response.status + ". ";
                     app.$.toast.show();
@@ -345,6 +353,12 @@
                 });
                 dialogBox.appendChild(mv);
                 dialogBox.open();
+            },
+
+            _multiselection: function ()
+            {
+                var vf = document.getElementById('homedir').querySelector('view-file');
+                vf.multiSelection = this.querySelector('paper-toggle-button').active;
             }
         });
     </script>

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -69,7 +69,8 @@
         <paper-material id="content" elevation="1">
             <iron-list id="feList" items="[]"
                        selected-item="{{selectedItem}}"
-                       selected-items="{{selectedItems}}" selection-enabled>
+                       selected-items="{{selectedItems}}"
+                       selection-enabled multi-selection="{{multiSelection}}">
                 <template>
                     <div>
                         <list-row class$="[[_computedClass(selected)]]" tabindex$="[[tabIndex]]"
@@ -154,6 +155,7 @@
                     type:String,
                     notify: true
                 },
+
                 target: {
                     type: Object,
                     value: function() {
@@ -166,16 +168,29 @@
                     value: 0,
                     notify: true
                 },
+
                 loading: {
                     type: Boolean,
                     value: true,
+                    notify: true
+                },
+
+                multiSelection: {
+                    type: Boolean,
+                    value: function () {
+                        if (app.$.selectedTitle.querySelector('paper-toggle-button') != null) {
+                            return app.$.selectedTitle.querySelector('paper-toggle-button').active;
+                        } else {
+                            return false;
+                        }
+                    },
                     notify: true
                 }
             },
 
             observers: [
                 'changedItems(items.*)',
-                'selectedItemsChanged(selectedItems)'
+                'selectedItemsChanged(selectedItems.*)'
             ],
 
             factoryImpl: function(path)
@@ -314,13 +329,9 @@
 
             selectedItemsChanged: function (selectedItems)
             {
-                /**
-                 * FIXME:
-                 * This is a temp solution, readjust when the
-                 * multiple selection is enable
-                 */
                 if (document.getElementById('selectedTitle') != null) {
-                    document.getElementById('selectedTitle').isSelected = selectedItems != null;
+                    document.getElementById('selectedTitle').isSelected =
+                        !(selectedItems.base == null || selectedItems.base.length == 0);
                 }
             },
 


### PR DESCRIPTION
The move operation in dcache-view only support moving of a
single file.

This patch allow user to select multiple files. Selection
of multiple file can be enabled by using a newly added toggle
button to switch on or off the multiple selection feature.

At the present, only move operation is supported. Later patches
will add more operation that can use the multiple selection.

Target: trunk
Request: 1.2
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10052/

(cherry picked from commit 37a9ea166afe0a7e58d2a8fd52726246ba5a3bea)