### PR TITLE
dcache-view: adjust to work with dcache 3.0

### DIFF
--- a/src/elements/dv-elements/hover-contextual/hover-contextual.html
+++ b/src/elements/dv-elements/hover-contextual/hover-contextual.html
@@ -20,7 +20,6 @@
       }
     </style>
     <div>
-      <paper-icon-button icon="delete" title="delete" id="delete"></paper-icon-button>
       <paper-icon-button icon="{{icon}}" title="{{tip}}" id="view"></paper-icon-button>
       <paper-icon-button icon="info" title="metadata information" id="info"></paper-icon-button>
     </div>
@@ -79,8 +78,7 @@
       listeners:
       {
         'view.tap': '_view',
-        'info.tap': '_info',
-        'delete.tap': '_delete'
+        'info.tap': '_info'
       },
 
       _view: function(e)
@@ -141,47 +139,6 @@
         Polymer.dom.flush();
         app.$.metadata.openDrawer();
         e.stopPropagation();
-      },
-      _delete: function ()
-      {
-        var url = this._fileUrl("rest");
-        var name = this.name;
-
-        if (sessionStorage.upauth == null || sessionStorage.upauth === undefined){
-            app.$.toast.text = 'You need to login to delete a file.';
-            app.$.toast.show();
-            return;
-        }
-        var namespace = document.createElement('dcache-namespace');
-        namespace.auth = sessionStorage.upauth;
-        namespace.promise.then(
-          function () {
-            var list = document.querySelector('iron-list');
-            var arr = list.items;
-            const len = arr.length;
-            var i;
-            for (i=0; i<len; i++) {
-                if (arr[i].fileName == name) {
-                    list.splice('items', i, 1);
-                    break;
-                }
-            }
-
-            if (len == 1) {
-                var ed = document.createElement('empty-directory');
-                var vf = document.querySelector('view-file');
-                vf.querySelector('#content').appendChild(ed);
-            }
-          }
-        ).catch(
-          function(err) {
-            app.$.toast.text = err;
-            app.$.toast.show();
-          }
-        );
-        namespace.delete({
-            url: url
-        });
       },
 
       _fileUrl: function (serviceEndpoint)

--- a/src/elements/dv-elements/list-view/list-row.html
+++ b/src/elements/dv-elements/list-view/list-row.html
@@ -107,7 +107,8 @@
 
                 fileMimeType: {
                     type: String,
-                    notify: true
+                    notify: true,
+                    computed:'_computedFileMimeType(fileType)'
                 },
 
                 ctime: {
@@ -291,6 +292,14 @@
                 b.textContent = this.computedSize;
                 Polymer.dom.flush();
                 e.stopPropagation();
+            },
+
+            _computedFileMimeType: function (fileType)
+            {
+                if (fileType === "DIR") {
+                    return "application/vnd.dcache.folder";
+                }
+                return "application/octet-stream";
             }
         });
     </script>

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -73,7 +73,6 @@
                                   name="{{item.fileName}}" file-type="{{item.fileType}}"
                                   ctime="{{item.creationTime}}" mtime="{{item.mtime}}"
                                   size="{{item.size}}" loc="{{item.fileLocality}}"
-                                  file-mime-type="{{item.fileMimeType}}"
                                   parent-path="[[parent]]">
                         </list-row>
                     </div>


### PR DESCRIPTION
Major dcache-view version should be normalise to a
dcache version, that is,
    dcache-view 1.0.X -> dcache 2.16.x
    dcache-view 1.1.X -> dcache 3.0.x
    dcache-view 1.2.x -> dcache 3.1.x
Unfornately, some patches are in 1.1.x that contains features
that are not in dcache 3.0. For example: file deletion and
file mime type.

The patch remove file deletion and adjust file mime type in
other to work with dcache 3.0

Request: 1.1
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10262/