### PR TITLE
dcache-view: add user home directory tab

### DIFF
--- a/src/elements/routing.html
+++ b/src/elements/routing.html
@@ -16,7 +16,10 @@
         }
 
         // Middleware
+        window.CONFIG.isSomebody = sessionStorage.upauth != undefined;
+        window.CONFIG.homeDirectory = sessionStorage.homeDirectory;
         app.config = window.CONFIG;
+
 
         // Routes
         page('*', function(ctx, next) {

--- a/src/index.html
+++ b/src/index.html
@@ -66,9 +66,17 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <div class="fit">
                     <paper-drawer-panel drawer-width="60px" id="dfDrawerPanel">
                         <div class="horizontal layout" drawer>
+
                             <paper-menu attr-for-selected="data-route" id="df-page-navigator" selected="[[route]]">
-                                <a data-route="home" href$="{{baseUrl}}">
-                                    <paper-fab icon="device:storage" title="My Root" class="blue" mini></paper-fab>
+                                <template is="dom-if" if="[[config.isSomebody]]">
+                                    <a data-route="home" href$="{{baseUrl}}" on-tap="lsHomeDir">
+                                        <paper-fab icon="icons:home"
+                                                   title="Home Directory" class="red" mini></paper-fab>
+                                    </a>
+                                </template>
+                                <a data-route="home" href$="{{baseUrl}}" on-tap="lsRootDir">
+                                    <paper-fab icon="device:storage"
+                                               title="Root Directory" class="blue" mini></paper-fab>
                                 </a>
 
                                 <a data-route="admin" href$="{{baseUrl}}admin"><!--dashboard-->

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -20,6 +20,49 @@
         app.$.dfDrawerPanel.togglePanel();
     };
 
+    app.lsHomeDir = function()
+    {
+        const path = window.CONFIG.homeDirectory;
+
+        app.$.homedir.innerHTML = "";
+        app.$.selectedTitle.querySelector("#pagination").innerHTML = "";
+
+        const elRoot = new PaginationButton("Root", "/");
+        if ( path == "/") {
+            elRoot.querySelector('a').classList.add("active");
+            app.$.selectedTitle.querySelector("#pagination").appendChild(elRoot);
+        } else {
+            elRoot.querySelector('a').classList.remove("active");
+            app.$.selectedTitle.querySelector("#pagination").appendChild(elRoot);
+            const dirNames = path.split("/");
+            let pt =  "";
+            for (let i = 1; i < dirNames.length; i++) {
+                pt += "/" + dirNames[i];
+                const el = new PaginationButton(dirNames[i], pt);
+                el.querySelector('a').classList.remove("active");
+                if ( i == (dirNames.length-1) ) {
+                    el.querySelector('a').classList.add("active");
+                }
+                app.$.selectedTitle.querySelector("#pagination").appendChild(el);
+            }
+        }
+
+        const el1 = new ViewFile(path);
+        app.$.homedir.appendChild(el1);
+    };
+
+    app.lsRootDir = function()
+    {
+        app.$.homedir.innerHTML = "";
+        app.$.selectedTitle.querySelector("#pagination").innerHTML = "";
+
+        const elRoot = new PaginationButton("Root", "/");
+        elRoot.querySelector('a').classList.add("active");
+        app.$.selectedTitle.querySelector("#pagination").appendChild(elRoot);
+        const el1 = new ViewFile('/');
+        app.$.homedir.appendChild(el1);
+    };
+
     window.addEventListener('paper-responsive-change', function (event) {
         var narrow = event.detail.narrow;
         app.$.mainMenu.hidden = !narrow;

--- a/src/styles/dv-theme.html
+++ b/src/styles/dv-theme.html
@@ -65,6 +65,10 @@
         text-rendering: optimizeLegibility;
         text-decoration: none;
     }
+    #df-page-navigator a.iron-selected::after {
+        outline: 0 solid transparent !important;
+        color: transparent;
+    }
     paper-fab.blue {
         --paper-fab-background: var(--df-blue-500);
         --paper-fab-keyboard-focus-background: var(--df-blue-900);


### PR DESCRIPTION
Motivation:

Add a new user home directory tab.

Modification:

1. Add a home directory navigation button.
2. Adjust the root directory navigation button.
3. Response to the on-tap event of both bottons appropriately.
4. Add two new properties to the global variable (CONFIG).
5. Remove the ugly blue ring when a tab is selected.

Result:

Show a home directory tab when user is authenticated.

Target: trunk
Request: 1.2
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10103/

(cherry picked from commit 85e767e26c0e52ebe0d62489aecd7daca2b37560)