### PR TITLE
dcache-view: reset the multiselection after create and mv operations

### DIFF
--- a/src/elements/dv-elements/selected-title/selected-title.html
+++ b/src/elements/dv-elements/selected-title/selected-title.html
@@ -278,6 +278,7 @@
                                 );
                                 vf.querySelector('iron-list').fire('iron-resize');
                             }
+                            vf.resetMultiSelection();
                             app.$.toast.text = "Done! New directory created. ";
                             app.$.toast.show();
                         }
@@ -337,6 +338,7 @@
                         }
                     });
                     dialogBox.close();
+                    vf.resetMultiSelection();
                     app.$.toast.text = noOfMovedItems + " " + fileType + " have been moved from " +
                         e.detail.response.sourceDirName + " to " + e.detail.response.targetDirName + ". ";
                     app.$.toast.show();

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -420,6 +420,18 @@
                 var offset = this.__counter__ * limit;
                 this.$.ajax.params = {"limit":limit, "offset": offset};
                 this.$.ajax.generateRequest();
+            },
+
+            /**
+             * FIXME: This is a workaround to reset the checkbox.
+             * This bug that should be fix.
+             */
+            resetMultiSelection: function ()
+            {
+                if (this.multiSelection) {
+                    this.multiSelection = false;
+                    this.multiSelection = true;
+                }
             }
         });
     </script>


### PR DESCRIPTION
Motivation:

When a user activate multiple selection and select some files; if
a move or create operation is performed, the selection will move down
to the next file on the list. This is a bug and we've introduce a
workaround in a previous patch (see, https://rb.dcache.org/r/10144/)
by reseting the multiple selection.

Modification:

Reset the multiple selection after move and create operation. For
1.2 the `resetMultiSelection()` will be added to view-file element.

Result:

At least remove the awkward selection after these operation.
Although the main bug should be fix soon.

Target: trunk
Request: 1.2
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10251/