### PR TITLE
dcache-view (namespace): fix and redesign contextual menu

### DIFF
--- a/src/elements/dv-elements/contextual-content/change-qos-context-menu.html
+++ b/src/elements/dv-elements/contextual-content/change-qos-context-menu.html
@@ -1,28 +1,34 @@
 <link rel="import" href="../../../bower_components/polymer/polymer-element.html">
-
-<link rel="import" href="../../../bower_components/paper-dialog/paper-dialog.html">
+<link rel="import" href="../../../bower_components/paper-listbox/paper-listbox.html">
+<link rel="import" href="../../../bower_components/paper-item/paper-item.html">
 
 <dom-module id="change-qos-contextual-menu">
     <template>
         <style>
-            :host paper-menu {
-                margin-top: -20px;
-                margin-bottom: -20px;
+            :host {
+                display: block;
+                box-sizing: border-box;
+                max-width:100%;
+            }
+            :host paper-listbox {
+                margin: -20px;
+                padding: 0;
+                background: transparent;
             }
             .menuItem:hover{
-                background: #0e5aff;
-                color: #fff !important;
+                background: #1565C0;
+                border-radius: 4px;
+                color: #fff;
             }
             .menuItem {
-                font-size: 0.8em;
-                min-height: 30px !important;
-                max-height: 30px !important;
-            }
-            .menuItem:nth-child(1) {
-                border-top: 1px solid #cacaca;
+                font-size: 0.7em;
+                min-height: 30px;
+                font-weight: normal;
+                padding-right: 0;
+                padding-left: 5px;
             }
         </style>
-        <paper-menu class="menu-content">
+        <paper-listbox class="menu-content">
             <template is="dom-repeat" items="[[possibleTransition]]">
                 <paper-item on-tap="_changeQos" class="menuItem"
                             disabled$="[[_computedDisabled(item.backendCapability.name,currentQos)]]"
@@ -30,7 +36,7 @@
                     [[item.backendCapability.name]]
                 </paper-item>
             </template>
-        </paper-menu>
+        </paper-listbox>
     </template>
     <script>
         class ChangeQosContextualMenu extends Polymer.Element
@@ -41,7 +47,6 @@
                 this.path = t.filePath;
                 this.currentQos = t.currentQos;
                 this.targetNode = t;
-                this.index = app.$.homeDir.$.feList.items.indexOf(t.fileMData);
             }
 
             static get is()
@@ -70,18 +75,34 @@
                             return window.CONFIG.qos;
                         },
                         notify: true
+                    },
+                    targetNode: {
+                        type: Object
                     }
                 }
+            }
+
+            connectedCallback()
+            {
+                super.connectedCallback();
+                window.addEventListener('dv-namespace-receive-item-index', e => this.index = e.detail.index);
+                this.dispatchEvent(new CustomEvent('dv-namespace-request-item-index'), {
+                    detail:{item: this.targetNode}, bubbles: true, composed: true
+                });
+            }
+
+            disconnectedCallback()
+            {
+                super.disconnectedCallback();
+                window.removeEventListener('dv-namespace-receive-item-index', e => this.index = e.detail.index);
             }
 
             _changeQos(e)
             {
                 app.$.centralSubContextMenu.close();
                 app.$.centralContextMenu.close();
-                const target = e.target.getAttribute('data-transition-name');
                 const namespace = document.createElement('dcache-namespace');
                 namespace.auth = sessionStorage.upauth;
-                const path = this.path;
 
                 namespace.promise.then(
                     () => {
@@ -90,35 +111,35 @@
                         app.$.toast.show();
                         this.dispatchEvent(new CustomEvent('qos-in-transition', {detail: {options: {
                             currentQos: currentQos,
-                            targetQos: target,
+                            targetQos: e.target.getAttribute('data-transition-name'),
                             itemIndex: this.index,
-                            path: path
+                            path: this.path
                         }}}));
                     }
                 ).catch(
                     function(err) {
-                        app.$.toast.text = err.message + " ";
+                        app.$.toast.text = `${err.message} `;
                         app.$.toast.show();
                     }
                 );
 
                 namespace.qos({
-                    url: window.CONFIG["dcache-view.endpoints.webapi"] +'namespace',
-                    path: path,
-                    target: target
+                    url: `${window.CONFIG["dcache-view.endpoints.webapi"]}namespace`,
+                    path: this.path,
+                    target: e.target.getAttribute('data-transition-name')
                 });
             }
 
             _computedDisabled(buttonName,currentQos)
             {
-                if (buttonName == currentQos) {
+                if (buttonName === currentQos) {
                     return true;
                 } else {
                     for (let i=0; i<window.CONFIG.qos.length; i++) {
-                        if (window.CONFIG.qos[i].backendCapability.name == currentQos) {
+                        if (window.CONFIG.qos[i].backendCapability.name === currentQos) {
                             if (window.CONFIG.qos[i].backendCapability.transition.length > 0) {
                                 for (let j=0; j < window.CONFIG.qos[i].backendCapability.transition.length; j++) {
-                                    return window.CONFIG.qos[i].backendCapability.transition[j] != buttonName;
+                                    return window.CONFIG.qos[i].backendCapability.transition[j] !== buttonName;
                                 }
                             } else {
                                 return true;

--- a/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
+++ b/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
@@ -4,22 +4,42 @@
 <link rel="import" href="../../../bower_components/paper-item/paper-icon-item.html">
 
 <link rel="import" href="../qbi-dialog-content/qbi-dialog-content.html">
-<link rel="import" href="change-qos-context-menu.html">
 <dom-module id="namespace-contextual-content">
     <template>
         <style>
+            :host {
+                display: block;
+                box-sizing: border-box;
+                max-width:100%;
+            }
             :host paper-listbox {
-                margin-top: -20px;
-                margin-bottom: -20px;
+                margin: -20px;
+                padding: 0;
+                background: transparent;
             }
             paper-icon-item:hover{
-                background: #0e5aff;
-                color: #fff !important;
+                background: #1565C0;
+                color: #fff;
+                border-radius: 4px;
+                --paper-item-icon: {
+                    color: #fff;
+                }
             }
             paper-icon-item {
-                font-size: 0.8em;
-                min-height: 40px !important;
-                font-weight: normal !important;
+                font-size: 0.7em;
+                min-height: 30px;
+                font-weight: normal;
+                padding-right: 0;
+                padding-left: 5px;
+                --paper-item-icon: {
+                    width: 20px;
+                    height: 20px;
+                    margin-right: 10px;
+                    color: #4e4e4e;
+                }
+            }
+            paper-icon-item[disabled] > iron-icon {
+                color: #b7b7b7;
             }
             .none {
                 display: none;
@@ -29,6 +49,11 @@
             }
             #delete, #download {
                 border-top: 1px solid #cacaca;
+            }
+            #arrow {
+                --iron-icon-width: 20px;
+                --iron-icon-height: 20px;
+                margin-left: 75px;
             }
         </style>
         <paper-listbox>
@@ -43,7 +68,8 @@
                              class$="[[_computedClass('changeQos' , singleSelection,
                              multipleSelection, currentDir, targetNode)]]">
                 <iron-icon icon="settings-input-composite" slot="item-icon"></iron-icon>
-                Change QoS to ...
+                Change QoS
+                <iron-icon id="arrow" icon="av:play-arrow"></iron-icon>
             </paper-icon-item>
             <paper-icon-item id="qosInfo"
                              class$="[[_computedClass('qosInfo', singleSelection,
@@ -109,7 +135,6 @@
                 this.multipleSelection = n === 1;
                 this.currentDir = n === 2;
                 this.targetNode = t;
-                this._cqcm = new ChangeQosContextualMenu(t);
             }
 
             static get is()
@@ -144,10 +169,6 @@
             ready()
             {
                 super.ready();
-                if (app.$.centralSubContextMenu.opened) {
-                    app.$.centralSubContextMenu.close();
-                }
-                app.$.centralSubContextMenu.innerHTML = "";
             }
 
             connectedCallback()
@@ -160,12 +181,12 @@
                     this.$.qosInfo.addEventListener('tap', this._qosInfo.bind(this));
                     this.$.rename.addEventListener('tap', this._rename.bind(this));
 
-                    switch (this.targetNode.fileType) {
+                    switch (this.targetNode.fileMetaData.fileType) {
                         case "DIR":
-                            this.$.open.addEventListener('tap', this._open.bind(this));
+                            this.$.open.addEventListener('tap', this._openOrDownload.bind(this));
                             break;
                         case "REGULAR":
-                            this.$.download.addEventListener('tap', this._download.bind(this));
+                            this.$.download.addEventListener('tap', this._openOrDownload.bind(this));
                             break;
                     }
 
@@ -179,8 +200,9 @@
                     this.$.upload.addEventListener('tap', this._upload.bind(this));
                 }
 
-                this.addEventListener('mouseover', this._mouseOverLeave);
-                this.$.changeQos.addEventListener('mouseover', this._mouseOver.bind(this));
+                [...this.shadowRoot.querySelectorAll('paper-icon-item')].forEach(nd => {
+                    nd.addEventListener('mouseenter', (e)=>{this._mouseEnter(e)});
+                });
 
                 window.addEventListener('dv-namespace-current-path',(e)=>{this._setCurrentPath(e)});
                 this.dispatchEvent(
@@ -191,132 +213,72 @@
             {
                 super.disconnectedCallback();
                 if (this.singleSelection) {
-                    this.$.delete.removeEventListener('tap', this._delete);
-                    this.$.metadata.removeEventListener('tap', this._metadata);
-                    this.$.move.removeEventListener('tap', this._move);
-                    this.$.qosInfo.removeEventListener('tap', this._qosInfo);
-                    this.$.rename.removeEventListener('tap', this._rename);
+                    this.$.delete.removeEventListener('tap', this._delete.bind(this));
+                    this.$.metadata.removeEventListener('tap', this._metadata.bind(this));
+                    this.$.move.removeEventListener('tap', this._move.bind(this));
+                    this.$.qosInfo.removeEventListener('tap', this._qosInfo.bind(this));
+                    this.$.rename.removeEventListener('tap', this._rename.bind(this));
 
-                    switch (this.targetNode.fileType) {
+                    switch (this.targetNode.fileMetaData.fileType) {
                         case "DIR":
-                            this.$.open.removeEventListener('tap', this._open);
+                            this.$.open.removeEventListener('tap', this._openOrDownload.bind(this));
                             break;
                         case "REGULAR":
-                            this.$.download.removeEventListener('tap', this._download);
+                            this.$.download.removeEventListener('tap', this._openOrDownload.bind(this));
                             break;
                     }
 
                 } else if (this.multipleSelection) {
-                    this.$.delete.removeEventListener('tap', this._delete);
-                    this.$.move.removeEventListener('tap', this._move);
+                    this.$.delete.removeEventListener('tap', this._delete.bind(this));
+                    this.$.move.removeEventListener('tap', this._move.bind(this));
                 } else if (this.currentDir) {
-                    this.$.create.removeEventListener('tap', this._create);
-                    this.$.metadata.removeEventListener('tap', this._metadata);
-                    this.$.qosInfo.removeEventListener('tap', this._qosInfo);
-                    this.$.upload.removeEventListener('tap', this._upload);
+                    this.$.create.removeEventListener('tap', this._create.bind(this));
+                    this.$.metadata.removeEventListener('tap', this._metadata.bind(this));
+                    this.$.qosInfo.removeEventListener('tap', this._qosInfo.bind(this));
+                    this.$.upload.removeEventListener('tap', this._upload.bind(this));
                 }
 
-                this.removeEventListener('mouseover', this._mouseOverLeave);
-                this.$.changeQos.removeEventListener('mouseover', this._mouseOver);
+                [...this.shadowRoot.querySelectorAll('paper-icon-item')].forEach(nd => {
+                    nd.removeEventListener('mouseenter', (e)=>{this._mouseEnter(e)});
+                });
 
                 window.removeEventListener('dv-namespace-current-path',(e)=>{this._setCurrentPath(e)});
             }
 
-            _mouseOverLeave()
+            _mouseEnter(e)
             {
-                if (app.$.centralSubContextMenu.opened) {
+                if (window.CONFIG.isSomebody && e.composedPath()[0].id === "changeQos") {
+                    this.dispatchEvent(
+                        new CustomEvent('dv-namespace-namespace-open-subcontextmenu', {
+                            detail: {targetNode: this.targetNode}, bubbles: true, composed: true}));
+                }
+                if (e.composedPath()[0].id !== "changeQos") {
                     app.$.centralSubContextMenu.close();
                 }
             }
 
-            _mouseOver(e)
-            {
-                e.stopPropagation();
-                if (!window.CONFIG.isSomebody) {
-                    app.$.toast.text = "You need to login to be able to perform this operation. ";
-                    app.$.toast.show();
-                    return;
-                }
-                if (!app.$.centralSubContextMenu.opened) {
-                    app.$.centralSubContextMenu.appendChild(this._cqcm);
-                    let x = 0, y = 0;
-
-                    if (e.pageX || e.pageY) {
-                        x = e.pageX;
-                        y = e.pageY;
-                    } else if (e.clientX || e.clientY) {
-                        x = e.clientX + document.body.scrollLeft +
-                            document.documentElement.scrollLeft;
-                        y = e.clientY + document.body.scrollTop +
-                            document.documentElement.scrollTop;
-                    }
-
-                    const vx = window.innerWidth;
-                    const vy = window.innerHeight;
-                    const w = 250;
-                    const h = 100;
-
-                    if (vx - app.x < w*2.1) {
-                        app.a = app.x - w;
-                    } else {
-                        app.a = w + app.x;
-
-                    }
-                    app.b = app.y + 15;
-                    app.notifyPath('a');
-                    app.notifyPath('b');
-                    app.$.centralSubContextMenu.resetFit();
-                    app.$.centralSubContextMenu.open();
-                }
-
-                e.stopPropagation();
-            }
-
-            _open()
+            _openOrDownload()
             {
                 app.$.centralContextMenu.close();
-                app.ls(this.targetNode.filePath);
-                Polymer.dom.flush();
-            }
-
-            _download()
-            {
-                app.$.centralContextMenu.close();
-                let path;
-                const webdav = window.CONFIG["dcache-view.endpoints.webdav"];
-                if (webdav === "") {
-                    path =
-                        window.location.protocol + "//" + window.location.hostname
-                        + ":2880" + this.targetNode.filePath;
-                } else {
-                    if (webdav.endsWith("/")) {
-                        path = webdav.substring(0, webdav.length-1) + this.targetNode.filePath;
-                    } else {
-                        path = webdav + this.targetNode.filePath;
-                    }
-                }
-                window.open(path);
+                this.dispatchEvent(
+                    new CustomEvent('dv-namespace-namespace-open-file', {
+                        detail: {file: this.targetNode}, bubbles: true, composed: true}));
             }
 
             _metadata()
             {
                 app.$.centralContextMenu.close();
-                if (app.$.metadataDrawer.querySelector('file-metadata')) {
-                    app.$.metadataDrawer.removeChild(
-                        app.$.metadataDrawer.querySelector('file-metadata'));
-                }
-                const fm = this.targetNode.fileMData ?
-                    new FileMetadata(this.targetNode.fileMData, this.targetNode.filePath, 0) :
-                    new FileMetadata(this.targetNode, this.targetNode.filePath, 1);
-                app.$.metadataDrawer.appendChild(fm);
-                app.$.metadata.openDrawer();
+                this.dispatchEvent(
+                    new CustomEvent('dv-namespace-namespace-open-filemetadata-panel', {
+                        detail: {file: this.targetNode}, bubbles: true, composed: true}));
             }
 
             _rename()
             {
                 app.$.centralContextMenu.close();
-                const vf = document.querySelector('view-file');
-                vf.openDialog(this.targetNode, this.targetNode.name);
+                this.dispatchEvent(
+                    new CustomEvent('dv-namespace-namespace-open-rename-dialogbox', {
+                        detail: {file: this.targetNode}, bubbles: true, composed: true}));
             }
 
             _move()
@@ -324,8 +286,6 @@
                 app.$.centralContextMenu.close();
                 let noOfMovedItems = 1;
                 let fileType = "item";
-                const dialogBox = document.getElementById('centralDialogBox');
-                app.removeAllChildren(dialogBox);
                 const mv = document.createElement('move-file');
                 mv.auth = app.getAuthValue();
                 mv.currentPath = this.currentPath;
@@ -335,13 +295,15 @@
                     noOfMovedItems = mv.mvFiles.length;
                     fileType = "items";
                 } else {
-                    mv.mvFiles = [this.targetNode.fileMData];
+                    mv.mvFiles = [this.targetNode.fileMetaData];
                 }
 
                 mv.addEventListener('move', (e) => {
                     this.dispatchEvent(new CustomEvent('dv-namespace-remove-items', {
                         detail: {files: mv.mvFiles},bubbles: true, composed: true}));
-                    dialogBox.close();
+                    this.dispatchEvent(
+                        new CustomEvent('dv-namespace-namespace-close-central-dialogbox', {
+                            bubbles: true, composed: true}));
                     app.$.toast.text = `${noOfMovedItems} ${fileType} have been moved from
                         ${e.detail.response.sourceDirName} to ${e.detail.response.targetDirName}. `;
                     app.$.toast.show();
@@ -351,7 +313,9 @@
                     app.$.toast.show();
                 });
                 mv.addEventListener('dismiss', function (e) {
-                    dialogBox.close();
+                    this.dispatchEvent(
+                        new CustomEvent('dv-namespace-namespace-close-central-dialogbox', {
+                            bubbles: true, composed: true}));
                 });
                 mv.addEventListener('move-create', function (e) {
                     const file = {
@@ -366,8 +330,10 @@
                     this.dispatchEvent(new CustomEvent('dv-namespace-add-items', {
                         detail: {files: [file]},bubbles: true, composed: true}));
                 });
-                dialogBox.appendChild(mv);
-                dialogBox.open();
+
+                this.dispatchEvent(
+                    new CustomEvent('dv-namespace-namespace-open-central-dialogbox', {
+                        detail: {node: mv}, bubbles: true, composed: true}));
             }
 
             _delete()
@@ -378,49 +344,27 @@
                     app.$.toast.show();
                     return;
                 }
-                let url = window.CONFIG["dcache-view.endpoints.webapi"] + "namespace";
-
                 if (this.multipleSelection) {
-                    let vf = document.getElementById('homedir').querySelector('view-file');
-                    vf.multiSelection = false;
-
                     for (let i=0; i<this.targetNode.files.length; i++) {
-                        this._deleteSingleEntry(url, this.targetNode.files[i].fileName,
-                            this.targetNode.parentPath + this.targetNode.files[i].fileName);
+                        this._deleteSingleEntry(this.targetNode.files[i]);
                     }
-
-                    vf.multiSelection = true;
                 } else {
-                    if (this.targetNode.checkboxDisplay) {
-                        this.targetNode.querySelector('paper-checkbox').checked = false;
-                    }
-                    this._deleteSingleEntry(url, this.targetNode.name, this.targetNode.filePath);
+                    this._deleteSingleEntry(this.targetNode.fileMetaData);
                 }
             }
 
-            _deleteSingleEntry(url, name, path)
+            _deleteSingleEntry(file)
             {
-                let namespace = document.createElement('dcache-namespace');
+                const fullPath = this.currentPath.endsWith('/') ? `${this.currentPath}${file.fileName}`:
+                    `${this.currentPath}/${file.fileName}`;
+                const namespace = document.createElement('dcache-namespace');
                 namespace.auth = app.getAuthValue();
                 namespace.promise.then(
                     ()=>{
-                        let list = app.$.homedir.querySelector('view-file').$.feList;
-                        let arr = list.items;
-                        const len = arr.length;
-                        for (let i=0; i<len; i++) {
-                            if (arr[i].fileName == name) {
-                                list.splice('items', i, 1);
-                                break;
-                            }
-                        }
-
-                        if (len === 1) {
-                            const ed = document.createElement('empty-directory');
-                            const vf = document.querySelector('view-file');
-                            vf.querySelector('#content').appendChild(ed);
-                        }
-
-                        const type = this.targetNode.fileType == "DIR" ? "Folder" : "File";
+                        this.dispatchEvent(new CustomEvent('dv-namespace-remove-items', {
+                            detail: {files: [file]},bubbles: true, composed: true
+                        }));
+                        const type = file.fileType === "DIR" ? "Folder" : "File";
                         app.$.toast.text = type + " deleted. ";
                         app.$.toast.show();
                     }
@@ -431,8 +375,8 @@
                     }
                 );
                 namespace.rm({
-                    url: url,
-                    path: path
+                    url: `${window.CONFIG["dcache-view.endpoints.webapi"]}namespace`,
+                    path: fullPath
                 });
             }
 
@@ -440,23 +384,19 @@
             {
                 app.$.centralContextMenu.close();
 
-                const dialogBox = document.getElementById('centralDialogBox');
-                app.removeAllChildren(dialogBox);
-
-                let mkdir = document.createElement('create-directory');
+                const mkdir = document.createElement('create-directory');
                 mkdir.dirFullPath = this.currentPath;
                 mkdir.header = false;
                 mkdir.addEventListener('create',(e) => {
-                    let name = e.detail.newFolderName;
-                    let url = window.CONFIG["dcache-view.endpoints.webapi"] + "namespace";
-                    let namespace = document.createElement('dcache-namespace');
+                    const namespace = document.createElement('dcache-namespace');
                     namespace.auth = app.getAuthValue();
 
                     namespace.promise.then(() => {
-                        dialogBox.close();
-                        dialogBox.removeChild(mkdir);
+                        this.dispatchEvent(
+                            new CustomEvent('dv-namespace-namespace-close-central-dialogbox', {
+                                bubbles: true, composed: true}));
                         const file = {
-                            "fileName" : name,
+                            "fileName" : e.detail.newFolderName,
                             "fileMimeType" : "application/vnd.dcache.folder",
                             "fileLocality" : "",
                             "size" : "--",
@@ -472,23 +412,25 @@
                         app.$.toast.show();
                     }).catch(
                         function(err) {
-                            app.$.toast.text = err.message + " ";
+                            app.$.toast.text = `${err.message} `;
                             app.$.toast.show();
                         }
                     );
 
                     namespace.mkdir({
-                        url: url,
+                        url: `${window.CONFIG["dcache-view.endpoints.webapi"]}namespace`,
                         path: this.currentPath,
-                        name: name
+                        name: e.detail.newFolderName
                     });
                 });
                 mkdir.addEventListener('close',function() {
-                    dialogBox.close();
-                    dialogBox.removeChild(mkdir);
+                    this.dispatchEvent(
+                        new CustomEvent('dv-namespace-namespace-close-central-dialogbox', {
+                            bubbles: true, composed: true}));
                 });
-                dialogBox.appendChild(mkdir);
-                dialogBox.open();
+                this.dispatchEvent(
+                    new CustomEvent('dv-namespace-namespace-open-central-dialogbox', {
+                        detail: {node: mkdir}, bubbles: true, composed: true}));
             }
 
             _upload()
@@ -503,9 +445,6 @@
             {
                 app.$.centralContextMenu.close();
 
-                let dialogBox = document.getElementById('centralDialogBox');
-                dialogBox.innerHTML = "";
-
                 if (!window.CONFIG.isSomebody) {
                     app.$.toast.text = "You need to login to view this information. ";
                     app.$.toast.show();
@@ -517,10 +456,10 @@
                     return;
                 }
 
-                let content = document.createElement('qbi-dialog-content');
-
-                dialogBox.appendChild(content);
-                dialogBox.open();
+                const content = document.createElement('qbi-dialog-content');
+                this.dispatchEvent(
+                    new CustomEvent('dv-namespace-namespace-open-central-dialogbox', {
+                        detail: {node: content}, bubbles: true, composed: true}));
             }
 
             /**
@@ -547,15 +486,18 @@
             {
                 if (multipleSelection && (id === 'open' || id === 'metadata' || id === 'rename' ||
                     id === 'download' || id === 'changeQos' || id === 'qosInfo')) {
-                    this.root.querySelector('#'+id).setAttribute('disabled', "");
+                    this.$[id].setAttribute('disabled', "");
                 }
 
                 if (singleSelection) {
-                    if (t.fileType === 'DIR' && (id === 'download' || id === 'changeQos')) {
-                        this.root.querySelector('#'+id).setAttribute('disabled', "");
-                    } else if (id  === 'open' && t.fileType === 'REGULAR') {
-                        this.root.querySelector('#'+id).setAttribute('disabled', "");
+                    if (t.fileMetaData.fileType === 'DIR' && (id === 'download' || id === 'changeQos')) {
+                        this.$[id].setAttribute('disabled', "");
+                    } else if (id  === 'open' && t.fileMetaData.fileType === 'REGULAR') {
+                        this.$[id].setAttribute('disabled', "");
                     }
+                }
+                if (!window.CONFIG.isSomebody && id === 'changeQos') {
+                    this.$[id].setAttribute('disabled', "");
                 }
             }
 

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -154,6 +154,8 @@
                 this.$.feList.addEventListener('click', (e)=>{
                     e.stopPropagation();
                 });
+
+                window.addEventListener('dv-namespace-namespace-open-rename-dialogbox', (e)=>{this.openDialog(e)});
             }
             disconnectedCallback()
             {
@@ -171,6 +173,8 @@
                 this.$.feList.removeEventListener('click', (e)=>{
                     e.stopPropagation();
                 });
+
+                window.removeEventListener('dv-namespace-namespace-open-rename-dialogbox', (e)=>{this.openDialog(e)});
             }
             static get is()
             {
@@ -207,6 +211,11 @@
                         notify: true
                     },
 
+                    currentDirMetaData: {
+                        type: Object,
+                        value: ()=>{return {};}
+                    },
+
                     name: {
                         type:String,
                         notify: true
@@ -225,11 +234,6 @@
                     loading: {
                         type: Boolean,
                         value: true,
-                        notify: true
-                    },
-
-                    multiSelection: {
-                        type: Boolean,
                         notify: true
                     },
 
@@ -345,6 +349,12 @@
                         this.$.feList.fire('iron-resize');
                     }
                 }
+                if (Object.keys(this.currentDirMetaData).length === 0) {
+                    const a = JSON.parse(JSON.stringify(e.detail.response));
+                    delete a['children'];
+                    this.currentDirMetaData = a;
+                    this.currentDirMetaData.fileName = this.currentDirName;
+                }
             }
 
             handleError(request)
@@ -373,6 +383,8 @@
                 let dle = new DirectoryLsError(msg, code);
                 content.appendChild(dle);
 
+                this.currentDirMetaData = {"fileName": this.currentDirName, "fileType": "DIR", "size" : 512};
+
                 Polymer.dom.flush();
                 this.updateStyles();
             }
@@ -400,13 +412,14 @@
                 }
             }
 
-            openDialog(targetNode, name)
+            openDialog(e)
             {
-                this.name = name;
-                this._previousName = name;
+
+                this.name = e.detail.file.fileName;
+                this._previousName = e.detail.file.fileName;
                 const dialog = this.$.dialog;
-                dialog.positionTarget = targetNode.$.nameContainer;
-                this._renameTargetNode = targetNode;
+                dialog.positionTarget = e.detail.file.$.nameContainer;
+                this._renameTargetNode = e.detail.file;
                 dialog.open();
             }
 

--- a/src/elements/elements.html
+++ b/src/elements/elements.html
@@ -64,6 +64,7 @@
 <link rel="import" href="dv-elements/table-header/list-row-header.html">
 <link rel="import" href="dv-elements/utils/ajax-ls/view-file.html">
 <link rel="import" href="dv-elements/contextual-content/namespace-contextual-content.html">
+<link rel="import" href="dv-elements/contextual-content/change-qos-context-menu.html">
 <link rel="import" href="dv-elements/selected-title/selected-title.html">
 <link rel="import" href="dv-elements/pagination-button/pagination-button.html">
 <link rel="import" href="dv-elements/dialog-box/central-dialog-box.html">

--- a/src/index.html
+++ b/src/index.html
@@ -198,6 +198,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             float:right;
                             color: white;
                         }
+                        .contextmenu {
+                            margin:0;
+                            width:200px;
+                            border: 1px solid #ccc;
+                            border-radius: 5px;
+                            background: #e8e8e8;
+                        }
                     </style>
                 </custom-style>
                 <paper-header-panel class="flex" mode="standard" shadow id="dv-main-header">
@@ -362,14 +369,14 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 <paper-dialog id="centralContextMenu" vertical-align="top"
                               horizontal-align="left" dynamic-align
                               vertical-offset="[[y]]" horizontal-offset="[[x]]"
-                              style="margin:0; width:250px;">
+                              class="contextmenu">
                 </paper-dialog>
 
                 <!-- HERE IS A CUSTOM SUB-CONTEXT MENU BOX -->
                 <paper-dialog id="centralSubContextMenu" vertical-align="top"
                               horizontal-align="left" dynamic-align
                               vertical-offset="[[b]]" horizontal-offset="[[a]]"
-                              style="margin:0; width:250px;">
+                              class="contextmenu">
                 </paper-dialog>
 
                 <!-- HERE IS A CENTRAL TOAST -->

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -92,12 +92,13 @@
          * a. https://caniuse.com/#search=Shadow%20DOM
          * b. https://caniuse.com/#search=Custom%20Elements
          */
+        app.$.centralSubContextMenu.close();
         const contextMenu = app.$.centralContextMenu;
-        if (contextMenu.opened) contextMenu.close();
+        contextMenu.close();
         app.removeAllChildren(contextMenu);
 
         const vf = app.$.homedir.querySelector('view-file');
-        let x = 0, y = 0, h = 176, cc;
+        let x = 0, y = 0, h = 110, cc;
         if (e.screenX === 0 & e.screenY === 0) {
             const arr = e.path || (e.composedPath && e.composedPath());
             const lr = arr.find(function (el) {
@@ -105,19 +106,16 @@
             });
 
             if (lr.xSelected && vf._xSelectedItems.length > 1) {
-                cc = new NamespaceContextualContent({files: vf._xSelectedItems,
-                    parentPath: this.path}, 1);
+                cc = new NamespaceContextualContent({files: vf._xSelectedItems}, 1);
             } else {
                 cc = new NamespaceContextualContent(lr, 0);
             }
-            h = 340;
+            h = 245;
         } else {
-            const path = vf.path;
-            cc = new NamespaceContextualContent({"name":name,
-                "filePath":path, "fileType":"DIR"}, 2);
+            cc = new NamespaceContextualContent(vf, 2);
         }
 
-        const w = 250;
+        const w = 200;
         if (e.pageX || e.pageY) {
             x = e.pageX;
             y = e.pageY;
@@ -145,8 +143,25 @@
         app.notifyPath('x');
         app.notifyPath('y');
         contextMenu.appendChild(cc);
-        contextMenu.resetFit();
         contextMenu.open();
+    };
+
+    app.subContextMenu = function(e)
+    {
+        if (!app.$.centralSubContextMenu.opened) {
+            app.removeAllChildren(app.$.centralSubContextMenu);
+            const content = new ChangeQosContextualMenu(e.detail.targetNode);
+
+            const vx = window.innerWidth;
+            const w = 198;
+
+            app.a = vx - app.x < w * 2.1 ? app.x - w : w + app.x;
+            app.b = app.y + 15;
+            app.notifyPath('a');
+            app.notifyPath('b');
+            app.$.centralSubContextMenu.appendChild(content);
+            app.$.centralSubContextMenu.open();
+        }
     };
 
     app.click = function (e) {
@@ -577,5 +592,23 @@
                 `${webdav}${e.detail.file.filePath}`;
             window.open(path);
         }
+    });
+    window.addEventListener('dv-namespace-namespace-open-subcontextmenu', e => app.subContextMenu(e));
+    window.addEventListener('dv-namespace-namespace-open-filemetadata-panel', e => {
+        app.removeAllChildren(app.$.metadataDrawer);
+        const file = e.detail.file;
+        const fm = file.fileMetaData ?
+            new FileMetadata(file.fileMetaData, file.filePath, 0) :
+            new FileMetadata({}, file.path, 1);
+        app.$.metadataDrawer.appendChild(fm);
+        app.$.metadata.openDrawer();
+    });
+    window.addEventListener('dv-namespace-namespace-open-central-dialogbox',(e)=>{
+        app.removeAllChildren(app.$.centralDialogBox);
+        app.$.centralDialogBox.appendChild(e.detail.node);
+        app.$.centralDialogBox.open()
+    });
+    window.addEventListener('dv-namespace-namespace-close-central-dialogbox',()=>{
+        app.$.centralDialogBox.close();
     });
 })(document);


### PR DESCRIPTION
Motivation:

The recent patches introduces some bugs that makes the context
menu not to work properly or as espected. Therefore, to fix the
bugs it is necessary to redesign namespace-contextual-menu element.
Also this redesign will fall into the category of our recent
undertakens to update all dcache-view elements to the new design
paradigm.

Modification:

1. index.html
    - Create and add a new css class to the two nodes for
    the context menu.
2. namespace-contextual-content and change-qos-context-menu
    - use es6 syntax
    - change the styling to make it more appealing UX
    - replace paper-menu with paper-listbox inside the
    change-qos-contextual-menu element
    - disptach `dv-namespace-request-item-index` event from
    the change-qos-contextual-menu element. This is used to
    request for the index number of that particular list-row
    in the view-file element.
    - adds eventlistner called `dv-namespace-receive-item-index`
    inside the connectedCallback of change-qos-contextual-menu
    and this is removed in the disconnectedCallback. This event
    is used to set the index property.
    - decouple all access to properties of other elements that
    are not their children. Hence, disptaching of events are
    used where necessary.
    - listen to mouseenter event on all the paper-icon-items.
    An event is dispatched when paper-icon-items `id` is "changeQos"
    and user is known. If the id is not "changeQos"; ensure that
    the sub context menu is closed.
    - adjust properties names to the new names used.
3. dv.js
    - add listeners for responding to opening and closing of the
    context menu. Also for opening the drawer of file-metadata.
    - adds the callback function for opening the sub-context menu (
    this was actually moved from the namespace-contextual-content).
    - adjust the callback function for the main context menu event
    listener to factor in the new design of namespace-contextual-content
    and the view-file element.
4. elements.html
    - Add change-qos-context-menu to the list of elements that
    should be loaded at first instant because it creation has
    been moved from namespace-contextual-content element.
5. view-file
    - remove multiSelection property since is no more used
    - add a new property called currentDirMetaData. This is
    set after the ajax request have been made.

Result:
a. better UX and new stylish design
b. fix flickering issue in safari
c. instead of showing a message when a user hover change qos option,
this option is now made unavailable if the user hasn't logged-in.
d. all functionalities are now working as espected.

Target: master
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Albert Rossi <arossi@fnal.gov>

Reviewed at https://rb.dcache.org/r/10861/

(cherry picked from commit ef219c2c647a22f74ff9137fed556fde84af30ec)