### PR TITLE
dcache-view (namespace): fix upload request in the context menu

### DIFF
--- a/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
+++ b/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
@@ -493,10 +493,10 @@
 
             _upload()
             {
+                //FIXME: context menu stay opened even long after the file picker appears.
                 app.$.centralContextMenu.close();
-
-                let uploadButton = document.createElement('upload-files-button');
-                uploadButton.querySelector('#files').click();
+                this.dispatchEvent(new CustomEvent('dv-namespace-upload-files', {
+                    detail:{}, bubbles: true, composed: true}));
             }
 
             _qosInfo()

--- a/src/elements/dv-elements/upload-files/upload-files-button.html
+++ b/src/elements/dv-elements/upload-files/upload-files-button.html
@@ -37,11 +37,17 @@
             {
                 super.connectedCallback();
                 this.$.files.addEventListener('change', this.handleFileSelection.bind(this));
+                window.addEventListener('dv-namespace-upload-files', ()=>{
+                    this.$.files.click();
+                });
             }
             disconnectedCallback()
             {
                 super.disconnectedCallback();
                 this.$.files.removeEventListener('change', this.handleFileSelection);
+                window.removeEventListener('dv-namespace-upload-files', ()=>{
+                    this.$.files.click();
+                });
             }
 
             handleFileSelection(e)
@@ -71,13 +77,11 @@
                     el.setAttribute("id", i.toString());
                     uploadList.appendChild(el);
                     const upLs = el;
-                    var uploadURL;
-                    if (window.CONFIG["dcache-view.endpoints.webdav"] == "") {
-                        uploadURL = window.location.protocol + "//" + window.location.hostname
-                                + ":2880" + path + f.name;
-                    } else {
-                        uploadURL = window.CONFIG["dcache-view.endpoints.webdav"] + path + f.name;
-                    }
+                    const uploadURL = window.CONFIG["dcache-view.endpoints.webdav"] === "" ?
+                        `${window.location.protocol}//${window.location.hostname}:2880${path}${f.name}` :
+                        path.startsWith('/') ?
+                        `${window.CONFIG["dcache-view.endpoints.webdav"]}${path.slice(1)}${f.name}` :
+                        `${window.CONFIG["dcache-view.endpoints.webdav"]}${path}${f.name}`;
                     var uploader = new UploadHandler({
                         file: f,
                         upauth: app.getAuthValue(),


### PR DESCRIPTION
Motivation:

When the upload file is clicked in the context menu,
it result in an Uncaught TypeError because the node
is not attached to the dom when created.

Modification:

Create and dispatch new a custom events called
dv-namespace-upload-files. This event will trigger
a click on the file input element to open a file
picker dialog that allow the user to choose file(s).

Result:

The upload request through context menu now works.

Target: master
Reuest: 1.4
Require-notes: no
Require-book: no
Acked-by: Albert Rossi <arossi@fnal.gov>

Reviewed at https://rb.dcache.org/r/10830/

(cherry picked from commit 19ee1b512e5cf975d6dd28e8f931392c3adfe920)