### PR TITLE
dcache-view: prevent file removal when dnd is cancelled

### DIFF
--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -273,15 +273,22 @@
     app.dragNdropMoveFiles = function (destinationPath, dropFlag)
     {
         const currentViewPath = app.$.homedir.querySelector('view-file').path;
-        const sourcePath = app.mvObj.source;
+        const sourcePath = ((app.mvObj.source).length > 1  && (app.mvObj.source).endsWith("/")) ?
+            (app.mvObj.source).slice(0, -1) : app.mvObj.source;
+
+        // prevent moving file if destination and source path are the same
+        if (sourcePath === destinationPath) {
+            return;
+        }
+
         app.mvObj.files.forEach((file) => {
             let namespace = document.createElement('dcache-namespace');
             namespace.auth = app.getAuthValue();
 
             namespace.mv({
                 url: "/api/v1/namespace",
-                path: sourcePath + "/" + file.fileName,
-                destination: destinationPath + "/" + file.fileName
+                path: `${sourcePath}/${file.fileName}`,
+                destination: `${destinationPath}/${file.fileName}`
             });
 
             namespace.promise.then( () => {


### PR DESCRIPTION
Motivation:

When a user drags a file or files and release the
mouse before droping it on any target, this result in
the file/s to be removed from the current display list
of files. The effect of this behaviour should should
equal to cancelling the move operation. Hence, the
current implementation is wrong.

Modification:

Add a check that will prevent the moving of files if the
destination path is the same as the source path.

Result:

Prevent file/s from been removed from the list and no more
display of unnecessary toast message.

Target: master
Request: 1.3
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10657/

(cherry picked from commit 6e9a13ebc6a00ae0f6d096bf3669ed9fbcdd05af)