### PR TITLE
dcache-view: update QosBackendInformation element usuage

### DIFF
--- a/src/elements/dv-elements/utils/ajax-ls/file-metadata.html
+++ b/src/elements/dv-elements/utils/ajax-ls/file-metadata.html
@@ -343,7 +343,7 @@
                 this.currentQos = currentQos;
                 if (window.CONFIG.qos == undefined && window.CONFIG.isSomebody) {
                     const apiEndPoint = window.CONFIG.webapiEndpoint;
-                    const qos = new QosBackendInformation(apiEndPoint);
+                    const qos = new QosBackendInformation(apiEndPoint, "Basic "+ sessionStorage.upauth);
                     qos.addEventListener('qos-backend-response', (e) => {
                         window.CONFIG.qos = e.detail.response;
                         this.possibleTransition = e.detail.response;


### PR DESCRIPTION
Motivation:

Our 3rd party element: QosBackendInformation now takes in authentication
information in its constructor and if this is not supply, its makes the
request using anonymous user credentials. In the case of FileMetadata
element in dcache-view, it only ask for the qos backend information only
if the user had been authenticated. Hence, the user credential needs to
be supplied when the QosBackendInformation element is created.

Modification:

Add user authentication credential to QosBackendInformation element when
its been created.

Result:

User can now see the qos information also can change/modify the qos.

Request: 1.2
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10250/