### PR TITLE
dcache-view: change menu tooltip names

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -68,7 +68,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                         <div class="horizontal layout" drawer>
                             <paper-menu attr-for-selected="data-route" id="df-page-navigator" selected="[[route]]">
                                 <a data-route="home" href$="{{baseUrl}}">
-                                    <paper-fab icon="device:storage" title="My Root" class="blue" mini></paper-fab>
+                                    <paper-fab icon="device:storage"
+                                               title="Namespace view" class="blue" mini></paper-fab>
                                 </a>
 
                                 <a data-route="admin" href$="{{baseUrl}}admin"><!--dashboard-->


### PR DESCRIPTION
Target: trunk
Request: 1.3
Request: 1.2
Request: 1.1
Request: 1.0
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10385/

(cherry picked from commit e0cf6e3a0b1e79c8e9cf444e80685b9fd8828422)