### PR TITLE
dcache-view: fix Uncaught TypeError in DirectoryLsError

### DIFF
--- a/src/elements/dv-elements/directory-ls-message/directory-ls-error.html
+++ b/src/elements/dv-elements/directory-ls-message/directory-ls-error.html
@@ -70,9 +70,12 @@
             },
             detached: function ()
             {
-                if (this.parentNode == (app.$.homedir.querySelector('view-file')).querySelector('#content')) {
-                    app.$.listTableHeader.querySelector('list-row-header').classList.remove('hidden');
-                }
+                setTimeout(()=>{
+                    if (this.parentNode.id === (app.$.homedir.querySelector('view-file')).querySelector('#content').id) {
+                        app.$.listTableHeader.querySelector('list-row-header').classList.remove('hidden');
+                    }
+                },10);
+
             }
         });
     </script>


### PR DESCRIPTION
Motivation:

In the namespace page, when a user hit an error due to there interaction
with dcache, the error at times is display on the page and the table
header for each colum will be remove (since it serve no purpose at this
time).

But when the user rectify the cause of the error (in one way or the
other) the header title are not shown because the detached callback
for DirectoryLsError element which suppose to do this; is called when
the other part of the page is not ready. And this result in the following:

Uncaught TypeError: Cannot read property 'querySelector' of null
    at HTMLElement.detached (elements.html:26466)
    at HTMLElement._invokeBehavior (elements.html:482)
    at HTMLElement._doBehavior (elements.html:472)
    at elements.html:261
    at Object.whenReady (elements.html:134)
    at HTMLElement.detachedCallback (elements.html:259)
    at HTMLTemplateElement.app.ls (dv.js:43)
    at HTMLElement._ref (elements.html:35499)
    at HTMLAnchorElement.handler (elements.html:3438)
    at HTMLElement.fire (elements.html:4215)

Modification:

Use settimeout function to delay the execution of the detached
callback.

Result:

No more Uncaught TypeError and user can see the table header
when necessary.

Target: trunk
Request: 1.1
Request: 1.2
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10255/

(cherry picked from commit 832737727b60d857d3433d77b33d61cd45199550)