### PR TITLE
dcache-view (user): set css overflow-y property to auto

### DIFF
--- a/src/elements/dv-elements/user-profile/user-profile.html
+++ b/src/elements/dv-elements/user-profile/user-profile.html
@@ -70,7 +70,7 @@
             color: #757575;
             max-width: calc(452px - 150px + 68px);
             max-height: calc(70px - 24px);
-            overflow-y: scroll;
+            overflow-y: auto;
             word-wrap: break-word;
             margin-right: 10px;
         }


### PR DESCRIPTION
Motivation:

In the user profile page, the value containers have css
overflow-y css property was set to scroll because the value
size might be more than container space. However, in some
browsers the overflow side bar will appear irrespective of
whether the content length. Hence, this result in an untidy
UI.

Motivation:

Set the overflow-y css property of the div for the values
(inside the user-profile element) to auto.

Result:

Better UI.

Target: master
Reuest: 1.4
Request: 1.3
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10848/

(cherry picked from commit c52c21abe2c391503f11124e839cc3c3b3ff88d5)