### PR TITLE
dcache-view (admin): fix behavior when space data is missing

### DIFF
--- a/src/elements/dv-elements/admin/views/pool-plots-view.html
+++ b/src/elements/dv-elements/admin/views/pool-plots-view.html
@@ -420,10 +420,14 @@
                     removable = data.poolData.detailsData.costData.space.removable;
                     precious = data.poolData.detailsData.costData.space.precious;
                 } else {
-                    total = data.groupSpaceData.total;
-                    free = data.groupSpaceData.free;
-                    removable = data.groupSpaceData.removable;
-                    precious = data.groupSpaceData.precious;
+                    if (data.groupSpaceData) {
+                        total = data.groupSpaceData.total;
+                        free = data.groupSpaceData.free;
+                        removable = data.groupSpaceData.removable;
+                        precious = data.groupSpaceData.precious;
+                    } else {
+                        return null;
+                    }
                 }
 
                 pinned = total - free - removable - precious;
@@ -464,15 +468,18 @@
                 const histogram = event.detail.response;
 
                 if (Object.keys(histogram).length > 0) {
-                    const plot = new PoolInfoChart();
-                    plot.title = name;
-                    plot.inputData = {
-                        'type': this.plotType,
-                        'seriesData': this._getSeriesData(histogram)
-                    };
-                    this.shadowRoot.querySelector('#chart-placeholders')
-                        .appendChild(plot);
-                    this.push('charts', plot);
+                    const seriesData = this._getSeriesData(histogram);
+                    if (seriesData) {
+                        const plot = new PoolInfoChart();
+                        plot.title = name;
+                        plot.inputData = {
+                            'type': this.plotType,
+                            'seriesData': seriesData
+                        };
+                        this.shadowRoot.querySelector('#chart-placeholders')
+                            .appendChild(plot);
+                        this.push('charts', plot);
+                    }
                 }
 
                 this.plotDataResponses += 1;


### PR DESCRIPTION
Motivation:

When data is missing for the pool plots no plot should be
generated.   This does occur for the queue and file lifetime
plots, but not for space data, which is aggregated differently.

Modification:

Add check for definition of the seriesData, not just for
the present of object keys.

Return null when the group data child is missing.

Result:

Space plots behave like the others.

Target: master
Request: 1.4
Require-notes: yes
Require-book: no
Bug: #59
Acked-by: Olufemi