### PR TITLE
dcache-view: show the current qos of files

### DIFF
--- a/src/elements/dv-elements/list-view/list-row.html
+++ b/src/elements/dv-elements/list-view/list-row.html
@@ -1,11 +1,6 @@
 <link rel="import" href="../../../bower_components/polymer/polymer.html">
 
 <link rel="import" href="../../../bower_components/iron-flex-layout/iron-flex-layout.html">
-<link rel="import" href="../../../bower_components/iron-icons/iron-icons.html">
-<link rel="import" href="../../../bower_components/iron-icons/editor-icons.html">
-<link rel="import" href="../../../bower_components/iron-icons/communication-icons.html">
-<link rel="import" href="../../../bower_components/iron-icons/notification-icons.html">
-
 
 <link rel="import" href="../../../bower_components/paper-icon-button/paper-icon-button.html">
 
@@ -31,11 +26,8 @@
         .name{
             @apply(--layout-flex-3);
         }
-        .ctime, .locality {
+        .ctime, .qos {
             @apply(--layout-flex);
-        }
-        .locality {
-            text-align: center;
         }
         .size {
             @apply(--layout-flex);
@@ -46,30 +38,6 @@
         }
         .fit {
             @apply(--layout-fit);
-        }
-        .online {
-            font-size: 0.3em;
-            color: #2196F3;
-        }
-        .nearline {
-            border: 1px solid #969696;
-            border-radius:3px;
-            margin: 0px !important;
-            font-size: 0.1em !important;
-            color: #f44336;
-            -ms-transform: rotate(180deg); /* IE 9 */
-            -webkit-transform: rotate(180deg); /* Chrome, Safari, Opera */
-            transform: rotate(180deg);
-            animation: blink-animation 1s steps(5, start) 3;
-            -webkit-animation: blink-animation 1s steps(5, start) 3;
-            width: 24px;
-            height: 18px;
-        }
-        @keyframes blink-animation {
-            to {visibility: hidden;}
-        }
-        @-webkit-keyframes blink-animation {
-            to {visibility: hidden;}
         }
         #filename {
             min-width:10px;
@@ -109,14 +77,7 @@
                 </div>
             </div>
             <div class="cell ctime">{{computedCTime}}</div>
-            <div class="cell locality">
-                <template is="dom-if" if="{{isNearline}}" restamp>
-                    <iron-icon icon="communication:voicemail" class="nearline"></iron-icon>
-                </template>
-                <template is="dom-if" if="{{isOnline}}" restamp>
-                    <iron-icon icon="av:album" class="online"></iron-icon>
-                </template>
-            </div>
+            <div class="cell qos"><i>{{qosValue}}</i></div>
             <div class="cell size" id="hovering">
                 <span>{{computedSize}}</span>
             </div>
@@ -177,23 +138,15 @@
                     computed:'_computeFilePath(parentPath, name)'
                 },
 
-                loc: {
+                currentQos: {
                     type: String,
                     notify: true
                 },
 
-                locality: {
+                qosValue: {
                     type: String,
                     notify: true,
-                    computed: '_computeLocality(loc)'
-                },
-                isNearline: {
-                    type: Boolean,
-                    notify: true
-                },
-                isOnline: {
-                    type: Boolean,
-                    notify: true
+                    computed: '_computeQoSValue(currentQos)'
                 }
             },
 
@@ -208,17 +161,17 @@
                 return parentPath + name;
             },
 
-            _computeLocality: function(loc)
+            _computeQoSValue: function(qos)
             {
-                if(loc == "NEARLINE"){
-                    this.isNearline = true;
-                    this.isOnline = false;
-                } else if ( loc == "ONLINE") {
-                    this.isNearline = false;
-                    this.isOnline = true;
-                } else {
-                    this.isNearline = false;
-                    this.isOnline = false;
+                switch (qos) {
+                    case "disk":
+                        return "Disk";
+                    case "tape":
+                        return "Tape";
+                    case "disk+tape":
+                        return "Disk & Tape";
+                    case "unavailable":
+                        return "unavailable";
                 }
             },
 

--- a/src/elements/dv-elements/table-header/list-row-header.html
+++ b/src/elements/dv-elements/table-header/list-row-header.html
@@ -28,7 +28,7 @@
             <div style="padding-left: 10px; padding-right: 10px">Type</div>
             <div class="flex3" style="padding-left:5px;">Name</div>
             <div class="flex">Creation time</div>
-            <div class="flex" style="text-align: center;">Locality</div>
+            <div class="flex">File location</div>
             <div class="flex" style="text-align: right; padding-right: 10px;">Size</div>
         </div>
     </template>

--- a/src/elements/dv-elements/utils/ajax-ls/file-metadata.html
+++ b/src/elements/dv-elements/utils/ajax-ls/file-metadata.html
@@ -87,7 +87,7 @@
                         </div>
                     </div>
                     <div class="card-actions">
-                        <p><b>Last Modified:</b></p>
+                        <p><b>Last modified:</b></p>
                         <div class="horizontal justified">
                             <div style="width:220px; word-wrap: break-word;">
                                 <code>{{mTime}}</code>
@@ -105,18 +105,19 @@
                     </div>
 
                     <div class="card-actions">
-                        <p><b>File Type:</b></p>
+                        <p><b>File type:</b></p>
                         <div class="horizontal justified">
                             <code>{{metadata.fileType}}</code>
                         </div>
                     </div>
 
-                    <template is="dom-if" if="{{isNotDir}}">
+                    <template is="dom-if" if="{{isSomebody}}">
                         <div class="card-actions">
-                            <p><b>Locality Information:</b></p>
+                            <p><b>Quality of Service</b></p>
                             <div class="horizontal justified">
                                 <div style=" width:220px; word-wrap: break-word;">
-                                    <code>{{metadata.fileLocality}}</code>
+                                    <span style="font-size: 0.7em; margin: 5px;">Current File Location: </span>
+                                    <code>{{metadata.currentQos}}</code>
                                 </div>
                             </div>
                         </div>
@@ -170,10 +171,10 @@
                 url: {
                     type: Object,
                     notify: true,
-                    computed: '_url(path)'
+                    computed: '_url(upw,path)'
                 },
 
-                isNotDir: {
+                isSomebody: {
                     type: Boolean,
                     notify: true
                 }
@@ -184,9 +185,7 @@
                 this.fileName = fileName;
                 this.path = path;
                 this.fileType = fileType;
-                if (fileType == "DIR") {
-                    this.isNotDir = false;
-                } else { this.isNotDir = true; }
+                this.isSomebody = !(sessionStorage.upauth === undefined || sessionStorage.upauth == null);
             },
 
             _computedUpw: function(path)
@@ -202,14 +201,18 @@
                 'closeFileMetadataPanel.tap': '_closeFileMetadataPanel'
             },
 
-            _url: function(path)
+            _url: function(upw, path)
             {
-                if ( this.path==null || this.path == "" || this.path == "/") {
-                    return window.CONFIG.webapiEndpoint + "namespace/?children=true&locality=true";
+                if ( path==null || path == "" || path == "/") {
+                    return upw == "anonymous:nopassword" ?
+                        window.CONFIG.webapiEndpoint + "namespace/?children=true" :
+                        window.CONFIG.webapiEndpoint + "namespace/?children=true&qos=true";
                 } else {
-                    path = decodeURIComponent(this.path);
+                    path = decodeURIComponent(path);
                     path = path.replace(/=/g, "/");
-                    return window.CONFIG.webapiEndpoint + "namespace"+ path +"/?children=true&locality=true";
+                    return upw == "anonymous:nopassword" ?
+                        window.CONFIG.webapiEndpoint + "namespace"+ path +"/?children=true" :
+                        window.CONFIG.webapiEndpoint + "namespace"+ path +"/?children=true&qos=true";
                 }
             },
 

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -76,7 +76,7 @@
                         <list-row class$="[[_computedClass(selected)]]" tabindex$="[[tabIndex]]"
                                   name="{{item.fileName}}" file-type="{{item.fileType}}"
                                   ctime="{{item.creationTime}}" mtime="{{item.mtime}}"
-                                  size="{{item.size}}" loc="{{item.fileLocality}}"
+                                  size="{{item.size}}" current-qos="{{item.currentQos}}"
                                   file-mime-type="{{item.fileMimeType}}"
                                   parent-path="[[parent]]">
                         </list-row>
@@ -148,7 +148,7 @@
                 url: {
                     type: Object,
                     notify: true,
-                    computed: '_url(path)'
+                    computed: '_url(upw,path)'
                 },
 
                 name: {
@@ -226,14 +226,18 @@
                 return classes;
             },
 
-            _url: function(path)
+            _url: function(upw, path)
             {
-                if ( this.path==null || this.path == "" || this.path == "/") {
-                    return window.CONFIG.webapiEndpoint + "namespace/?children=true&locality=true";
+                if ( path==null || path == "" || path == "/") {
+                    return upw == "anonymous:nopassword" ?
+                        window.CONFIG.webapiEndpoint + "namespace/?children=true" :
+                        window.CONFIG.webapiEndpoint + "namespace/?children=true&qos=true";
                 } else {
-                    path = decodeURIComponent(this.path);
+                    path = decodeURIComponent(path);
                     path = path.replace(/=/g, "/");
-                    return window.CONFIG.webapiEndpoint + "namespace"+ path +"/?children=true&locality=true";
+                    return upw == "anonymous:nopassword" ?
+                        window.CONFIG.webapiEndpoint + "namespace"+ path +"/?children=true" :
+                        window.CONFIG.webapiEndpoint + "namespace"+ path +"/?children=true&qos=true";
                 }
             },
 


### PR DESCRIPTION
Motivation:

The dcache-resful api now have an implementation to show the file qos.
This patch adjusted dcache-view to utilise the new implementation.

Modification:

1. The url property of both the view-file and file-metadata element
will be set based on the authentication status of the user. Also,
the qos=true parameter is use instead of the previous locality=true.
2. Display file location with text.

Result:

Based on the current implemenatation; the file location will only be
shown if the user is authenticated.

Target: trunk
Request: 1.2
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10078/

(cherry picked from commit dc6a771b7af2cc84496784a921bd153735f87230)