### PR TITLE
dcache-view: update in-house dependencies to the latest version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,12 +20,12 @@
   "dependencies": {
     "admin-page": "dcache-elements/admin-page#0.0.5",
     "create-directory": "dcache-elements/create-directory#0.0.3",
-    "dcache-namespace": "dcache-elements/dcache-namespace#0.0.3",
+    "dcache-namespace": "dcache-elements/dcache-namespace#0.0.4",
     "file-icon": "dcache-elements/file-icon#0.0.3",
-    "move-file": "dcache-elements/move-file#0.0.2",
+    "move-file": "dcache-elements/move-file#0.0.3",
     "page": "visionmedia/page.js#1.6.4",
     "polymer": "Polymer/polymer#1.7.1",
-    "polymer-iron-elements": "dcache-elements/polymer-iron-elements#0.0.2",
-    "polymer-paper-elements": "dcache-elements/polymer-paper-elements#0.0.2"
+    "polymer-iron-elements": "dcache-elements/polymer-iron-elements#0.0.3",
+    "polymer-paper-elements": "dcache-elements/polymer-paper-elements#0.0.3"
   }
 }

--- a/src/elements/dv-elements/hover-contextual/hover-contextual.html
+++ b/src/elements/dv-elements/hover-contextual/hover-contextual.html
@@ -146,6 +146,7 @@
       {
         var url = this._fileUrl("rest");
         var name = this.name;
+        var path = this.path;
 
         if (sessionStorage.upauth == null || sessionStorage.upauth === undefined){
             app.$.toast.text = 'You need to login to delete a file.';
@@ -172,15 +173,20 @@
                 var vf = document.querySelector('view-file');
                 vf.querySelector('#content').appendChild(ed);
             }
+
+            let type = this.fileType == "DIR" ? "Folder" : "File";
+            app.$.toast.text = type + " deleted. ";
+            app.$.toast.show();
           }
         ).catch(
           function(err) {
-            app.$.toast.text = err;
+            app.$.toast.text = err.message;
             app.$.toast.show();
           }
         );
-        namespace.delete({
-            url: url
+        namespace.rm({
+            url: url,
+            path: path
         });
       },
 
@@ -199,7 +205,7 @@
                       }
                   }
               case "rest":
-                  return window.CONFIG.webapiEndpoint + "namespace" + this.path;
+                  return window.CONFIG.webapiEndpoint + "namespace";
           }
       }
     });

--- a/src/elements/dv-elements/selected-title/selected-title.html
+++ b/src/elements/dv-elements/selected-title/selected-title.html
@@ -239,7 +239,7 @@
                 mkdir.dirFullPath = path;
                 mkdir.addEventListener('create',function(e) {
                     var name = e.detail.newFolderName;
-                    var url = window.CONFIG.webapiEndpoint + "namespace" + path;
+                    var url = window.CONFIG.webapiEndpoint + "namespace";
                     var namespace = document.createElement('dcache-namespace');
 
                     if (!(sessionStorage.upauth === undefined || sessionStorage.upauth == null)) {
@@ -247,7 +247,7 @@
                     }
 
                     namespace.promise.then(
-                        function(req) {
+                        function() {
                             dialogBox.close();
                             dialogBox.removeChild(mkdir);
 
@@ -273,18 +273,19 @@
                                 );
                                 vf.querySelector('iron-list').fire('iron-resize');
                             }
-                            app.$.toast.text = req.response.status + ". ";
+                            app.$.toast.text = "Done! New directory created. ";
                             app.$.toast.show();
                         }
                     ).catch(
                         function(err) {
-                            app.$.toast.text = err.toString() + ". ";
+                            app.$.toast.text = err.message + " ";
                             app.$.toast.show();
                         }
                     );
 
                     namespace.mkdir({
                         url: url,
+                        path: path,
                         name: name
                     });
                 });
@@ -301,6 +302,8 @@
                 var home = document.getElementById('homedir');
                 var vf = home.querySelector('view-file');
                 var currentPath = vf.path;
+                let noOfMovedItems = 1;
+                let fileType = "item";
                 var dialogBox = document.getElementById('centralDialogBox');
                 dialogBox.innerHTML = "";
                 var mv = document.createElement('move-file');
@@ -308,6 +311,8 @@
 
                 if (vf.selectedItems.constructor === Array) {
                     mv.mvFiles = vf.selectedItems;
+                    noOfMovedItems = mv.mvFiles.length;
+                    fileType = "items";
                 } else {
                     mv.mvFiles = [vf.selectedItems];
                 }
@@ -325,12 +330,12 @@
                         }
                     });
                     dialogBox.close();
-                    app.$.toast.text = e.detail.response.status + ". ";
+                    app.$.toast.text = noOfMovedItems + " " + fileType + " have been moved from " +
+                        e.detail.response.sourceDirName + " to " + e.detail.response.targetDirName + ". ";
                     app.$.toast.show();
                 });
                 mv.addEventListener('error', function (e) {
-                    var err = e.detail.error;
-                    app.$.toast.text = err.toString() + ". ";
+                    app.$.toast.text = e.detail.error+ " ";
                     app.$.toast.show();
                 });
                 mv.addEventListener('dismiss', function (e) {

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -386,10 +386,12 @@
                 var namespace = document.createElement('dcache-namespace');
                 namespace.auth = window.btoa(this.upw);
                 var path = this.path.endsWith("/") ? this.path : this.path + "/";
-                var source = window.CONFIG.webapiEndpoint + "namespace" + path + this._previousName;
+                var url = window.CONFIG.webapiEndpoint + "namespace";
+                var source = path + this._previousName;
                 var target = path + this.name;
                 namespace.mv({
-                    url: source,
+                    url: url,
+                    path: source,
                     destination: target
                 });
 
@@ -404,7 +406,7 @@
                     }
                 ).catch(
                     function (err) {
-                        app.$.toast.text = err.toString() + ". ";
+                        app.$.toast.text = err.message;
                         app.$.toast.show();
                         dialog.close();
                     }


### PR DESCRIPTION
Modification:

Latest version of these following in-house dependencies were
released:

    1. dcache-namespace
    2. move-file element
    3. polymer-paper-elements
    4. polymer-iron-elements

Hence the dcache-view part that uses the above elements were
adjusted to fit the latest version implementation.

Result:

Meaningfull message will be display based on the operation
performed.

Target: trunk
Request: 1.2
Requires-notes: no
Requires-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/10091/

(cherry picked from commit a8d38604644eca13f49d15d7ebfff611fa5020e5)