### PR TITLE
dcache-view (admin): change provider decorator to use outgoing events…

### DIFF
--- a/src/elements/dv-elements/admin/dv-vaadin-provider-decorator-alt.html
+++ b/src/elements/dv-elements/admin/dv-vaadin-provider-decorator-alt.html
@@ -1,0 +1,345 @@
+<link rel="import"
+      href="../../../bower_components/polymer/polymer-element.html">
+
+<!-- ------------------------------------------------------------------
+        Provides infrastructure for handling filtering, sorting and
+        selection on vaadin-grid components which use the data provider
+        to lazily load from a remote source in connection with infinite
+        scrolling.
+
+        Acts as stateful wrapper for a single vaadin-grid table.  Multiple
+        tables will require multiple instances of this decorator.
+     ------------------------------------------------------------------ -->
+<dom-module id="dv-vaadin-provider-decorator-alt">
+    <script>
+        class DvVaadinProviderDecoratorAlt extends
+            DcacheViewMixins.Selection(DcacheViewMixins.AdminBase(Polymer.Element)) {
+
+            static get is() {
+                return 'dv-vaadin-provider-decorator-alt';
+            }
+
+            static get properties() {
+                return {
+                    selectAll: {
+                        type: Boolean,
+                        value: false,
+                        notify: true
+                    },
+
+                    indeterminate: {
+                        type: Boolean,
+                        value: false,
+                        notify: true
+                    },
+
+                    currentItems: {
+                        type: Array,
+                        value: []
+                    },
+
+                    currentOffset: {
+                        type: Number,
+                        value: 0
+                    },
+
+                    currentFilters: {
+                        type: String,
+                        value: ""
+                    },
+
+                    currentSortOrders: {
+                        type: String,
+                        value: ""
+                    },
+
+                    vaadingrid: {
+                        type: Object
+                    },
+
+                    eventId: {
+                        type: String
+                    },
+
+                    /*
+                     * Optional.  Indicates which
+                     * of possibly multiple vaadingrid tables
+                     * the event is intended for.
+                     */
+                    index: {
+                        type: Number
+                    },
+
+                    /*
+                     * A function of two parameters (item, index),
+                     * the second of which should be the index property.
+                     *
+                     * The function allows for any special manipulation
+                     * of the raw data item that was received.
+                     */
+                    postProcessItem: {
+                        type: Object
+                    },
+
+                    /*
+                     * A function of one parameter (xhr),
+                     * which should be the response object.
+                     *
+                     * The function encapsulates how to derive the
+                     * actual data object from the response.
+                     */
+                    itemsArray: {
+                        type: Object
+                    },
+
+                    /*
+                     * A function of one parameter (index),
+                     * which should be the index property.
+                     *
+                     * The function encapsulates the specific RESTful
+                     * path to be used in fetching the data.
+                     */
+                    urlPath: {
+                        type: Object
+                    },
+
+                    /*
+                     * A function of one parameter (index),
+                     * which should be the index property.
+                     *
+                     * The function encapsulates the specific RESTful
+                     * parameters to be used in fetching the data.
+                     */
+                    parameters: {
+                        type: Object
+                    }
+                }
+            }
+
+            constructor(vaadingrid, index, postprocess,
+                        itemsArray, urlPath, parameters, eventId) {
+                super();
+                this.vaadingrid = vaadingrid;
+                this.index = index;
+                this.postProcessItem = postprocess;
+                this.itemsArray = itemsArray;
+                this.urlPath = urlPath;
+                this.parameters = parameters;
+                this.eventId = eventId;
+                this.currentItems = [];
+                this.currentOffset = 0;
+            }
+
+            resetProvider() {
+                this.currentOffset = 0;
+                this.currentItems = [];
+                this._notifyTableSizeChanged(0);
+                this.vaadingrid.clearCache();
+            }
+
+            runProvider(params, vaadincallback) {
+                if (this._paramsChanged(params)) {
+                    vaadincallback([]);
+                    this.resetProvider();
+                    return;
+                }
+
+                if (this.currentOffset === -1) {
+                    vaadincallback([]);
+                    return;
+                }
+
+                new Promise((resolve, reject) => {
+                    const xhr = new XMLHttpRequest();
+
+                    xhr.onload = () => {
+                        if (xhr.status == 200) {
+                            resolve(xhr);
+                        } else {
+                            reject(Error(xhr.statusText));
+                        }
+                    }
+
+                    xhr.onerror = () => {
+                        reject(Error("Network Error"));
+                    }
+
+                    this.currentOffset = params.page * params.pageSize;
+
+                    xhr.open('GET',
+                             this.getUrl(this.urlPath(this.index),
+                                         this._generateParams(this.currentOffset,
+                                                              params.pageSize,
+                                                              params.filters,
+                                                              params.sortOrders),
+                             true));
+
+                    this.setXHRHeaders(xhr);
+
+                    xhr.send();
+                }).then((xhr) => {
+                    const items = this.itemsArray(xhr);
+
+                    if (items && items.length > 0) {
+                        items.forEach(item => {
+                            this.currentItems.push(this.postProcessItem(item, this.index));
+                        });
+
+                        if (items.length < params.pageSize) {
+                            this.currentOffset = -1;
+                            this._notifyTableSizeChanged(this.currentItems.length);
+                        } else {
+                            this._notifyTableSizeChanged(this.currentItems.length
+                                                        + params.pageSize);
+                        }
+
+                        vaadincallback(items);
+                    } else {
+                        this.currentOffset = -1;
+                        this._notifyTableSizeChanged(this.currentItems.length);
+                        vaadincallback([]);
+                    }
+
+                    this._notifyTimeoutReset();
+                }, (error)=> {
+                    this.currentOffset = -1;
+                    this._notifyTableSizeChanged(this.currentItems.length);
+                    vaadincallback([]);
+                    this._notifyTimeoutReset();
+                    app.$.toast.text = error;
+                    app.$.toast.show();
+                });
+            }
+
+            /*
+             *  ---------------------- Filter & Sort -------------------------
+             */
+            _generateParams(offset, limit, filters, orders) {
+                let params = `?offset=${offset}&limit=${limit}`;
+                params += this.parameters(this.index);
+                params += this._getFilterString(filters);
+                params += this._getSortString(orders);
+                return params;
+            }
+
+            _getFilterString(filters) {
+                let filterString = "";
+
+                if (filters.length > 0) {
+                    filters.forEach((filter) => {
+                        filterString += `&${filter.path}=${filter.value}`;
+                    });
+                }
+
+                return filterString
+            }
+
+            _getSortString(sortOrders) {
+                let sort = "";
+
+                const len = sortOrders.length;
+
+                if (len > 0) {
+                    switch (sortOrders[0].direction) {
+                        case 'asc':
+                            sort += `${sortOrders[0].path}`;
+                            break;
+                        case 'desc':
+                            sort += `-${sortOrders[0].path}`;
+                            break;
+                    }
+
+                    for (let i = 1; i < len; i++) {
+                        switch (sortOrders[i].direction) {
+                            case 'asc':
+                                sort += `,${sortOrders[i].path}`;
+                                break;
+                            case 'desc':
+                                sort += `,-${sortOrders[i].path}`;
+                                break;
+                        }
+                    }
+                }
+
+                return sort === "" ? sort : `&sort=${sort}`;
+            }
+
+            _paramsChanged(params) {
+                const filterString = this._getFilterString(params.filters);
+                const sortString = this._getSortString(params.sortOrders);
+
+                const changed = (this.currentFilters !== filterString) ||
+                    (this.currentSortOrders !== sortString);
+
+                this.currentFilters = filterString;
+                this.currentSortOrders = sortString;
+
+                return changed;
+            }
+
+
+            /*
+             *  ----------------- Selection Column Control -------------------
+             */
+
+            clearSelected() {
+                this.selectAll = false;
+                this.indeterminate = false;
+                this.vaadingrid.selectedItems = [];
+                this._notifySelectionCleared();
+            }
+
+            currentlySelected() {
+                return `${this.vaadingrid.selectedItems.length} / ${this.currentItems.length}`;
+            }
+
+            isChecked() {
+                return this.computeChecked(this.indeterminate, this.selectAll);
+            }
+
+            isIndeterminate() {
+                return this.indeterminate;
+            }
+
+            selectItem(e) {
+                this.selectGridItem(e, this.vaadingrid);
+                this.indeterminate = this.computeIndeterminate(this.vaadingrid);
+                this._notifySelectionCleared();
+            }
+
+            toggleAll() {
+                this.selectAll
+                    = this.toggleAllGridItems(this.selectAll,
+                                              this.currentItems,
+                                              this.vaadingrid);
+                this.indeterminate = this.computeIndeterminate(this.vaadingrid);
+                this._notifySelectionCleared();
+            }
+
+
+            /*
+             *  ----------------- Table update events -------------------
+             */
+
+            _notifySelectionCleared() {
+                window.dispatchEvent(
+                    new CustomEvent(`dv-vaadin-provider-selection-column-clear-${this.eventId}`, {
+                        detail: {index: this.index}, composed: true}));
+            }
+
+            _notifyTimeoutReset() {
+                window.dispatchEvent(
+                    new CustomEvent(`dv-vaadin-provider-reset-timeout-${this.eventId}`, {
+                        detail: {index: this.index}, composed: true}));
+            }
+
+            _notifyTableSizeChanged(size) {
+                window.dispatchEvent(
+                    new CustomEvent(`dv-vaadin-provider-update-table-size-${this.eventId}`, {
+                        detail: {index: this.index, size: size}, composed: true}));
+            }
+        }
+
+        window.customElements.define(DvVaadinProviderDecoratorAlt.is, DvVaadinProviderDecoratorAlt);
+    </script>
+</dom-module>

--- a/src/elements/dv-elements/admin/views/alarms-view.html
+++ b/src/elements/dv-elements/admin/views/alarms-view.html
@@ -27,7 +27,7 @@
 <link rel="import"
       href="../../../../bower_components/vaadin-grid/vaadin-grid-table-scroll-behavior.html">
 <link rel="import"
-      href="../../../../elements/dv-elements/admin/dv-vaadin-provider-decorator.html">
+      href="../../../../elements/dv-elements/admin/dv-vaadin-provider-decorator-alt.html">
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dv-admin-mixins.html">
 <link rel="import" href="../dialogs/pool-info-dialog.html"/>
@@ -452,15 +452,24 @@
             }
 
             connectedCallback() {
-                if (super.connectedCallback) {
-                    super.connectedCallback();
-                }
+                super.connectedCallback();
+
+                window.addEventListener('dv-vaadin-provider-selection-column-clear-alarms', this.signalChange.bind(this));
+                window.addEventListener('dv-vaadin-provider-reset-timeout-alarms', this.resetTimeout.bind(this));
+                window.addEventListener('dv-vaadin-provider-update-table-size-alarms', this.setTableSize.bind(this));
 
                 this.afterDate = this._getInitialAfter();
                 this.shadowRoot.querySelector('#from').value
                     = this.parseDate(this.afterDate);
 
-                this.decorator = new DvVaadinProviderDecorator(this.$.alarms);
+                this.decorator
+                    = new DvVaadinProviderDecoratorAlt(this.$.alarms,
+                                                       null,
+                                                       this.handleItem.bind(this),
+                                                       (xhr) => JSON.parse(xhr.responseText),
+                                                       (index) => 'alarms/logentries',
+                                                       this.providerParams.bind(this),
+                                                       'alarms');
 
                 /*
                  * This must be assigned only after the decorator has been
@@ -469,11 +478,18 @@
                 this.$.alarms.dataProvider = this._remoteProvider.bind(this);
             }
 
+            disconnectedCallback() {
+                super.disconnectedCallback();
+                window.removeEventListener('dv-vaadin-provider-selection-column-clear-alarms', this.signalChange.bind(this));
+                window.removeEventListener('dv-vaadin-provider-reset-timeout-alarms', this.resetTimeout.bind(this));
+                window.removeEventListener('dv-vaadin-provider-update-table-size-alarms', this.setTableSize.bind(this));
+            }
+
             /*
              *  ------------------------ Selection ---------------------------
              */
 
-            signalChange() {
+            signalChange(e) {
                 this.selectionAction = !this.selectionAction;
             }
 
@@ -486,11 +502,11 @@
             }
 
             _selectItem(e) {
-                this.decorator.selectItem(e, this);
+                this.decorator.selectItem(e);
             }
 
             _toggleAll(e) {
-                this.decorator.toggleAll(this);
+                this.decorator.toggleAll();
             }
 
             /*
@@ -506,10 +522,6 @@
                     = this._convertSeverity(item.severity, item.closed);
 
                 return item;
-            }
-
-            itemsArray(xhr, index) {
-                return JSON.parse(xhr.responseText);
             }
 
             providerParams(index) {
@@ -534,16 +546,12 @@
                 return params;
             }
 
-            providerUrl(index) {
-                return 'alarms/logentries';
-            }
-
-            resetTimeout() {
+            resetTimeout(e) {
                 this.resetRefresh(this._refresh.bind(this), 60000);
             }
 
-            setTableSize(size, index) {
-                this.tableSize = size;
+            setTableSize(e) {
+                this.tableSize = e.detail.size;
             }
 
             _convertSeverity(severity, closed) {
@@ -580,12 +588,12 @@
 
             _refresh() {
                 if (this.decorator) {
-                    this.decorator.resetProvider(this);
+                    this.decorator.resetProvider();
                 }
             }
 
             _remoteProvider(params, callback) {
-                return this.decorator.runProvider(params, callback, this, null);
+                return this.decorator.runProvider(params, callback);
             }
 
 
@@ -601,7 +609,8 @@
                 });
 
                 this._sendPatch({'action': 'update', 'items': items});
-                this.decorator.clearSelected(this);
+
+                this.decorator.clearSelected();
             }
 
             _close() {
@@ -619,7 +628,8 @@
                     });
 
                     this._sendPatch({'action': 'delete', 'items': keys});
-                    this.decorator.clearSelected(this);
+
+                    this.decorator.clearSelected();
                 }
             }
 
@@ -635,13 +645,12 @@
             }
 
             _handlePatchResponse(event) {
-                this.handleError("Request completed.");
                 this._refresh();
             }
 
             _handlePatchError(event) {
                 this.handleError(event.detail.error.message);
-                this._interrupt()
+                this._interrupt();
                 this._refresh();
             }
 
@@ -683,7 +692,7 @@
             }
 
             _sendPatch(items) {
-                this.$.AjaxPatch.url = this.getUrl(this.providerUrl(), null);
+                this.$.AjaxPatch.url = this.getUrl('alarms/logentries', null);
                 this.$.AjaxPatch.headers = this.getHeaders();
                 this.$.AjaxPatch.body = items;
                 this.$.AjaxPatch.generateRequest();

--- a/src/elements/elements.html
+++ b/src/elements/elements.html
@@ -93,6 +93,7 @@
 <!-- dcache-view mixins and utils -->
 <link rel="import" href="dv-elements/admin/dv-admin-mixins.html">
 <link rel="import" href="dv-elements/admin/dv-vaadin-provider-decorator.html">
+<link rel="import" href="dv-elements/admin/dv-vaadin-provider-decorator-alt.html">
 
 <!-- dcache-view elements -->
 <link rel="import" href="../bower_components/admin-page/admin-page.html">


### PR DESCRIPTION
… instead of parent callbacks

Motivation:

The dv-vaadin-provider-decorator component
encapsulates state and code which is necessary
to support lazy loading by remote paging calls
on a vaadingrid table, including data fetchs,
filtering, sorting and checkbox selection.

This component currently requires parent components
which make use of it to implement an (implicit)
interface which it in turn invokes via callbacks.
Such a design is not idiomatic, and further
goes against Polymer 2.0 best practices
which suggest decoupling parents from children
and using outgoing custom events instead of
callbacks.

Modification:

This patch does two things.

A) It creates an alternate component,
dv-vaading-provider-decorator-alt, eliminates
callbacks in two ways:

i) by defining a set a function properties
   which must be set through the constructor;

ii) by implementing a set of custom event notifications.

The first modification eliminates method callbacks
which provide data or configuration specific to the
parent; the second eliminates update callbacks.

Of course, the functions provided in (i) are still
bound to the parent environment, but the coupling
is no longer explicit or tight.

B) The alarms view is modified to use the new
component.

Result:

Better design, and possibly improved efficiency
in loading, with no visible change in behavior.

Target: master
Require-notes: no
Require-book: no
Acked-by: Olufemi