### PR TITLE
dcache-view: adjust mkdir to the latest dcache-namespace

### DIFF
--- a/src/elements/dv-elements/selected-title/selected-title.html
+++ b/src/elements/dv-elements/selected-title/selected-title.html
@@ -217,7 +217,7 @@
                 mkdir.dirFullPath = path;
                 mkdir.addEventListener('create',function(e) {
                     var name = e.detail.newFolderName;
-                    var url = window.CONFIG.webapiEndpoint + "namespace" + path;
+                    var url = window.CONFIG.webapiEndpoint + "namespace";
                     var namespace = document.createElement('dcache-namespace');
 
                     if (!(sessionStorage.upauth === undefined || sessionStorage.upauth == null)) {
@@ -263,6 +263,7 @@
 
                     namespace.mkdir({
                         url: url,
+                        path: path,
                         name: name
                     });
                 });


### PR DESCRIPTION
Motivation:

After updating dcache-namespace to the latest one, the
side-effect is that user request to create a new directory
are rejected. This is because the current dcache-namespace
element now seperate the url (i.e., the rest api endpoint)
from the directory path. Therefore, creating a new directory
needs to be adjusted.

Modification:

Remove path from the url and supply it to the make
directory object.

Result:

User no visible change to the end user.

Request: 1.1
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10248/