### PR TITLE
dcache-view (namespace): modify list-row element internal design

### DIFF
--- a/src/elements/dv-elements/list-view/list-row.html
+++ b/src/elements/dv-elements/list-view/list-row.html
@@ -1,12 +1,7 @@
 <link rel="import" href="../../../bower_components/polymer/polymer-element.html">
 
 <link rel="import" href="../../../bower_components/iron-flex-layout/iron-flex-layout.html">
-
-<link rel="import" href="../../../bower_components/paper-icon-button/paper-icon-button.html">
-
 <link rel="import" href="../../../bower_components/file-icon/file-icon.html">
-
-<link rel="import" href="../utils/ajax-ls/view-file.html">
 
 <dom-module id="list-row">
     <template>
@@ -70,37 +65,32 @@
                 white-space: nowrap;
                 overflow: hidden;
                 text-overflow: ellipsis;
+                padding-left:5px;
             }
             #nameContainer {
                 display: flex;
                 align-items: center;
                 padding-right: 24px;
             }
-
-            paper-icon-button {
-                width: 34px !important;
-                height: 34px !important;
-                color: rgba(0, 0, 0, 0.54);
-                --paper-icon-button-hover: {
-                    color: #f09300 !important;
-                };
+            file-icon {
+                padding-left: 15px;
+                padding-right: 10px
             }
             .none {
                 display: none;
             }
         </style>
         <div id="row" class="row">
-            <file-icon mime-type="{{fileMimeType}}"
-                       style="padding-left: 15px; padding-right: 10px"></file-icon>
+            <file-icon mime-type="[[fileMetaData.fileMimeType]]"></file-icon>
             <div class="cell name">
                 <div id="nameContainer">
-                    <span id="fileName" style="padding-left:5px;">{{name}}</span>
+                    <span id="fileName">[[fileMetaData.fileName]]</span>
                 </div>
             </div>
-            <div class="cell ctime">{{computedCTime}}</div>
-            <div class="cell qos"><i>{{qosValue}}</i></div>
+            <div class="cell ctime">[[creationTime]]</div>
+            <div class="cell qos"><i>[[qosValue]]</i></div>
             <div class="cell size" id="hovering">
-                <span>{{computedSize}}</span>
+                <span>[[formattedSize]]</span>
             </div>
         </div>
     </template>
@@ -115,78 +105,35 @@
             static get properties()
             {
                 return {
-                    name: {
-                        type: String,
+                    fileMetaData: {
+                        type: Object,
                         notify: true
                     },
-
-                    fileType: {
+                    creationTime: {
                         type: String,
-                        notify: true
+                        computed:'_formattedDateTime(fileMetaData.creationTime)'
                     },
-
-                    fileMimeType: {
+                    formattedSize: {
                         type: String,
-                        notify: true
+                        computed:'_computeSize(fileMetaData)'
                     },
-
-                    ctime: {
-                        type: String,
-                        notify: true
-                    },
-
-                    computedCTime: {
-                        type: String,
-                        computed:'_computedCTime(ctime)'
-                    },
-
-                    mtime: {
-                        type: String,
-                        notify: true
-                    },
-
-                    size: {
-                        type: String,
-                        notify: true
-                    },
-
-                    computedSize: {
-                        type: String,
-                        computed:'_computeSize(fileType, size)'
-                    },
-
                     parentPath: {
                         type: String,
                         notify: true
                     },
-
                     filePath: {
                         type: String,
-                        computed:'_computeFilePath(parentPath, name)'
+                        computed:'_computeFilePath(parentPath, fileMetaData.fileName)'
                     },
-
-                    currentQos: {
-                        type: String,
-                        notify: true
-                    },
-
                     qosValue: {
                         type: String,
-                        notify: true,
-                        computed: '_computeQoSValue(currentQos)'
-                    },
-
-                    fileMData: {
-                        type: Object,
                         notify: true
                     },
-
                     counter: {
                         type: Number,
                         value: 0,
                         notify: true
                     },
-
                     xSelected: {
                         type: Boolean,
                         notify: true,
@@ -203,6 +150,13 @@
                         reflectToAttribute: true
                     }
                 }
+            }
+
+            static get observers()
+            {
+                return [
+                    '_fileCurrentQOSValue(fileMetaData.currentQos)'
+                ];
             }
 
             connectedCallback()
@@ -233,7 +187,7 @@
             {
                 event.stopPropagation();
                 event.preventDefault();
-                if (this.fileType === 'DIR'
+                if (this.fileMetaData.fileType === 'DIR'
                     && (this.xSelected === undefined || this.xSelected === false)) {
                     this.counter = 0;
                     this.dispatchEvent(new CustomEvent('dv-namespace-drop', {
@@ -246,7 +200,7 @@
             {
                 event.stopPropagation();
                 event.preventDefault();
-                if (this.fileType === "DIR"
+                if (this.fileMetaData.fileType === "DIR"
                     && (this.xSelected === undefined || this.xSelected === false)) {
                     this.counter++;
                     this.setAttribute('in-drop-zone', true);
@@ -260,7 +214,7 @@
             {
                 event.stopPropagation();
                 event.preventDefault();
-                if (this.fileType === "DIR"
+                if (this.fileMetaData.fileType === "DIR"
                     && (this.xSelected === undefined || this.xSelected === false)) {
                     this.counter--;
                     if (this.counter === 0) {
@@ -278,69 +232,52 @@
                     detail: {file: this, evt: event}, bubbles: true, composed: true}));
             }
 
-            _computeFilePath(parentPath, name)
+            _computeFilePath(parentPath, fileName)
             {
-                return parentPath + name;
+                return parentPath.endsWith("/") ?
+                    `${parentPath}${fileName}`: `${parentPath}/${fileName}`;
             }
 
-            _computeQoSValue(qos)
+            _fileCurrentQOSValue(qos)
             {
                 switch (qos) {
                     case "disk":
-                        return "Disk";
+                        this.qosValue = "Disk";
+                        break;
                     case "tape":
-                        return "Tape";
+                        this.qosValue = "Tape";
+                        break;
                     case "disk+tape":
-                        return "Disk & Tape";
-                    case "unavailable":
-                        return "unavailable";
+                        this.qosValue = "Disk & Tape";
+                        break;
+                    default:
+                        this.qosValue = "unavailable";
                 }
             }
 
-            _computedCTime(ctime)
+            _formattedDateTime(dateTimeValue)
             {
-                var x = new Date(ctime);
+                const x = new Date(dateTimeValue);
                 return x.toLocaleString();
             }
 
-            _computeSize(fileType, size)
+            _computeSize(file)
             {
-                if ( fileType == "DIR" ) {
-                    return  "--";
-                } else {
-                    if (size == 0) {
-                        return "0 Byte";
-                    }
+                if (file.fileType === "DIR") return "--";
+                if (file.size === 0) return "0 Byte";
 
-                    var k = 1000;
-                    var dm = 1 || 3;
-                    var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-                    var i = Math.floor(Math.log(size) / Math.log(k));
+                const k = 1000, dm = 1 || 3;
+                const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+                const i = Math.floor(Math.log(file.size) / Math.log(k));
 
-                    return parseFloat((size / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
-                }
+                return parseFloat((file.size / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
             }
 
             _openFileLoc()
             {
-                if ( this.fileType == "DIR" ) {
-                    app.ls(this.filePath);
-                    Polymer.dom.flush();
-                } else {
-                    //Download a file
-                    let path;
-                    const webdav = window.CONFIG["dcache-view.endpoints.webdav"];
-                    if (webdav == "") {
-                        path = window.location.protocol + "//" + window.location.hostname + ":2880" + this.filePath;
-                    } else {
-                        if (webdav.endsWith("/")) {
-                            path = webdav.substring(0, webdav.length-1) + this.filePath;
-                        } else {
-                            path = webdav + this.filePath;
-                        }
-                    }
-                    window.open(path);
-                }
+                this.dispatchEvent(
+                    new CustomEvent('dv-namespace-namespace-open-file', {
+                        detail: {file: this}, bubbles: true, composed: true}));
             }
 
             _openContextMenu(event)

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -65,12 +65,8 @@
                     <div>
                         <list-row class$="[[_computedClass(selected)]]" tabindex$="[[tabIndex]]"
                                   x-selected$="[[__computedXselected(item.xSelected)]]"
-                                  name="{{item.fileName}}" file-type="{{item.fileType}}"
-                                  ctime="{{item.creationTime}}" mtime="{{item.mtime}}"
-                                  size="{{item.size}}" current-qos="{{item.currentQos}}"
-                                  file-mime-type="{{item.fileMimeType}}" file-m-data="{{item}}"
-                                  parent-path="[[parent]]" draggable="[[_computedDraggable(item.xSelected)]]">
-                        </list-row>
+                                  file-meta-data="{{item}}" parent-path="[[parent]]"
+                                  draggable="[[_computedDraggable(item.xSelected)]]"></list-row>
                     </div>
                 </template>
             </iron-list>

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -113,7 +113,6 @@
             h = 340;
         } else {
             const path = vf.path;
-            const name = path === "/" ? 'ROOT' : path.slice(path.lastIndexOf("/"));
             cc = new NamespaceContextualContent({"name":name,
                 "filePath":path, "fileType":"DIR"}, 2);
         }
@@ -238,8 +237,8 @@
             dndCounter++;
             name = app.getfileName(app.$.homedir.querySelector('view-file').path);
         } else {
-            name = event.detail.file.fileMData ?
-                event.detail.file.fileMData.fileName: event.detail.file.name;
+            name = event.detail.file.fileMetaData ?
+                event.detail.file.fileMetaData.fileName: event.detail.file.name;
             event = event.detail.evt;
         }
 
@@ -546,7 +545,7 @@
 
         for (let i=0; i<len; i++) {
             const listRow = allListRows.find(function(lr) {
-                return (lr.fileMData.fileName === vf._xSelectedItems[i].fileName);
+                return (lr.fileMetaData.fileName === vf._xSelectedItems[i].fileName);
             });
             listRow.setAttribute('is-dragging', true);
         }
@@ -564,5 +563,19 @@
     });
     window.addEventListener('dv-namespace-drop', (e)=>{
         app.drop(e);
+    });
+    window.addEventListener('dv-namespace-namespace-open-file', function (e) {
+        if (e.detail.file.fileMetaData.fileType === "DIR") {
+            app.ls(e.detail.file.filePath);
+            Polymer.dom.flush();
+        } else {
+            //Download the file
+            const webdav = window.CONFIG["dcache-view.endpoints.webdav"];
+            const path = webdav === "" ?
+                `${window.location.protocol}//${window.location.hostname}:2880${e.detail.file.filePath}` :
+                webdav.endsWith("/") ? `${webdav.substring(0, webdav.length - 1)}${e.detail.file.filePath}` :
+                `${webdav}${e.detail.file.filePath}`;
+            window.open(path);
+        }
     });
 })(document);


### PR DESCRIPTION
Motivation:

At the moment we have some elements inside dcache-view with legacy
design pattern. The recommended design paradigm requires that child
element should not depends on parent properties, at least not directly.
Therefore, event should be used to achieve a similar result.
(see http://robdodson.me/interoperable-custom-elements/)

This patch (which focus on list-row element) is the first of the
series of patches that will aim at redesigning most of dcache-view
elements.

Modification:

- Here are the changes made to the list-row element:
    1. Remove links to unsed elements
    2. Remove any dependecies on the parent properties
    3. Streamline the element properties to the neccessary
    ones and remove all dublicate
    4. Use one way data binding
    5. Use ES6 syntax where neccessary
    6. Create a custom event called `dv-namespace-namespace-open-file`.
    This event will be responsible for opening or downloading a
    file. Inside the list-row element, this event is dispatch when
    the element is double clicked.
- The `dv-namespace-namespace-open-file` event is captured and respond
to at the top of the dom tree (see dv.js file).
- Also, inside the veiw-file element, the list-row node attributes is
adjusted to fit the new design.

Result:

Improve loading time but no visual change to the end user.

NB: This patch will break the context menu feature. The fix will follow.

Target: master
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/10816/

(cherry picked from commit cc30120e69c106cc5adf5e500b560ee153b57636)