### PR TITLE
dcache-view: hide main menu button base on page width

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -55,7 +55,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <paper-header-panel class="flex" mode="standard" shadow id="df-main-header">
 
                 <paper-toolbar class="medium-tall">
-                    <paper-icon-button icon="menu" on-tap="menuAction"></paper-icon-button>
+                    <paper-icon-button icon="menu" on-tap="menuAction" id="mainMenu" hidden></paper-icon-button>
                     <span class="title">[[config.orgName]]</span>
                     <div id="WhoAmI"><user-loginout-button></user-loginout-button></div>
                     <div class="bottom fit" style="height: 70px; background-color: #eee;

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -20,6 +20,11 @@
         app.$.dfDrawerPanel.togglePanel();
     };
 
+    window.addEventListener('paper-responsive-change', function (event) {
+        var narrow = event.detail.narrow;
+        app.$.mainMenu.hidden = !narrow;
+    });
+
     //Ensure that paper-input in the dialog box is always focused
     window.addEventListener('iron-overlay-opened', function(event) {
         var input = event.target.querySelector('[autofocus]');


### PR DESCRIPTION
Motivation:

The main menu button always appear on top of dcache-view.
This menu button is meant to be used to display the left-hand
drawer when the page is 'narrow', that is, when the page width
becomes smaller (e.g on mobile screen).

Therefore, it is redundant to display this menu button when the
page width is wide enough.

Modification:

Added event listener (`paper-responsive-change`) that will be fired
based on the page width. When the page is narrow, the menu button
will be display and vice versa.

Result:

Provide a task focus user interface.

Target: trunk
Request: 1.2
Request: 1.1
Request: 1.0
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10053/

(cherry picked from commit d7c0fc99de97271b5f87ac98e7a340f872b35a13)