### PR TITLE
dcache-view: modify file quality of service

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,12 +20,13 @@
   "dependencies": {
     "admin-page": "dcache-elements/admin-page#0.0.5",
     "create-directory": "dcache-elements/create-directory#0.0.3",
-    "dcache-namespace": "dcache-elements/dcache-namespace#0.0.4",
+    "dcache-namespace": "dcache-elements/dcache-namespace#0.0.5",
     "file-icon": "dcache-elements/file-icon#0.0.3",
-    "move-file": "dcache-elements/move-file#0.0.3",
+    "move-file": "dcache-elements/move-file#0.0.4",
     "page": "visionmedia/page.js#1.6.4",
     "polymer": "Polymer/polymer#1.7.1",
     "polymer-iron-elements": "dcache-elements/polymer-iron-elements#0.0.3",
-    "polymer-paper-elements": "dcache-elements/polymer-paper-elements#0.0.3"
+    "polymer-paper-elements": "dcache-elements/polymer-paper-elements#0.0.3",
+    "qos-backend-information": "dcache-elements/qos-backend-information#0.0.4"
   }
 }

--- a/src/elements/dv-elements/hover-contextual/hover-contextual.html
+++ b/src/elements/dv-elements/hover-contextual/hover-contextual.html
@@ -54,14 +54,26 @@
         path: {
           type: String,
           notify: true
+        },
+
+        currentQos: {
+            type: String,
+            notify: true
+        },
+
+        index: {
+            type: Number,
+            notify: true
         }
       },
 
-      factoryImpl: function(name, fileType, path)
+      factoryImpl: function(name, fileType, path, qos, index)
       {
         this.name = name;
         this.fileType = fileType;
         this.path = path;
+        this.currentQos = qos;
+        this.index = index;
 
         switch (fileType) {
           case "DIR":
@@ -135,7 +147,7 @@
       {
         e.stopPropagation();
         //TODO: Factor this function below out. Simply create an element for this sole purpose.
-        var el1 = new FileMetadata(this.name, this.path, this.fileType);
+        var el1 = new FileMetadata(this.name, this.path, this.fileType, this.currentQos, this.index);
         app.$.metadataDrawer.innerHTML = "";
         app.$.metadataDrawer.appendChild(el1);
         Polymer.dom.flush();

--- a/src/elements/dv-elements/list-view/list-row.html
+++ b/src/elements/dv-elements/list-view/list-row.html
@@ -166,6 +166,10 @@
                 checkboxDisplay: {
                     type: Boolean,
                     notify: true
+                },
+                fileMData: {
+                    type: Object,
+                    notify: true
                 }
             },
 
@@ -291,7 +295,9 @@
                 var a = '<span class="style-scope list-row">'+this.computedSize+'</span>';
                 if ( ((b.innerHTML).toString()).trim() == a.trim() ) {
                     b.querySelector('span').innerHTML = "";
-                    var el1 = new HoverContextual(this.name, this.fileType, this.filePath);
+                    const index = app.$.homeDir.querySelector('#feList').items.indexOf(this.fileMData);
+                    const el1 = new HoverContextual(this.name, this.fileType,
+                        this.filePath, this.fileMData.currentQos, index);
                     b.querySelector('span').appendChild(el1);
                 }
                 Polymer.dom.flush();

--- a/src/elements/dv-elements/selected-title/selected-title.html
+++ b/src/elements/dv-elements/selected-title/selected-title.html
@@ -190,32 +190,37 @@
             {
                 e.stopPropagation();
 
-                var el1;
-                var z = app.$.homedir.querySelector('view-file');
-                var x = app.$.homedir.querySelector("#feList");
+                let el1;
+                let z = app.$.homedir.querySelector('view-file');
+                let x = app.$.homedir.querySelector("#feList");
 
-                var path = z.path;
+                let path = z.path;
+
+                //-10 denote current view i.e. current view path
+                const currentViewIndex = -10;
 
                 app.$.metadataDrawer.innerHTML = "";
 
-                if (path == "/") {
+                if (path === "/") {
                     y = x.selectedItem;
 
-                    if ( y == null ) {
-                        el1 = new FileMetadata("Root", "/", "DIR");
+                    if ( y === null ) {
+                        el1 = new FileMetadata("Root", "/", "DIR", null, currentViewIndex);
                     } else {
-                        el1 = new FileMetadata(y.fileName, "/" + y.fileName, y.fileType);
+                        const index = x.items.indexOf(y);
+                        el1 = new FileMetadata(y.fileName, "/" + y.fileName, y.fileType, y.currentQos, index);
                     }
                     app.$.metadataDrawer.appendChild(el1);
 
                 } else {
-                    if ( x == null || x.selectedItem == null ) {
-                        var n = path.lastIndexOf("/");
-                        var name = path.slice(n+1);
-                        el1 = new FileMetadata(name, path, "DIR");
+                    if ( x === null || x.selectedItem === null ) {
+                        let n = path.lastIndexOf("/");
+                        let name = path.slice(n+1);
+                        el1 = new FileMetadata(name, path, "DIR", null, currentViewIndex);
                     } else {
-                        var y = x.selectedItem;
-                        el1 = new FileMetadata(y.fileName, path + "/" + y.fileName, y.fileType);
+                        let y = x.selectedItem;
+                        const index = x.items.indexOf(y);
+                        el1 = new FileMetadata(y.fileName, path + "/" + y.fileName, y.fileType, y.currentQos, index);
                     }
                     app.$.metadataDrawer.appendChild(el1);
                 }

--- a/src/elements/dv-elements/utils/ajax-ls/file-metadata.html
+++ b/src/elements/dv-elements/utils/ajax-ls/file-metadata.html
@@ -1,16 +1,18 @@
 <link rel="import" href="../../../../bower_components/polymer/polymer.html">
 
 <link rel="import" href="../../../../bower_components/iron-ajax/iron-ajax.html">
-<link rel="import" href="../../../../bower_components/iron-flex-layout/iron-flex-layout.html">
+<link rel="import" href="../../../../bower_components/iron-collapse/iron-collapse.html">
 <link rel="import" href="../../../../bower_components/iron-icons/iron-icons.html">
 
-
-<link rel="import" href="../../../../bower_components/paper-scroll-header-panel/paper-scroll-header-panel.html">
-<link rel="import" href="../../../../bower_components/paper-toolbar/paper-toolbar.html">
 <link rel="import" href="../../../../bower_components/paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../../../../bower_components/paper-scroll-header-panel/paper-scroll-header-panel.html">
+<link rel="import" href="../../../../bower_components/paper-spinner/paper-spinner.html">
+<link rel="import" href="../../../../bower_components/paper-toolbar/paper-toolbar.html">
 
-
+<link rel="import" href="../../../../bower_components/dcache-namespace/dcache-namespace.html">
 <link rel="import" href="../../../../bower_components/file-icon/file-icon.html">
+<link rel="import" href="../../../../bower_components/qos-backend-information/qos-backend-information.html">
+
 <link rel="import" href="../../directory-ls-message/directory-ls-error.html">
 
 <dom-module id="file-metadata">
@@ -18,12 +20,10 @@
         :host {
             height: 100%;
             margin: 0;
+            width: 100%;
         }
         .dir {
             --iron-icon-fill-color:#4FC3F7;
-        }
-        .flex {
-            @apply(--layout-flex);
         }
         .spacer {
             margin-left: 10px !important;
@@ -38,6 +38,10 @@
         .content {
             padding: 2px 7px;
             background: #eee;
+            width: 100%;
+        }
+        .content #content {
+            width: 100%;
         }
         .cafe-light {
             color: var(--paper-grey-600);
@@ -53,6 +57,76 @@
             font-size: 15px;
             vertical-align: middle;
         }
+        .flex, #qosActionsButtons {
+            display: flex;
+        }
+        #qosActionsButtons > paper-button {
+            text-transform: capitalize;
+            font-size: 0.7em;
+            flex: 1 1 auto;
+        }
+        paper-button[disabled] {
+            color: #a8a8a8;
+        }
+        .collapse-header {
+            width: 100%;
+            height: 40px;
+            display: flex;
+            align-items: center;
+        }
+        .collapse-header > span {
+            flex:1;
+            font-size: 0.7em;
+            margin-left: 7px;
+        }
+        .collapse-content > paper-icon-button {
+            width: 34px;
+            height: 34px;
+            color: #333;
+        }
+        .collapse-content {
+            padding: 5px;
+            border: 1px solid #dedede;
+            font-size: 0.7em;
+            white-space:normal !important;
+            max-width: 350px;
+        }
+        .clicked {
+            background: #efefef;
+            border-top: 1px solid #424242;
+        }
+        .rotate {
+            -webkit-animation-name: rotate;
+            -webkit-animation-duration:3s;
+            -webkit-animation-iteration-count: 1;
+            -webkit-animation-timing-function: ease;
+            -webkit-animation-fill-mode: forwards;
+            animation-name: rotate;
+            animation-duration:0.5s;
+            animation-iteration-count: 1;
+            animation-timing-function: ease;
+            animation-fill-mode: forwards;
+        }
+        .key {
+            text-transform:capitalize;
+        }
+
+        @-webkit-keyframes rotate {
+            from {
+                -webkit-transform: rotate(0deg);
+            }
+            to {
+                -webkit-transform: rotate(180deg);
+            }
+        }
+        @keyframes rotate {
+            from {
+                transform: rotate(0deg);
+            }
+            to {
+                transform: rotate(180deg);
+            }
+        }
     </style>
     <template>
         <paper-scroll-header-panel class="flex" fixed>
@@ -61,8 +135,7 @@
                 <div class="spacer title">Metadata Info</div>
                 <paper-icon-button icon="close" title="close" id="closeFileMetadataPanel"></paper-icon-button>
             </paper-toolbar>
-
-            <div class="content">
+            <paper-card class="content">
                 <iron-ajax
                         auto
                         url="{{url}}"
@@ -113,17 +186,68 @@
 
                     <template is="dom-if" if="{{isSomebody}}">
                         <div class="card-actions">
-                            <p><b>Quality of Service</b></p>
+                            <p><b>Quality of Service (QoS)</b></p>
                             <div class="horizontal justified">
                                 <div style=" width:220px; word-wrap: break-word;">
                                     <span style="font-size: 0.7em; margin: 5px;">Current File Location: </span>
-                                    <code>{{metadata.currentQos}}</code>
+                                    <code id="currentQos">{{currentQos}}</code>
                                 </div>
                             </div>
                         </div>
+                        <template is="dom-if" if="{{isRegular}}">
+                            <paper-card style="width:90%; margin: 10px; border: solid 1px #ccc;">
+                                <div class="horizontal justified">
+                                    <p style="font-size: 0.8em; margin: 5px; color:#616161;">
+                                        <b>Change file QoS to:</b>
+                                    </p>
+                                    <div id="qosActionsButtons"
+                                         class="card-actions" style="height: 30px !important; padding: 5px 1px;">
+                                        <template is="dom-repeat" items="[[possibleTransition]]">
+                                            <paper-button on-tap="_changeQos"
+                                                          disabled$="[[_computedDisabled(item.backendCapability.name,currentQos)]]"
+                                                          data-transition-name$="[[item.backendCapability.name]]">
+                                                [[item.backendCapability.name]]
+                                            </paper-button>
+                                        </template>
+                                    </div>
+                                </div>
+                            </paper-card>
+                            <div class="card-actions">
+                                <p style="font-size: 0.8em; margin: 5px; color:#dc2222;">
+                                    <b>Backend Capabilities Information</b>
+                                </p>
+                                <div class="horizontal justified">
+                                    <template is="dom-repeat" items="[[possibleTransition]]">
+                                        <div class="card-actions" style="padding: 0;">
+                                            <div on-tap="_details" class="collapse-header">
+                                                <span>[[item.backendCapability.name]]</span>
+                                                <paper-icon-button icon="icons:expand-more"></paper-icon-button>
+                                            </div>
+                                            <iron-collapse>
+                                                <div class="collapse-content">
+                                                    <div>
+                                                        Transition:
+                                                        [[_valueToString(item.backendCapability.transition)]]
+                                                    </div>
+                                                    <template is="dom-repeat"
+                                                              items="[[_getQosBackendMetadata(item.backendCapability.metadata)]]">
+                                                        <div>
+                                                            <span class="key">[[_formatKey(item.key)]]: </span>
+                                                            <label>[[_valueToString(item.value)]]</label>
+                                                        </div>
+                                                    </template>
+                                                    <paper-spinner active="{{_loadingBackendQosInfo}}"
+                                                                   style="left: 45%;"></paper-spinner>
+                                                </div>
+                                            </iron-collapse>
+                                        </div>
+                                    </template>
+                                </div>
+                            </div>
+                        </template>
                     </template>
                 </paper-card>
-            </div>
+            </paper-card>
         </paper-scroll-header-panel>
     </template>
     <script>
@@ -156,6 +280,11 @@
                     notify: true
                 },
 
+                currentQos: {
+                    type: String,
+                    notify: true
+                },
+
                 parentPath: {
                     type: String,
                     notify: true,
@@ -177,15 +306,49 @@
                 isSomebody: {
                     type: Boolean,
                     notify: true
+                },
+
+                isRegular: {
+                    type: Boolean,
+                    notify: true
+                },
+
+                index: {
+                    type: Number,
+                    notify: true
+                },
+
+                _loadingBackendQosInfo: {
+                    type: Boolean,
+                    value: true,
+                    notify: true
+                },
+                possibleTransition: {
+                    type: Array,
+                    value: function () {
+                        return window.CONFIG.qos;
+                    },
+                    notify: true
                 }
             },
 
-            factoryImpl: function(fileName, path, fileType)
+            factoryImpl: function(fileName, path, fileType, currentQos, index)
             {
                 this.fileName = fileName;
                 this.path = path;
                 this.fileType = fileType;
+                this.index = index;
                 this.isSomebody = !(sessionStorage.upauth === undefined || sessionStorage.upauth == null);
+                this.isRegular = fileType == 'REGULAR';
+                this.currentQos = currentQos;
+                if (window.CONFIG.qos == undefined && window.CONFIG.isSomebody) {
+                    const apiEndPoint = window.CONFIG.webapiEndpoint;
+                    const qos = new QosBackendInformation(apiEndPoint);
+                    qos.addEventListener('qos-backend-response', (e) => {
+                        window.CONFIG.qos = e.detail.response;
+                        this.possibleTransition = e.detail.response;
+                    });
+                }
             },
 
             _computedUpw: function(path)
@@ -250,6 +413,9 @@
                 if (x != null || x != undefined || x != "" ) {
                     this.cTime = new Date(x.creationTime);
                     this.mTime = new Date(x.mtime);
+                    if (this.currentQos == null && this.isSomebody){
+                        this.currentQos = x.currentQos;
+                    }
                 }
             },
 
@@ -289,7 +455,116 @@
                 this.updateStyles();
 
                 e.stopPropagation();
+            },
+
+            _changeQos: function (e)
+            {
+                const target = e.target.getAttribute('data-transition-name');
+                const namespace = document.createElement('dcache-namespace');
+                namespace.auth = sessionStorage.upauth;
+                const path = this.path;
+
+                namespace.promise.then(
+                    () => {
+                        const currentQos = this.currentQos;
+                        app.$.toast.text = "Request successful! File in transition. ";
+                        app.$.toast.show();
+                        this.fire('qos-in-transition', {options: {
+                            currentQos: currentQos,
+                            targetQos: target,
+                            itemIndex: this.index,
+                            path: path
+                        }});
+                    }
+                ).catch(
+                    function(err) {
+                        app.$.toast.text = err.message + " ";
+                        app.$.toast.show();
+                    }
+                );
+
+                namespace.qos({
+                    url: window.CONFIG.webapiEndpoint +'namespace',
+                    path: path,
+                    target: target
+                });
+            },
+
+            _details: function (e)
+            {
+                for (let i = 0; i < e.path.length; i++) {
+                    if (e.path[i].classList.contains("collapse-header")) {
+                        this._showMore(e.path[i].nextElementSibling,e.path[i].children[1]);
+                        break;
+                    }
+                }
+
+            },
+
+            _valueToString: function (arr)
+            {
+                if (arr.toString() == "") {
+                    return 'null';
+                }
+                return arr.toString();
+            },
+
+            _showMore: function (feCollapseNode, btn)
+            {
+                feCollapseNode.toggle();
+                btn.parentNode.classList.toggle("clicked");
+                btn.classList.toggle("rotate");
+                this._loadingBackendQosInfo = window.CONFIG.qos == undefined;
+            },
+
+            _computedDisabled: function (buttonName,currentQos)
+            {
+                if (buttonName == currentQos){
+                    return true;
+                } else {
+                    for (let i=0; i<window.CONFIG.qos.length; i++){
+                        if (window.CONFIG.qos[i].backendCapability.name == currentQos) {
+                            if (window.CONFIG.qos[i].backendCapability.transition.length > 0) {
+                                for (let j=0; j < window.CONFIG.qos[i].backendCapability.transition.length; j++) {
+                                    return window.CONFIG.qos[i].backendCapability.transition[j] != buttonName;
+                                }
+                            } else {
+                                return true;
+                            }
+                            break;
+                        }
+                    }
+                }
+            },
+
+            _getQosBackendMetadata: function (i)
+            {
+                let a = JSON.stringify(i);
+                a = a.slice(1, -1);
+                let b = a.split(",");
+                const len = b.length;
+                let arr = [];
+                for (let j=0; j<len; j++) {
+                    let z = b[j].split(":");
+                    let jsonString = '{"key": ' + z[0] + ', "value": ' + z[1] +'}';
+                    arr.push(JSON.parse(jsonString));
+                }
+                return arr;
+            },
+
+            _formatKey: function (str)
+            {
+                if (str.includes("cdmi_")) {
+                    str = str.replace("cdmi_", "");
+                } else if (str.includes("_provided")) {
+                    str = str.replace("_provided", "");
+                } else if (str.includes("_")) {
+                    str.replace("_", " ");
+                }
+
+                return str
             }
+
         });
     </script>
 </dom-module>

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -78,7 +78,7 @@
                                   name="{{item.fileName}}" file-type="{{item.fileType}}"
                                   ctime="{{item.creationTime}}" mtime="{{item.mtime}}"
                                   size="{{item.size}}" current-qos="{{item.currentQos}}"
-                                  file-mime-type="{{item.fileMimeType}}"
+                                  file-mime-type="{{item.fileMimeType}}" file-m-data="{{item}}"
                                   parent-path="[[parent]]" checkbox-display="{{multiSelection}}">
                         </list-row>
                     </div>

--- a/src/index.html
+++ b/src/index.html
@@ -86,7 +86,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         </div>
 
                         <div main>
-                            <paper-drawer-panel id="metadata" responsive-width="300000px" right-drawer disable-swipe>
+                            <paper-drawer-panel id="metadata" responsive-width="300000px"
+                                                right-drawer drawer-width="400px" disable-swipe>
                                 <paper-header-panel id="metadataDrawer" drawer>
                                     <paper-scroll-header-panel class="flex">
                                         <paper-toolbar style="background:#fafafa; color:#333;">

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -83,4 +83,52 @@
             }
         }
     });
+
+    function updateFeListAndMetaDataDrawer(status, itemIndex)
+    {
+        if (app.$.metadata.selected == 'drawer'){
+            app.$.metadata.querySelector('file-metadata').currentQos = status;
+        }
+        app.$.homeDir.querySelector('#feList')
+            .set('items.'+itemIndex+'.currentQos', status);
+        app.$.homeDir.querySelector('#feList').notifyPath('items.'+itemIndex+'.currentQos');
+    }
+
+    function periodicalCurrentQosRequest(options)
+    {
+        let namespace = document.createElement('dcache-namespace');
+        namespace.auth = sessionStorage.upauth;
+        namespace.promise.then( (req) => {
+            if (req.response.targetQos !== undefined) {
+                updateFeListAndMetaDataDrawer('&#8594; '+ options.targetQos, options.itemIndex);
+
+                //ask every two seconds
+                setTimeout(periodicalCurrentQosRequest(options), 2000);
+            } else if (req.response.currentQos == options.targetQos) {
+                updateFeListAndMetaDataDrawer(req.response.currentQos, options.itemIndex);
+
+                app.$.toast.text = "Transition complete! ";
+                app.$.toast.show();
+            } else {
+                updateFeListAndMetaDataDrawer(options.currentQos, options.itemIndex);
+
+                app.$.toast.text = "Transition terminated. ";
+                app.$.toast.show();
+            }
+        }).catch(
+            function(err) {
+                app.$.toast.text = err.message + " ";
+                app.$.toast.show();
+            }
+        );
+        namespace.getqos({
+            url: window.CONFIG.webapiEndpoint + 'namespace',
+            path: options.path
+        });
+    }
+
+    window.addEventListener('qos-in-transition', function(event) {
+        //make request after 0.1 seconds
+        setTimeout(periodicalCurrentQosRequest(event.detail.options), 100);
+    });
 })(document);


### PR DESCRIPTION
Motivation:

Enable user to modify the qos of a file.

Modification:

1. adjust in-house dependencies to accomodate the new changes:
    dcache-namespace and move-file: this two elements make use
    of a script called precondition. Since polymer 1.xx does not
    support es6 yet and other new elements may use this script,
    the script was wrappered as an html element to avoid multiple
    import and conflict.
2. create a new element called QosBackendInformation, this element
make use of a new script (called majax-requests) that can make
multiple ajax request and return just a single response. Hence all
the qos backend information can be request for all at once.
(see https://github.com/dcache-elements/qos-backend-information)
3. update dependencies inside bower.json
4. modify the FileMetadata element:
    a. added currentQos and index: which is the index number of
the element on the iron-list
    b. store the qos backend on the dcache-view global variable
    c. show the backend information on request
    d. enable the change qos buttons (that is, disk, tape and disk
    and tape) based on the currentQos and possible transition provided
    by backend information.
5. ViewFile, ListRow, SelectedTile and HoverContextual elements were
adjusted to fit the new structure of file-metadata element.
6. listen to the event fired when a change in qos is requested. Once
this event is triggered, its call a function after 0.1 seconds and
this function request for the qos of the file periodically (every 2
seconds) until the transition is complete (see dv.js).
7. increase the width size of the drawer that is used to display the
file metadata (index.html).

Result:

Authenticated user can now modify the qos of a file.

Target: trunk
Request: 1.2
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10102/

(cherry picked from commit 8cabdf4fdeef29f809ceb3df02ddee13044de00c)