### PR TITLE
dcache-view: add Suppress-WWW-Authenticate header

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,11 +20,11 @@
   "dependencies": {
     "admin-page": "dcache-elements/admin-page#0.0.5",
     "create-directory": "dcache-elements/create-directory#0.0.3",
-    "dcache-namespace": "dcache-elements/dcache-namespace#0.0.3",
+    "dcache-namespace": "dcache-elements/dcache-namespace#0.0.6",
     "file-icon": "dcache-elements/file-icon#0.0.3",
     "page": "visionmedia/page.js#1.6.4",
     "polymer": "Polymer/polymer#1.7.1",
     "polymer-iron-elements": "dcache-elements/polymer-iron-elements#0.0.2",
-    "polymer-paper-elements": "dcache-elements/polymer-paper-elements#0.0.2"
+    "polymer-paper-elements": "dcache-elements/polymer-paper-elements#0.0.3"
   }
 }

--- a/src/elements/dv-elements/user-authentication/user-login-page.html
+++ b/src/elements/dv-elements/user-authentication/user-login-page.html
@@ -160,7 +160,7 @@
                 this.$.ajaxUser.url = window.CONFIG.webapiEndpoint+"user";
                 this.$.ajaxUser.headers = {
                     "Authorization": "Basic "+this.auth,
-                    "X-Requested-With": "XMLHttpRequest"
+                    "Suppress-WWW-Authenticate": "Suppress"
                 };
                 sessionStorage.setItem("name", this.username);
                 this.$.ajaxUser.generateRequest();

--- a/src/elements/dv-elements/utils/ajax-ls/file-metadata.html
+++ b/src/elements/dv-elements/utils/ajax-ls/file-metadata.html
@@ -215,7 +215,8 @@
 
             _computeHeaders: function(upw)
             {
-                return '{"Authorization":"Basic ' + window.btoa(upw) + '", "Accept":"application/json"}';
+                return '{"Authorization":"Basic ' + window.btoa(upw)
+                    + '", "Accept":"application/json", "Suppress-WWW-Authenticate": "Suppress"}';
             },
 
             _computeParent: function(path)

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -220,7 +220,8 @@
 
             _computeHeaders: function(upw)
             {
-                return '{"Authorization":"Basic ' + window.btoa(upw) + '", "Accept":"application/json"}';
+                return '{"Authorization":"Basic ' + window.btoa(upw)
+                    + '", "Accept":"application/json", "Suppress-WWW-Authenticate": "Suppress"}';
             },
 
             handleResponse: function(e)

--- a/src/elements/dv-elements/utils/dcache-view-uploader/dcache-view-uploader.js
+++ b/src/elements/dv-elements/utils/dcache-view-uploader/dcache-view-uploader.js
@@ -48,6 +48,7 @@ UploadHandler.prototype.upload = function()
     xhr.open(this.httpMethod, this.url, true);
     xhr.setRequestHeader('Content-Type', this.contentType);
     xhr.setRequestHeader('Authorization', 'Basic ' + this.upauth);
+    xhr.setRequestHeader('Suppress-WWW-Authenticate', "Suppress");
     if (xhr.upload) {
         xhr.upload.addEventListener('progress', this.onProgress);
     }


### PR DESCRIPTION
Motivation:

Since dcache allow us to remove WWW-Authenticate header, this
patch adjust dcache-view and all its dependencies to reflect
this change.

Modification:

Add `Suppress-WWW-Authenticate: suppress` to request send to
dcache.

Result:

No more browser native login prompt.

Target: trunk
Request: 1.1
Request: 1.2
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10231/

(cherry picked from commit 94270ce4c2c423f8bdee4d00f71f073660d34ed1)