### PR TITLE
dcache-view: log errors during vulcanisation

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 var gulp = require('gulp');
 var vulcanize = require('gulp-vulcanize');
 var bower = require('gulp-bower');
+var gutil = require('gulp-util');
 
 gulp.task('bower', function() {
     return bower();
@@ -67,6 +68,7 @@ gulp.task('vulcanize', function() {
             inlineScripts: true,
             inlineCss: true
         }))
+        .on('error', gutil.log)
         .pipe(gulp.dest('./target/elements'));
 });
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "bower": "~1.7.2",
     "gulp": "^3.9.0",
     "gulp-bower": "~0.0.13",
-    "gulp-vulcanize": "~6.1.0"
+    "gulp-vulcanize": "~6.1.0",
+    "gulp-util ": "~3.0.8"
   },
   "scripts": {
     "prebuild": "npm install",


### PR DESCRIPTION
Motivation:

If errors occur during the process of vulcanising all the
elements, it is difficult to trace these errors since these
are not logged out.

Modification
Add gutil to the packages and adjust the gulp vulcanise task
to logged error out when they occur.

Result:

Make build errors cause during vulcanise more traceable.

Target: trunk
Request: 1.2, 1.1, 1.0
Requires-notes: no
Requires-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/10093/

(cherry picked from commit 3f2fd3d6c21e007d19bbf16c7012d9297b057c32)