### PR TITLE
dcache-view: change configuration state names

### DIFF
--- a/src/elements/dv-elements/hover-contextual/hover-contextual.html
+++ b/src/elements/dv-elements/hover-contextual/hover-contextual.html
@@ -206,7 +206,7 @@
       {
           switch (serviceEndpoint) {
               case "webdav":
-                  var webdav = window.CONFIG.webdavEndpoint;
+                  var webdav = window.CONFIG["dcache-view.endpoints.webdav"];
                   if (webdav == "") {
                       return window.location.protocol + "//" + window.location.hostname + ":2880" + this.path;
                   } else {
@@ -217,7 +217,7 @@
                       }
                   }
               case "rest":
-                  return window.CONFIG.webapiEndpoint + "namespace";
+                  return window.CONFIG["dcache-view.endpoints.webapi"] + "namespace";
           }
       }
     });

--- a/src/elements/dv-elements/list-view/list-row.html
+++ b/src/elements/dv-elements/list-view/list-row.html
@@ -274,7 +274,7 @@
                     Polymer.dom.flush();
                 } else {
                     //Download a file
-                    var webdav = window.CONFIG.webdavEndpoint;
+                    var webdav = window.CONFIG["dcache-view.endpoints.webdav"];
                     if (webdav == "") {
                         path = window.location.protocol + "//" + window.location.hostname + ":2880" + this.filePath;
                     } else {

--- a/src/elements/dv-elements/selected-title/selected-title.html
+++ b/src/elements/dv-elements/selected-title/selected-title.html
@@ -244,7 +244,7 @@
                 mkdir.dirFullPath = path;
                 mkdir.addEventListener('create',function(e) {
                     var name = e.detail.newFolderName;
-                    var url = window.CONFIG.webapiEndpoint + "namespace";
+                    var url = window.CONFIG["dcache-view.endpoints.webapi"] + "namespace";
                     var namespace = document.createElement('dcache-namespace');
 
                     if (!(sessionStorage.upauth === undefined || sessionStorage.upauth == null)) {

--- a/src/elements/dv-elements/upload-files/upload-files-button.html
+++ b/src/elements/dv-elements/upload-files/upload-files-button.html
@@ -74,11 +74,11 @@
                     uploadList.appendChild(el);
                     const upLs = el;
                     var uploadURL;
-                    if (window.CONFIG.webdavEndpoint == "") {
+                    if (window.CONFIG["dcache-view.endpoints.webdav"] == "") {
                         uploadURL = window.location.protocol + "//" + window.location.hostname
                                 + ":2880" + path + f.name;
                     } else {
-                        uploadURL = window.CONFIG.webdavEndpoint + path + f.name;
+                        uploadURL = window.CONFIG["dcache-view.endpoints.webdav"] + path + f.name;
                     }
                     var uploader = new UploadHandler({
                         file: f,

--- a/src/elements/dv-elements/user-authentication/user-login-page.html
+++ b/src/elements/dv-elements/user-authentication/user-login-page.html
@@ -157,7 +157,7 @@
 
                 var up = this.username + ":" + this.password;
                 this.auth = window.btoa(up);
-                this.$.ajaxUser.url = window.CONFIG.webapiEndpoint+"user";
+                this.$.ajaxUser.url = window.CONFIG["dcache-view.endpoints.webapi"] + "user";
                 this.$.ajaxUser.headers = {
                     "Authorization": "Basic "+this.auth,
                     "Suppress-WWW-Authenticate": "Suppress"

--- a/src/elements/dv-elements/utils/ajax-ls/file-metadata.html
+++ b/src/elements/dv-elements/utils/ajax-ls/file-metadata.html
@@ -342,7 +342,7 @@
                 this.isRegular = fileType == 'REGULAR';
                 this.currentQos = currentQos;
                 if (window.CONFIG.qos == undefined && window.CONFIG.isSomebody) {
-                    const apiEndPoint = window.CONFIG.webapiEndpoint;
+                    const apiEndPoint = window.CONFIG["dcache-view.endpoints.webapi"];
                     const qos = new QosBackendInformation(apiEndPoint, "Basic "+ sessionStorage.upauth);
                     qos.addEventListener('qos-backend-response', (e) => {
                         window.CONFIG.qos = e.detail.response;
@@ -368,14 +368,14 @@
             {
                 if ( path==null || path == "" || path == "/") {
                     return upw == "anonymous:nopassword" ?
-                        window.CONFIG.webapiEndpoint + "namespace/?children=true" :
-                        window.CONFIG.webapiEndpoint + "namespace/?children=true&qos=true";
+                        window.CONFIG["dcache-view.endpoints.webapi"] + "namespace/?children=true" :
+                        window.CONFIG["dcache-view.endpoints.webapi"] + "namespace/?children=true&qos=true";
                 } else {
                     path = decodeURIComponent(path);
                     path = path.replace(/=/g, "/");
                     return upw == "anonymous:nopassword" ?
-                        window.CONFIG.webapiEndpoint + "namespace"+ path +"/?children=true" :
-                        window.CONFIG.webapiEndpoint + "namespace"+ path +"/?children=true&qos=true";
+                        window.CONFIG["dcache-view.endpoints.webapi"] + "namespace"+ path +"/?children=true" :
+                        window.CONFIG["dcache-view.endpoints.webapi"] + "namespace"+ path +"/?children=true&qos=true";
                 }
             },
 
@@ -485,7 +485,7 @@
                 );
 
                 namespace.qos({
-                    url: window.CONFIG.webapiEndpoint +'namespace',
+                    url: window.CONFIG["dcache-view.endpoints.webapi"] +'namespace',
                     path: path,
                     target: target
                 });

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -244,14 +244,14 @@
             {
                 if ( path==null || path == "" || path == "/") {
                     return upw == "anonymous:nopassword" ?
-                        window.CONFIG.webapiEndpoint + "namespace/?children=true" :
-                        window.CONFIG.webapiEndpoint + "namespace/?children=true&qos=true";
+                        window.CONFIG["dcache-view.endpoints.webapi"] + "namespace/?children=true" :
+                        window.CONFIG["dcache-view.endpoints.webapi"] + "namespace/?children=true&qos=true";
                 } else {
                     path = decodeURIComponent(path);
                     path = path.replace(/=/g, "/");
                     return upw == "anonymous:nopassword" ?
-                        window.CONFIG.webapiEndpoint + "namespace"+ path +"/?children=true" :
-                        window.CONFIG.webapiEndpoint + "namespace"+ path +"/?children=true&qos=true";
+                        window.CONFIG["dcache-view.endpoints.webapi"] + path +"/?children=true" :
+                        window.CONFIG["dcache-view.endpoints.webapi"] + "namespace"+ path +"/?children=true&qos=true";
                 }
             },
 
@@ -387,7 +387,7 @@
                 var namespace = document.createElement('dcache-namespace');
                 namespace.auth = window.btoa(this.upw);
                 var path = this.path.endsWith("/") ? this.path : this.path + "/";
-                var url = window.CONFIG.webapiEndpoint + "namespace";
+                var url = window.CONFIG["dcache-view.endpoints.webapi"] + "namespace";
                 var source = path + this._previousName;
                 var target = path + this.name;
                 namespace.mv({

--- a/src/elements/routing.html
+++ b/src/elements/routing.html
@@ -19,6 +19,7 @@
         window.CONFIG.isSomebody = sessionStorage.upauth != undefined;
         window.CONFIG.homeDirectory = sessionStorage.homeDirectory;
         app.config = window.CONFIG;
+        app.organisationName = window.CONFIG["dcache-view.org-name"];
 
 
         // Routes

--- a/src/index.html
+++ b/src/index.html
@@ -56,7 +56,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                 <paper-toolbar class="medium-tall">
                     <paper-icon-button icon="menu" on-tap="menuAction" id="mainMenu" hidden></paper-icon-button>
-                    <span class="title">[[config.orgName]]</span>
+                    <span class="title">[[organisationName]]</span>
                     <div id="WhoAmI"><user-loginout-button></user-loginout-button></div>
                     <div class="bottom fit" style="height: 70px; background-color: #eee;
                             display: flex; flex-direction: column; justify-content: center;">

--- a/src/scripts/config.js
+++ b/src/scripts/config.js
@@ -1,6 +1,6 @@
 var CONFIG =
 {
-	"webapiEndpoint": "/api/v1/",
-	"webdavEndpoint": "",
-	"orgName": "dCache View"
+    "dcache-view.endpoints.webapi": "/api/v1/",
+    "dcache-view.endpoints.webdav": "",
+    "dcache-view.org-name": "dCache View"
 };


### PR DESCRIPTION
Motivation:

The patch (here)[https://rb.dcache.org/r/10282/] refactored
how dcache exposes configuration state information through
the frontend service. Also, this patch introduce some new
naming conventions for easy identification purpose. Since
dcache-view rely on these state information. Therefore, it
is neccesary to update dcache-view accordingly.

Modification:

Update all the part of dcache-view using this configuration
data to reflect the new names.

Result:

Complied with the lastest dcache. No visible change to the
end user.

Target: master
Request: 1.2
Request: 1.1
Request: 1.0
Require-book: no
Require-notes: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10287/