### PR TITLE
fix/master/table-size-update-for-async

### DIFF
--- a/src/elements/dv-elements/admin/dv-vaadin-provider-decorator.html
+++ b/src/elements/dv-elements/admin/dv-vaadin-provider-decorator.html
@@ -152,8 +152,8 @@
                             this.currentOffset = -1;
                             parent.setTableSize(this.currentItems.length, index);
                         } else {
-                            parent.setTableSize(params.pageSize * (params.page + 2),
-                                index);
+                            parent.setTableSize(this.currentItems.length
+                                                + params.pageSize, index);
                         }
                         callback(items);
                     } else {


### PR DESCRIPTION
Motivation:

For the purposes of efficiency, table scroll updating
was changed to use a Promise.   This, however, introduced
the potential for out-of-order page updates when multiple
pages are fetched.

The current code uses the current page number to compute
the table size, leaving a buffer in order to trigger
further fetches.  In the case of out of order processing,
this function will no longer be monotonically increasing,
and can truncate the table before all fetches of data
can be processed (by setting next size to something smaller
than or equal to the current size).

Modification:

Change the computation of table size to be independent of
the page number being processed (previous items + next items
+ buffer).

Result:

The scrolling behavior is as expected (scroll through until
no more data is available).

Target: master
Request: 1.4
Require-notes: yes
Require-book: no
Acked-by: Olufemi