### PR TITLE
dcache-view: change configuration state names

### DIFF
--- a/src/elements/dv-elements/hover-contextual/hover-contextual.html
+++ b/src/elements/dv-elements/hover-contextual/hover-contextual.html
@@ -145,7 +145,7 @@
       {
           switch (serviceEndpoint) {
               case "webdav":
-                  var webdav = window.CONFIG.webdavEndpoint;
+                  var webdav = window.CONFIG["dcache-view.endpoints.webdav"];
                   if (webdav == "") {
                       return window.location.protocol + "//" + window.location.hostname + ":2880" + this.path;
                   } else {
@@ -156,7 +156,7 @@
                       }
                   }
               case "rest":
-                  return window.CONFIG.webapiEndpoint + "namespace" + this.path;
+                  return window.CONFIG["dcache-view.endpoints.webapi"] + "namespace" + this.path;
           }
       }
     });

--- a/src/elements/dv-elements/list-view/list-row.html
+++ b/src/elements/dv-elements/list-view/list-row.html
@@ -256,7 +256,7 @@
                     Polymer.dom.flush();
                 } else {
                     //Download a file
-                    var webdav = window.CONFIG.webdavEndpoint;
+                    var webdav = window.CONFIG["dcache-view.endpoints.webdav"];
                     if (webdav == "") {
                         path = window.location.protocol + "//" + window.location.hostname + ":2880" + this.filePath;
                     } else {

--- a/src/elements/dv-elements/selected-title/selected-title.html
+++ b/src/elements/dv-elements/selected-title/selected-title.html
@@ -217,7 +217,7 @@
                 mkdir.dirFullPath = path;
                 mkdir.addEventListener('create',function(e) {
                     var name = e.detail.newFolderName;
-                    var url = window.CONFIG.webapiEndpoint + "namespace";
+                    var url = window.CONFIG["dcache-view.endpoints.webapi"] + "namespace";
                     var namespace = document.createElement('dcache-namespace');
 
                     if (!(sessionStorage.upauth === undefined || sessionStorage.upauth == null)) {

--- a/src/elements/dv-elements/upload-files/upload-files-button.html
+++ b/src/elements/dv-elements/upload-files/upload-files-button.html
@@ -74,11 +74,11 @@
                     uploadList.appendChild(el);
                     const upLs = el;
                     var uploadURL;
-                    if (window.CONFIG.webdavEndpoint == "") {
+                    if (window.CONFIG["dcache-view.endpoints.webdav"] == "") {
                         uploadURL = window.location.protocol + "//" + window.location.hostname
                                 + ":2880" + path + f.name;
                     } else {
-                        uploadURL = window.CONFIG.webdavEndpoint + path + f.name;
+                        uploadURL = window.CONFIG["dcache-view.endpoints.webdav"] + path + f.name;
                     }
                     var uploader = new UploadHandler({
                         file: f,

--- a/src/elements/dv-elements/user-authentication/user-login-page.html
+++ b/src/elements/dv-elements/user-authentication/user-login-page.html
@@ -157,7 +157,7 @@
 
                 var up = this.username + ":" + this.password;
                 this.auth = window.btoa(up);
-                this.$.ajaxUser.url = window.CONFIG.webapiEndpoint+"user";
+                this.$.ajaxUser.url = window.CONFIG["dcache-view.endpoints.webapi"]+"user";
                 this.$.ajaxUser.headers = {
                     "Authorization": "Basic "+this.auth,
                     "Suppress-WWW-Authenticate": "Suppress"

--- a/src/elements/dv-elements/utils/ajax-ls/file-metadata.html
+++ b/src/elements/dv-elements/utils/ajax-ls/file-metadata.html
@@ -205,11 +205,11 @@
             _url: function(path)
             {
                 if ( this.path==null || this.path == "" || this.path == "/") {
-                    return window.CONFIG.webapiEndpoint + "namespace/?children=true&locality=true";
+                    return window.CONFIG["dcache-view.endpoints.webapi"] + "namespace/?children=true&locality=true";
                 } else {
                     path = decodeURIComponent(this.path);
                     path = path.replace(/=/g, "/");
-                    return window.CONFIG.webapiEndpoint + "namespace"+ path +"/?children=true&locality=true";
+                    return window.CONFIG["dcache-view.endpoints.webapi"] + "namespace"+ path +"/?children=true&locality=true";
                 }
             },
 

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -197,11 +197,11 @@
             _url: function(path)
             {
                 if ( this.path==null || this.path == "" || this.path == "/") {
-                    return window.CONFIG.webapiEndpoint + "namespace/?children=true&locality=true";
+                    return window.CONFIG["dcache-view.endpoints.webapi"] + "namespace/?children=true&locality=true";
                 } else {
                     path = decodeURIComponent(this.path);
                     path = path.replace(/=/g, "/");
-                    return window.CONFIG.webapiEndpoint + "namespace"+ path +"/?children=true&locality=true";
+                    return window.CONFIG["dcache-view.endpoints.webapi"] + "namespace"+ path +"/?children=true&locality=true";
                 }
             },
 

--- a/src/elements/routing.html
+++ b/src/elements/routing.html
@@ -17,6 +17,7 @@
 
         // Middleware
         app.config = window.CONFIG;
+        app.organisationName = window.CONFIG["dcache-view.org-name"];
 
         // Routes
         page('*', function(ctx, next) {

--- a/src/index.html
+++ b/src/index.html
@@ -56,7 +56,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                 <paper-toolbar class="medium-tall">
                     <paper-icon-button icon="menu" on-tap="menuAction" id="mainMenu" hidden></paper-icon-button>
-                    <span class="title">[[config.orgName]]</span>
+                    <span class="title">[[organisationName]]</span>
                     <div id="WhoAmI"><user-loginout-button></user-loginout-button></div>
                     <div class="bottom fit" style="height: 70px; background-color: #eee;
                             display: flex; flex-direction: column; justify-content: center;">


### PR DESCRIPTION
Motivation:

The patch (here)[https://rb.dcache.org/r/10282/] refactored
how dcache exposes configuration state information through
the frontend service. Also, this patch introduce some new
naming conventions for easy identification purpose. Since
dcache-view rely on these state information. Therefore, it
is neccesary to update dcache-view accordingly.

Modification:

Update all the part of dcache-view using this configuration
data to reflect the new names.

Result:

Complied with the lastest dcache. No visible change to the
end user.

Target: master
Request: 1.2
Request: 1.1
Request: 1.0
Require-book: no
Require-notes: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10287/