### PR TITLE
dcache-view (admin): upgrade dependency to vaadin-grid 4.1.7

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -33,7 +33,7 @@
     "qos-backend-information": "dCacheElements/qos-backend-information#0.0.7",
     "google-apis": "#2.0.0",
     "google-chart": "#2.0.0",
-    "vaadin-grid": "#3.0.2",
+    "vaadin-grid": "#4.1.7",
     "web-animations-js": "#2.3.1"
   },
   "resolutions": {

--- a/src/elements/dv-elements/admin/dialogs/billing-records-dialog.html
+++ b/src/elements/dv-elements/admin/dialogs/billing-records-dialog.html
@@ -21,13 +21,11 @@
 <link rel="import"
       href="../../../../bower_components/vaadin-grid/vaadin-grid-column-group.html">
 <link rel="import"
-      href="../../../../bower_components/vaadin-grid/vaadin-grid-table-scroll-behavior.html">
-<link rel="import"
-      href="../../../../bower_components/vaadin-grid/vaadin-grid-cell-click-behavior.html">
-<link rel="import"
       href="../../../../elements/dv-elements/admin/dialogs/file-info-dialog.html">
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dialogs/pool-info-dialog.html">
+<link rel="import"
+      href="../../../../elements/dv-elements/admin/dv-vaadin-theme.html">
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dv-vaadin-provider-decorator.html">
 <link rel="import"
@@ -67,36 +65,6 @@
                 color: #ffffff;
                 height: 30px;
                 padding: 5px 0px;
-            }
-
-            vaadin-grid {
-                position: relative;
-                height: 100%;
-                -webkit-font-smoothing: antialiased;
-                --divider-color: #d4d4d4;
-
-                --vaadin-grid-cell: {
-                    padding: 0 8px;
-                    height: 32px;
-                    border-right: 1px solid #d4d4d4;
-                    box-sizing: border-box;
-                    font-size: 8pt;
-                    cursor: default;
-                };
-
-                --vaadin-grid-header-cell: {
-                    height: 36px;
-                    border-bottom: 1px solid #d4d4d4;
-                    background-image: linear-gradient(to bottom, #fafafa 2%, #efefef 98%);
-                    font-size: 9pt;
-                    text-style: bold;
-                    text-align: center;
-                    cursor: default;
-                };
-
-                --vaadin-grid-body-row-odd-cell: {
-                    background-color: #f5f5f5;
-                };
             }
 
             iron-pages {
@@ -231,7 +199,7 @@
                                 <template class="header"></template>
                                 <template>
                                     <paper-checkbox aria-label="UserInfo"
-                                                    checked="{{expanded}}">
+                                                    checked="{{detailsOpened}}">
                                     </paper-checkbox>
                                 </template>
                             </vaadin-grid-column>
@@ -267,7 +235,8 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span class$="actionable[[item.pool.active]]">
+                                    <span onclick="sendBillingRecordsCellClick('R', '4')"
+                                          class$="actionable[[item.pool.active]]">
                                         [[item.pool.name]]
                                     </span>
                                 </template>
@@ -415,7 +384,7 @@
                                 <template class="header"></template>
                                 <template>
                                     <paper-checkbox aria-label="UserInfo"
-                                                    checked="{{expanded}}">
+                                                    checked="{{detailsOpened}}">
                                     </paper-checkbox>
                                 </template>
                             </vaadin-grid-column>
@@ -451,7 +420,8 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span class$="actionable[[item.pool.active]]">
+                                    <span onclick="sendBillingRecordsCellClick('W', '4')"
+                                          class$="actionable[[item.pool.active]]">
                                         [[item.pool.name]]
                                     </span>
                                 </template>
@@ -593,7 +563,8 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span class$="actionable[[item.serverPool.active]]">
+                                    <span onclick="sendBillingRecordsCellClick('P', '3')"
+                                          class$="actionable[[item.serverPool.active]]">
                                         [[item.serverPool.name]]
                                     </span>
                                 </template>
@@ -618,7 +589,8 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span class$="actionable[[item.clientPool.active]]">
+                                    <span onclick="sendBillingRecordsCellClick('P', '4')"
+                                          class$="actionable[[item.clientPool.active]]">
                                         [[item.clientPool.name]]
                                     </span>
                                 </template>
@@ -718,7 +690,8 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span class$="actionable[[item.pool.active]]">
+                                    <span onclick="sendBillingRecordsCellClick('F', '3')"
+                                          class$="actionable[[item.pool.active]]">
                                         [[item.pool.name]]
                                     </span>
                                 </template>
@@ -807,7 +780,8 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span class$="actionable[[item.pool.active]]">
+                                    <span onclick="sendBillingRecordsCellClick('S', '3')"
+                                          class$="actionable[[item.pool.active]]">
                                         [[item.pool.name]]
                                     </span>
                                 </template>
@@ -861,7 +835,13 @@
     </template>
 
     <script>
-        class BillingRecordsDialog extends Polymer.mixinBehaviors([Polymer.PaperDialogBehavior, vaadin.elements.grid.CellClickBehavior],
+        function sendBillingRecordsCellClick(table, cell) {
+            window.dispatchEvent(
+                new CustomEvent(`dv-billing-records-table-cell-click`, {
+                    detail: {table: table, cell: parseInt(cell)}}));
+        }
+
+        class BillingRecordsDialog extends Polymer.mixinBehaviors([Polymer.PaperDialogBehavior],
             DcacheViewMixins.AdminAutoRefresh(DcacheViewMixins.AdminBase(Polymer.Element))) {
 
             static get is() {
@@ -914,7 +894,8 @@
                     },
 
                     cell: {
-                        type: Number
+                        type: Number,
+                        value: 0
                     },
 
                     table: {
@@ -938,20 +919,15 @@
             connectedCallback() {
                 super.connectedCallback();
 
-                this.$.reads.addEventListener('cell-focus', this._handleReadsClick.bind(this));
-                this.$.writes.addEventListener('cell-focus', this._handleWritesClick.bind(this));
-                this.$.p2ps.addEventListener('cell-focus', this._handleP2psClick.bind(this));
-                this.$.stores.addEventListener('cell-focus', this._handleFlushesClick.bind(this));
-                this.$.restores.addEventListener('cell-focus', this._handleStagesClick.bind(this));
-
                 window.addEventListener('dv-vaadin-provider-reset-timeout-billing', this.resetTimeout.bind(this));
                 window.addEventListener('dv-vaadin-provider-update-table-size-billing', this.setTableSize.bind(this));
+                window.addEventListener('dv-billing-records-table-cell-click', this.setCell.bind(this));
 
-                this.decorators[0] = this._createDecorator(this.$.reads, 0);
-                this.decorators[1] = this._createDecorator(this.$.writes, 1);
-                this.decorators[2] = this._createDecorator(this.$.p2ps, 2);
-                this.decorators[3] = this._createDecorator(this.$.stores, 3);
-                this.decorators[4] = this._createDecorator(this.$.restores, 4);
+                this.decorators[0] = this._createDecorator(this.$.reads, 0, 3);
+                this.decorators[1] = this._createDecorator(this.$.writes, 1, 3);
+                this.decorators[2] = this._createDecorator(this.$.p2ps, 2, 3);
+                this.decorators[3] = this._createDecorator(this.$.stores, 3, 1);
+                this.decorators[4] = this._createDecorator(this.$.restores, 4, 1);
 
                 this.$.reads.dataProvider = this._remoteProvider(0).bind(this);
                 this.$.writes.dataProvider = this._remoteProvider(1).bind(this);
@@ -973,58 +949,26 @@
 
             disconnectedCallback() {
                 super.disconnectedCallback();
-                this.$.reads.removeEventListener('cell-focus', this._handleReadsClick.bind(this));
-                this.$.writes.removeEventListener('cell-focus', this._handleWritesClick.bind(this));
-                this.$.p2ps.removeEventListener('cell-focus', this._handleP2psClick.bind(this));
-                this.$.stores.removeEventListener('cell-focus', this._handleFlushesClick.bind(this));
-                this.$.restores.removeEventListener('cell-focus', this._handleStagesClick.bind(this));
 
                 window.removeEventListener('dv-vaadin-provider-reset-timeout-billing', this.resetTimeout.bind(this));
                 window.removeEventListener('dv-vaadin-provider-update-table-size-billing', this.setTableSize.bind(this));
+                window.removeEventListener('dv-billing-records-table-cell-click', this.setCell.bind(this));
             }
 
-            _createDecorator(table, index) {
+            setCell(event) {
+                this.table = event.detail.table;
+                this.cell = event.detail.cell;
+            }
+
+            _createDecorator(table, index, filter) {
                 return new DvVaadinProviderDecorator(table,
                                                     index,
                                                     this.handleItem.bind(this),
                                                     (xhr) => JSON.parse(xhr.responseText),
                                                     this.providerUrl.bind(this),
                                                     (index) => '',
-                                                    'billing');
-            }
-
-            _handleReadsClick(e) {
-                e.stopPropagation();
-                this._handleCellFocus(e, "R");
-            }
-
-            _handleWritesClick(e) {
-                e.stopPropagation();
-                this._handleCellFocus(e, "W");
-            }
-
-            _handleP2psClick(e) {
-                e.stopPropagation();
-                this._handleCellFocus(e, "P");
-            }
-
-            _handleFlushesClick(e) {
-                e.stopPropagation();
-                this._handleCellFocus(e, "F");
-            }
-
-            _handleStagesClick(e) {
-                e.stopPropagation();
-                this._handleCellFocus(e, "S");
-            }
-
-            _handleCellFocus(event, table) {
-                this.cell = 0;
-                const cell = event.composedPath()[0];
-                if (cell) {
-                    this.cell = parseInt(cell.order.toString().charAt(0));
-                }
-                this.table = table;
+                                                    'billing',
+                                                    filter);
             }
 
             /*
@@ -1120,8 +1064,8 @@
                     this.currentItem = item.detail.value;
                 }
 
-                if (typeof this.currentItem == 'undefined' ||
-                    typeof this.cell == 'undefined') {
+                if (typeof this.currentItem === 'undefined' ||
+                    typeof this.cell === 'undefined') {
                     return;
                 }
 
@@ -1153,6 +1097,9 @@
                         }
                         break;
                 }
+
+                this.table = '';
+                this.cell = 0;
             }
 
             _hideToast() {

--- a/src/elements/dv-elements/admin/dialogs/file-info-dialog.html
+++ b/src/elements/dv-elements/admin/dialogs/file-info-dialog.html
@@ -21,6 +21,8 @@
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dialogs/pool-info-dialog.html">
 <link rel="import"
+      href="../../../../elements/dv-elements/admin/dv-vaadin-theme.html">
+<link rel="import"
       href="../../../../elements/dv-elements/admin/dv-admin-mixins.html">
 
 <dom-module id="file-info-dialog">
@@ -37,34 +39,10 @@
             }
 
             vaadin-grid {
-                position: relative;
-                height: 20vh;
-                margin-bottom: 15px;
-                -webkit-font-smoothing: antialiased;
-                --divider-color: #d4d4d4;
-
-                --vaadin-grid-cell: {
-                    padding: 0 8px;
-                    height: 24px;
-                    border-right: 1px solid #d4d4d4;
-                    box-sizing: border-box;
-                    font-size: 8pt;
-                    cursor: default;
-                };
-
-                --vaadin-grid-header-cell: {
-                    height: 24px;
-                    border-bottom: 1px solid #d4d4d4;
-                    background-image: linear-gradient(to bottom, #fafafa 2%, #efefef 98%);
-                    font-size: 9pt;
-                    text-style: bold;
-                    text-align: center;
-                    cursor: default;
-                };
-
-                --vaadin-grid-body-row-odd-cell: {
-                    background-color: #f5f5f5;
-                };
+                --dv-vaadin-grid-height: 20vh;
+                --dv-vaadin-grid-cell-height: 24px;
+                --dv-vaadin-grid-header-cell-height: 24px;
+                --dv-vaadin-grid-cell-font-size: 9pt;
             }
 
             paper-scroll-header-panel {

--- a/src/elements/dv-elements/admin/dialogs/pool-activity-dialog.html
+++ b/src/elements/dv-elements/admin/dialogs/pool-activity-dialog.html
@@ -21,15 +21,13 @@
 <link rel="import"
       href="../../../../bower_components/vaadin-grid/vaadin-grid-column-group.html">
 <link rel="import"
-      href="../../../../bower_components/vaadin-grid/vaadin-grid-table-scroll-behavior.html">
-<link rel="import"
-      href="../../../../bower_components/vaadin-grid/vaadin-grid-cell-click-behavior.html">
-<link rel="import"
       href="../../../../elements/dv-elements/admin/dialogs/file-info-dialog.html">
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dialogs/pool-info-dialog.html">
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dv-vaadin-provider-decorator.html">
+<link rel="import"
+      href="../../../../elements/dv-elements/admin/dv-vaadin-theme.html">
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dv-admin-mixins.html">
 
@@ -59,36 +57,6 @@
                 color: #ffffff;
                 height: 30px;
                 padding: 5px 0px;
-            }
-
-            vaadin-grid {
-                position: relative;
-                height: 100%;
-                -webkit-font-smoothing: antialiased;
-                --divider-color: #d4d4d4;
-
-                --vaadin-grid-cell: {
-                    padding: 0 8px;
-                    height: 32px;
-                    border-right: 1px solid #d4d4d4;
-                    box-sizing: border-box;
-                    font-size: 8pt;
-                    cursor: default;
-                };
-
-                --vaadin-grid-header-cell: {
-                    height: 36px;
-                    border-bottom: 1px solid #d4d4d4;
-                    background-image: linear-gradient(to bottom, #fafafa 2%, #efefef 98%);
-                    font-size: 9pt;
-                    text-style: bold;
-                    text-align: center;
-                    cursor: default;
-                };
-
-                --vaadin-grid-body-row-odd-cell: {
-                    background-color: #f5f5f5;
-                };
             }
 
             .opaque {
@@ -160,10 +128,6 @@
                 height: 100%;
             }
 
-            .detailinfo {
-                margin: 20px auto 20px auto;
-            }
-
         </style>
 
         <div class="opaque">
@@ -212,8 +176,11 @@
                                                focus-target>
                                     </vaadin-grid-filter>
                                 </template>
-                                <template><span
-                                        class$="actionable[[item.pnfsId.active]]">[[item.pnfsId.id]]</span>
+                                <template>
+                                    <span onclick="sendPoolActivityCellClick()"
+                                          class$="actionable[[item.pnfsId.active]]">
+                                        [[item.pnfsId.id]]
+                                    </span>
                                 </template>
                             </vaadin-grid-column>
                         </vaadin-grid-column-group>
@@ -421,8 +388,11 @@
                                                focus-target>
                                     </vaadin-grid-filter>
                                 </template>
-                                <template><span
-                                        class$="actionable[[item.pnfsId.active]]">[[item.pnfsId.id]]</span>
+                                <template>
+                                    <span onclick="sendPoolActivityCellClick()"
+                                            class$="actionable[[item.pnfsId.active]]">
+                                            [[item.pnfsId.id]]
+                                    </span>
                                 </template>
                             </vaadin-grid-column>
                         </vaadin-grid-column-group>
@@ -570,7 +540,7 @@
 
                         <template class="row-details">
                             <div class="details">
-                                <table class="detailinfo">
+                                <table>
                                     <tr>
                                         <td><strong>UUID:</strong></td>
                                         <td><strong>[[item.uuid]]</strong></td>
@@ -592,7 +562,7 @@
                                 <template class="header"></template>
                                 <template>
                                     <paper-checkbox aria-label="Details"
-                                                    checked="{{expanded}}">
+                                                    checked="{{detailsOpened}}">
                                     </paper-checkbox>
                                 </template>
                             </vaadin-grid-column>
@@ -614,8 +584,11 @@
                                                focus-target>
                                     </vaadin-grid-filter>
                                 </template>
-                                <template><span
-                                        class$="actionable[[item.pnfsId.active]]">[[item.pnfsId.id]]</span>
+                                <template>
+                                    <span onclick="sendPoolActivityCellClick()"
+                                          class$="actionable[[item.pnfsId.active]]">
+                                            [[item.pnfsId.id]]
+                                    </span>
                                 </template>
                             </vaadin-grid-column>
                         </vaadin-grid-column-group>
@@ -714,7 +687,7 @@
 
                         <template class="row-details">
                             <div class="details">
-                                <table class="detailinfo">
+                                <table>
                                     <tr>
                                         <td><strong>UUID:</strong></td>
                                         <td><strong>[[item.uuid]]</strong></td>
@@ -736,7 +709,7 @@
                                 <template class="header"></template>
                                 <template>
                                     <paper-checkbox aria-label="Details"
-                                                    checked="{{expanded}}">
+                                                    checked="{{detailsOpened}}">
                                     </paper-checkbox>
                                 </template>
                             </vaadin-grid-column>
@@ -758,8 +731,11 @@
                                                focus-target>
                                     </vaadin-grid-filter>
                                 </template>
-                                <template><span
-                                        class$="actionable[[item.pnfsId.active]]">[[item.pnfsId.id]]</span>
+                                <template>
+                                    <span onclick="sendPoolActivityCellClick()"
+                                          class$="actionable[[item.pnfsId.active]]">
+                                            [[item.pnfsId.id]]
+                                    </span>
                                 </template>
                             </vaadin-grid-column>
                         </vaadin-grid-column-group>
@@ -858,7 +834,7 @@
 
                         <template class="row-details">
                             <div class="details">
-                                <table class="detailinfo">
+                                <table>
                                     <tr>
                                         <td><strong>UUID:</strong></td>
                                         <td><strong>[[item.uuid]]</strong></td>
@@ -884,7 +860,7 @@
                                 <template class="header"></template>
                                 <template>
                                     <paper-checkbox aria-label="Details"
-                                                    checked="{{expanded}}">
+                                                    checked="{{detailsOpened}}">
                                     </paper-checkbox>
                                 </template>
                             </vaadin-grid-column>
@@ -905,8 +881,11 @@
                                                focus-target>
                                     </vaadin-grid-filter>
                                 </template>
-                                <template><span
-                                        class$="actionable[[item.pnfsId.active]]">[[item.pnfsId.id]]</span>
+                                <template>
+                                    <span onclick="sendPoolActivityCellClick()"
+                                            class$="actionable[[item.pnfsId.active]]">
+                                        [[item.pnfsId.id]]
+                                    </span>
                                 </template>
                             </vaadin-grid-column>
                         </vaadin-grid-column-group>
@@ -1003,8 +982,12 @@
     </template>
 
     <script>
-        class PoolActivityDialog extends
-            Polymer.mixinBehaviors([Polymer.PaperDialogBehavior, vaadin.elements.grid.CellClickBehavior],
+        function setPoolActivityCellClick() {
+            window.dispatchEvent(
+                new CustomEvent(`dv-pool-activity-table-cell-click`, {}));
+        }
+
+        class PoolActivityDialog extends Polymer.mixinBehaviors([Polymer.PaperDialogBehavior],
             DcacheViewMixins.AdminAutoRefresh(DcacheViewMixins.AdminBase(Polymer.Element))) {
 
             static get is() {
@@ -1056,8 +1039,9 @@
                         type: String
                     },
 
-                    cell: {
-                        type: Number
+                    pnfsidClicked: {
+                        type: Boolean,
+                        value: false
                     },
 
                     selected: {
@@ -1077,20 +1061,15 @@
             connectedCallback() {
                 super.connectedCallback();
 
-                this.$.movers.addEventListener('cell-focus', this._handleCellFocus.bind(this));
-                this.$.p2ps.addEventListener('cell-focus', this._handleCellFocus.bind(this));
-                this.$.flushes.addEventListener('cell-focus', this._handleCellFocus.bind(this));
-                this.$.stages.addEventListener('cell-focus', this._handleCellFocus.bind(this));
-                this.$.removes.addEventListener('cell-focus', this._handleCellFocus.bind(this));
-
                 window.addEventListener('dv-vaadin-provider-reset-timeout-pool', this.resetTimeout.bind(this));
                 window.addEventListener('dv-vaadin-provider-update-table-size-pool', this.setTableSize.bind(this));
+                window.addEventListener('dv-pool-activity-table-cell-click', this.setPnfsidClicked.bind(this));
 
-                this.decorators[0] = this._createDecorator(this.$.movers, 0);
-                this.decorators[1] = this._createDecorator(this.$.p2ps, 1);
-                this.decorators[2] = this._createDecorator(this.$.flushes, 2);
-                this.decorators[3] = this._createDecorator(this.$.stages, 3);
-                this.decorators[4] = this._createDecorator(this.$.removes, 4);
+                this.decorators[0] = this._createDecorator(this.$.movers, 0, 6);
+                this.decorators[1] = this._createDecorator(this.$.p2ps, 1, 4);
+                this.decorators[2] = this._createDecorator(this.$.flushes, 2, 3);
+                this.decorators[3] = this._createDecorator(this.$.stages, 3, 3);
+                this.decorators[4] = this._createDecorator(this.$.removes, 4, 3);
 
                 this.$.movers.dataProvider = this._remoteProvider(0).bind(this);
                 this.$.p2ps.dataProvider = this._remoteProvider(1).bind(this);
@@ -1112,33 +1091,21 @@
 
             disconnectedCallback() {
                 super.disconnectedCallback();
-                this.$.movers.removeEventListener('cell-focus', this._handleCellFocus.bind(this));
-                this.$.p2ps.removeEventListener('cell-focus', this._handleCellFocus.bind(this));
-                this.$.flushes.removeEventListener('cell-focus', this._handleCellFocus.bind(this));
-                this.$.stages.removeEventListener('cell-focus', this._handleCellFocus.bind(this));
-                this.$.removes.removeEventListener('cell-focus', this._handleCellFocus.bind(this));
 
                 window.removeEventListener('dv-vaadin-provider-reset-timeout-pool', this.resetTimeout.bind(this));
                 window.removeEventListener('dv-vaadin-provider-update-table-size-pool', this.setTableSize.bind(this));
+                window.removeEventListener('dv-pool-activity-table-cell-click', this.setPnfsidClicked.bind(this));
             }
 
-            _createDecorator(table, index) {
+            _createDecorator(table, index, filters) {
                 return new DvVaadinProviderDecorator(table,
                                                     index,
                                                     this.handleItem.bind(this),
                                                     (xhr) => JSON.parse(xhr.responseText),
                                                     this.providerUrl.bind(this),
                                                     this.providerParams.bind(this),
-                                                    'pool');
-            }
-
-            _handleCellFocus(event) {
-                event.stopPropagation();
-                this.cell = 0;
-                const cell = event.composedPath()[0];
-                if (cell) {
-                    this.cell = parseInt(cell.order.toString().charAt(0));
-                }
+                                                    'pool',
+                                                    filters);
             }
 
             /*
@@ -1214,6 +1181,10 @@
                 this.resetRefresh(this._refresh.bind(this), 60000);
             }
 
+            setPnfsidClicked(e) {
+                this.pnfsidClicked = true;
+            }
+
             setTableSize(e) {
                 switch (e.detail.index) {
                     case 0:
@@ -1266,10 +1237,11 @@
                     return;
                 }
 
-                if ((this.selected < 2 && this.cell === 2) ||
-                    (this.selected > 1 && this.cell === 3)) {
+                if (this.pnfsidClicked) {
                     this.openFileInfoDialog(this.currentItem.pnfsId.id, this.pool);
                 }
+
+                this.pnfsidClicked = false;
             }
         }
 

--- a/src/elements/dv-elements/admin/dialogs/pool-info-dialog.html
+++ b/src/elements/dv-elements/admin/dialogs/pool-info-dialog.html
@@ -19,6 +19,8 @@
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dialogs/pool-activity-dialog.html">
 <link rel="import"
+      href="../../../../elements/dv-elements/admin/dv-vaadin-theme.html">
+<link rel="import"
       href="../../../../elements/dv-elements/admin/dv-admin-mixins.html">
 
 <dom-module id="pool-info-dialog">
@@ -49,34 +51,10 @@
             }
 
             vaadin-grid {
-                position: relative;
-                height: 20vh;
-                margin-bottom: 15px;
-                -webkit-font-smoothing: antialiased;
-                --divider-color: #d4d4d4;
-
-                --vaadin-grid-cell: {
-                    padding: 0 8px;
-                    height: 24px;
-                    border-right: 1px solid #d4d4d4;
-                    box-sizing: border-box;
-                    font-size: 8pt;
-                    cursor: default;
-                };
-
-                --vaadin-grid-header-cell: {
-                    height: 24px;
-                    border-bottom: 1px solid #d4d4d4;
-                    background-image: linear-gradient(to bottom, #fafafa 2%, #efefef 98%);
-                    font-size: 9pt;
-                    text-style: bold;
-                    text-align: center;
-                    cursor: default;
-                };
-
-                --vaadin-grid-body-row-odd-cell: {
-                    background-color: #f5f5f5;
-                };
+                --dv-vaadin-grid-height: 20vh;
+                --dv-vaadin-grid-cell-height: 24px;
+                --dv-vaadin-grid-header-cell-height: 24px;
+                --dv-vaadin-grid-cell-font-size: 9pt;
             }
 
             iron-list {

--- a/src/elements/dv-elements/admin/dialogs/pools-of-group-dialog.html
+++ b/src/elements/dv-elements/admin/dialogs/pools-of-group-dialog.html
@@ -31,9 +31,7 @@
 <link rel="import"
       href="../../../../bower_components/vaadin-grid/vaadin-grid-column-group.html">
 <link rel="import"
-      href="../../../../bower_components/vaadin-grid/vaadin-grid-table-scroll-behavior.html">
-<link rel="import"
-      href="../../../../bower_components/vaadin-grid/vaadin-grid-cell-click-behavior.html">
+      href="../../../../elements/dv-elements/admin/dv-vaadin-theme.html">
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dv-admin-mixins.html">
 <link rel="import" href="pool-info-dialog.html"/>
@@ -81,44 +79,6 @@
 
             paper-dropdown-menu {
                 padding: 0px 55px;
-            }
-
-            vaadin-grid {
-                position: relative;
-                height: 100%;
-                --divider-color: #d4d4d4;
-
-                --vaadin-grid-cell: {
-                    padding: 0 8px;
-                    height: 32px;
-                    border-right: 1px solid #d4d4d4;
-                    box-sizing: border-box;
-                    font-size: 8pt;
-                    cursor: default;
-                };
-
-                --vaadin-grid-header-cell: {
-                    height: 36px;
-                    border-bottom: 1px solid #d4d4d4;
-                    background-image: linear-gradient(to bottom, #fafafa 2%, #efefef 98%);
-                    font-size: 9pt;
-                    text-style: bold;
-                    text-align: center;
-                    cursor: default;
-                };
-
-                --vaadin-grid-footer-cell: {
-                    height: 36px;
-                    border-bottom: 1px solid #d4d4d4;
-                    background-image: linear-gradient(to bottom, #fafafa 2%, #efefef 98%);
-                    font-size: 8pt;
-                    text-style: bold;
-                    cursor: default;
-                };
-
-                --vaadin-grid-body-row-odd-cell: {
-                    background-color: #f5f5f5;
-                };
             }
 
             .opaque {

--- a/src/elements/dv-elements/admin/dv-vaadin-provider-decorator.html
+++ b/src/elements/dv-elements/admin/dv-vaadin-provider-decorator.html
@@ -112,12 +112,29 @@
                      */
                     parameters: {
                         type: Object
+                    },
+
+                    /*
+                     * An issue has been reported on the vaadin-grid
+                     * GitHub repository regarding the fact that
+                     * multiple calls are made to the provider
+                     * on load if there are column filters (N+1 calls,
+                     * where N is the number of filters).
+                     *
+                     * Once this issue is fixed, we will need to revisit
+                     * this. TODO
+                     *
+                     * See https://github.com/vaadin/vaadin-grid/issues/1267
+                     */
+                    numberOfFilters: {
+                        type: Number,
+                        value: 0
                     }
                 }
             }
 
-            constructor(vaadingrid, index, postprocess,
-                        itemsArray, urlPath, parameters, eventId) {
+            constructor(vaadingrid, index, postprocess, itemsArray,
+                        urlPath, parameters, eventId, numberOfFilters) {
                 super();
                 this.vaadingrid = vaadingrid;
                 this.index = index;
@@ -128,6 +145,12 @@
                 this.eventId = eventId;
                 this.currentItems = [];
                 this.currentOffset = 0;
+
+                /**
+                 * See the comments to the numberOfFilters property.
+                 * TODO revisit if the issue is fixed by vaadin-grid
+                 */
+                this.numberOfFilters = numberOfFilters;
             }
 
             resetProvider() {
@@ -138,14 +161,20 @@
             }
 
             runProvider(params, vaadincallback) {
+                /**
+                 * See the comments to the numberOfFilters property.
+                 * TODO revisit if the issue is fixed by vaadin-grid
+                 */
+                if (params.filters.length !== this.numberOfFilters) {
+                    return;
+                }
+
                 if (this._paramsChanged(params)) {
-                    vaadincallback([]);
                     this.resetProvider();
                     return;
                 }
 
                 if (this.currentOffset === -1) {
-                    vaadincallback([]);
                     return;
                 }
 
@@ -164,15 +193,13 @@
                         reject(Error("Network Error"));
                     }
 
-                    this.currentOffset = params.page * params.pageSize;
-
                     xhr.open('GET',
-                             this.getUrl(this.urlPath(this.index),
-                                         this._generateParams(this.currentOffset,
-                                                              params.pageSize,
-                                                              params.filters,
-                                                              params.sortOrders),
-                             true));
+                        this.getUrl(this.urlPath(this.index),
+                            this._generateParams(this.currentOffset,
+                                                 params.pageSize,
+                                                 params.filters,
+                                                 params.sortOrders),
+                            true));
 
                     this.setXHRHeaders(xhr);
 
@@ -189,22 +216,21 @@
                             this.currentOffset = -1;
                             this._notifyTableSizeChanged(this.currentItems.length);
                         } else {
+                            this.currentOffset = this.currentItems.length;
                             this._notifyTableSizeChanged(this.currentItems.length
-                                                        + params.pageSize);
+                                 + params.pageSize);
                         }
 
                         vaadincallback(items);
                     } else {
                         this.currentOffset = -1;
                         this._notifyTableSizeChanged(this.currentItems.length);
-                        vaadincallback([]);
                     }
 
                     this._notifyTimeoutReset();
-                }, (error)=> {
+                }, (error) => {
                     this.currentOffset = -1;
                     this._notifyTableSizeChanged(this.currentItems.length);
-                    vaadincallback([]);
                     this._notifyTimeoutReset();
                     app.$.toast.text = error;
                     app.$.toast.show();
@@ -214,6 +240,7 @@
             /*
              *  ---------------------- Filter & Sort -------------------------
              */
+
             _generateParams(offset, limit, filters, orders) {
                 let params = `?offset=${offset}&limit=${limit}`;
                 params += this.parameters(this.index);
@@ -276,7 +303,6 @@
 
                 return changed;
             }
-
 
             /*
              *  ----------------- Selection Column Control -------------------

--- a/src/elements/dv-elements/admin/dv-vaadin-theme.html
+++ b/src/elements/dv-elements/admin/dv-vaadin-theme.html
@@ -1,0 +1,55 @@
+<dom-module id="dv-vaadin-grid-main" theme-for="vaadin-grid">
+    <template>
+        <style>
+            :host {
+                position: relative;
+                height: var(--dv-vaadin-grid-height, 100%);
+                -webkit-font-smoothing: antialiased;
+                border: 1px solid #d4d4d4;
+            }
+
+            [part~="cell"] {
+                padding: 0 8px;
+                height: var(--dv-vaadin-grid-cell-height, 32px);
+                border-right: 1px solid #d4d4d4;
+                box-sizing: border-box;
+                font-size: var(--dv-vaadin-grid-cell-font-size, 8pt);
+                cursor: default;
+                background-color: #ffffff;
+            }
+
+            [part~="header-cell"] {
+                height: var(--dv-vaadin-grid-header-cell-height, 36px);
+                border-top: 1px solid #d4d4d4;
+                border-bottom: 1px solid #d4d4d4;
+                background-image: linear-gradient(to bottom, #fafafa 2%, #efefef 98%);
+                font-size: 9pt;
+                text-style: bold;
+                text-align: center;
+                cursor: default;
+            }
+
+            [part~="footer-cell"] {
+                height: var(--dv-vaadin-grid-footer-cell-height, 36px);
+                border-bottom: 1px solid #d4d4d4;
+                background-image: linear-gradient(to bottom, #fafafa 2%, #efefef 98%);
+                font-size: 8pt;
+                text-style: bold;
+                cursor: default;
+            }
+
+            [part~="details-cell"] {
+                width: 95%;
+                overflow: auto;
+                font-size: 10pt;
+                font-weight: bold;
+            }
+
+            [part~="row"][odd] [part~="body-cell"]{
+                background-color: #f2f2f2;
+            }
+        </style>
+    </template>
+</dom-module>
+
+

--- a/src/elements/dv-elements/admin/views/alarms-view.html
+++ b/src/elements/dv-elements/admin/views/alarms-view.html
@@ -25,11 +25,11 @@
 <link rel="import"
       href="../../../../bower_components/vaadin-grid/vaadin-grid-column-group.html">
 <link rel="import"
-      href="../../../../bower_components/vaadin-grid/vaadin-grid-table-scroll-behavior.html">
-<link rel="import"
       href="../../../../elements/dv-elements/admin/dv-vaadin-provider-decorator.html">
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dv-admin-mixins.html">
+<link rel="import"
+      href="../../../../elements/dv-elements/admin/dv-vaadin-theme.html">
 <link rel="import" href="../dialogs/pool-info-dialog.html"/>
 <link rel="import" href="../dialogs/file-info-dialog.html"/>
 
@@ -40,36 +40,6 @@
                 display: block;
                 height: 70vh;
                 @apply(--layout-vertical);
-            }
-
-            vaadin-grid {
-                position: relative;
-                height: 100%;
-                -webkit-font-smoothing: antialiased;
-                --divider-color: #d4d4d4;
-
-                --vaadin-grid-cell: {
-                    padding: 0 8px;
-                    height: 32px;
-                    border-right: 1px solid #d4d4d4;
-                    box-sizing: border-box;
-                    font-size: 8pt;
-                    cursor: default;
-                };
-
-                --vaadin-grid-header-cell: {
-                    height: 36px;
-                    border-bottom: 1px solid #d4d4d4;
-                    background-image: linear-gradient(to bottom, #fafafa 2%, #efefef 98%);
-                    font-size: 9pt;
-                    text-style: bold;
-                    text-align: center;
-                    cursor: default;
-                };
-
-                --vaadin-grid-body-row-odd-cell: {
-                    background-color: #f5f5f5;
-                };
             }
 
             paper-toolbar {
@@ -91,6 +61,11 @@
                 @apply(--layout-flex);
                 width: 300px;
                 padding-right: 10px;
+            }
+
+            table {
+                margin: 0 100px;
+                font-size: 8pt;
             }
 
             .tablediv {
@@ -151,12 +126,6 @@
                 color: var(--dv-main-background);
                 width: 100%;
             }
-
-            .detailinfo {
-                width: 90%;
-                margin: 20px auto;
-                overflow: auto;
-            }
         </style>
 
         <iron-ajax
@@ -204,8 +173,9 @@
                          multi-sort="true" size="[[tableSize]]">
                 <template class="row-details">
                     <div class="details">
-                        <p class="detailinfo"><strong>[[item.info]]</strong>
-                        </p>
+                        <table>
+                            <tr><td>[[item.info]]</td></tr>
+                        </table>
                     </div>
                 </template>
                 <vaadin-grid-selection-column>
@@ -227,7 +197,7 @@
                         <template class="header"></template>
                         <template>
                             <paper-checkbox aria-label="Details"
-                                            checked="{{expanded}}">
+                                            checked="{{detailsOpened}}">
                             </paper-checkbox>
                         </template>
                     </vaadin-grid-column>
@@ -469,13 +439,14 @@
                                                        (xhr) => JSON.parse(xhr.responseText),
                                                        (index) => 'alarms/logentries',
                                                        this.providerParams.bind(this),
-                                                       'alarms');
+                                                       'alarms',
+                                                        6);
 
                 /*
                  * This must be assigned only after the decorator has been
                  * constructed; it is called immediately upon assignment.
                  */
-                this.$.alarms.dataProvider = this._remoteProvider.bind(this);
+                 this.$.alarms.dataProvider = this._remoteProvider.bind(this);
             }
 
             disconnectedCallback() {

--- a/src/elements/dv-elements/admin/views/cell-info-view.html
+++ b/src/elements/dv-elements/admin/views/cell-info-view.html
@@ -9,11 +9,11 @@
 <link rel="import"
       href="../../../../bower_components/vaadin-grid/vaadin-grid-column-group.html">
 <link rel="import"
-      href="../../../../bower_components/vaadin-grid/vaadin-grid-table-scroll-behavior.html">
-<link rel="import"
       href="../../../../bower_components/paper-toolbar/paper-toolbar.html">
 <link rel="import"
       href="../../../../bower_components/iron-ajax/iron-ajax.html">
+<link rel="import"
+      href="../../../../elements/dv-elements/admin/dv-vaadin-theme.html">
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dv-admin-mixins.html">
 
@@ -24,36 +24,6 @@
                 display: block;
                 height: 80vh;
                 @apply(--layout-vertical);
-            }
-
-            vaadin-grid {
-                position: relative;
-                height: 100%;
-                -webkit-font-smoothing: antialiased;
-                --divider-color: #d4d4d4;
-
-                --vaadin-grid-cell: {
-                    padding: 0 8px;
-                    height: 32px;
-                    border-right: 1px solid #d4d4d4;
-                    box-sizing: border-box;
-                    font-size: 8pt;
-                    cursor: default;
-                };
-
-                --vaadin-grid-header-cell: {
-                    height: 36px;
-                    border-bottom: 1px solid #d4d4d4;
-                    background-image: linear-gradient(to bottom, #fafafa 2%, #efefef 98%);
-                    font-size: 9pt;
-                    text-style: bold;
-                    text-align: center;
-                    cursor: default;
-                };
-
-                --vaadin-grid-body-row-odd-cell: {
-                    background-color: #f5f5f5;
-                };
             }
 
             paper-toolbar {

--- a/src/elements/dv-elements/admin/views/pool-group-view.html
+++ b/src/elements/dv-elements/admin/views/pool-group-view.html
@@ -13,11 +13,11 @@
 <link rel="import"
       href="../../../../bower_components/vaadin-grid/vaadin-grid-column-group.html">
 <link rel="import"
-      href="../../../../bower_components/vaadin-grid/vaadin-grid-table-scroll-behavior.html">
-<link rel="import"
       href="../../../../elements/dv-elements/admin/charts/layout-bar.html">
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dialogs/pools-of-group-dialog.html">
+<link rel="import"
+      href="../../../../elements/dv-elements/admin/dv-vaadin-theme.html">
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dv-admin-mixins.html">
 
@@ -28,36 +28,6 @@
                 display: block;
                 height: 80vh;
                 @apply(--layout-vertical);
-            }
-
-            vaadin-grid {
-                position: relative;
-                height: 100%;
-                -webkit-font-smoothing: antialiased;
-                --divider-color: #d4d4d4;
-
-                --vaadin-grid-cell: {
-                    padding: 0 8px;
-                    height: 32px;
-                    border-right: 1px solid #d4d4d4;
-                    box-sizing: border-box;
-                    font-size: 8pt;
-                    cursor: default;
-                };
-
-                --vaadin-grid-header-cell: {
-                    height: 36px;
-                    border-bottom: 1px solid #d4d4d4;
-                    background-image: linear-gradient(to bottom, #fafafa 2%, #efefef 98%);
-                    font-size: 9pt;
-                    text-style: bold;
-                    text-align: center;
-                    cursor: default;
-                };
-
-                --vaadin-grid-body-row-odd-cell: {
-                    background-color: #f5f5f5;
-                };
             }
 
             paper-toolbar {

--- a/src/elements/dv-elements/admin/views/restores-view.html
+++ b/src/elements/dv-elements/admin/views/restores-view.html
@@ -13,11 +13,9 @@
 <link rel="import"
       href="../../../../bower_components/vaadin-grid/vaadin-grid-column-group.html">
 <link rel="import"
-      href="../../../../bower_components/vaadin-grid/vaadin-grid-cell-click-behavior.html">
-<link rel="import"
-      href="../../../../bower_components/vaadin-grid/vaadin-grid-table-scroll-behavior.html">
-<link rel="import"
       href="../../../../elements/dv-elements/admin/dv-vaadin-provider-decorator.html">
+<link rel="import"
+      href="../../../../elements/dv-elements/admin/dv-vaadin-theme.html">
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dv-admin-mixins.html">
 <link rel="import" href="../dialogs/pool-info-dialog.html"/>
@@ -32,39 +30,14 @@
                 @apply(--layout-vertical);
             }
 
-            vaadin-grid {
-                position: relative;
-                height: 100%;
-                -webkit-font-smoothing: antialiased;
-                --divider-color: #d4d4d4;
-
-                --vaadin-grid-cell: {
-                    padding: 0 8px;
-                    height: 32px;
-                    border-right: 1px solid #d4d4d4;
-                    box-sizing: border-box;
-                    font-size: 8pt;
-                    cursor: default;
-                };
-
-                --vaadin-grid-header-cell: {
-                    height: 36px;
-                    border-bottom: 1px solid #d4d4d4;
-                    background-image: linear-gradient(to bottom, #fafafa 2%, #efefef 98%);
-                    font-size: 9pt;
-                    text-style: bold;
-                    text-align: center;
-                    cursor: default;
-                };
-
-                --vaadin-grid-body-row-odd-cell: {
-                    background-color: #f5f5f5;
-                };
-            }
-
             paper-toolbar {
                 color: var(--dv-main-background);
                 background: var(--dv-charcoal-grey);
+            }
+
+            table {
+                margin: 0 100px;
+                font-size: 8pt;
             }
 
             .tablediv {
@@ -99,12 +72,6 @@
                 color: var(--dv-main-background);
                 background: var(--dv-indigo-900);
             }
-
-            .path {
-                margin: auto;
-                font-weight: bold;
-                font-size: 9pt;
-            }
         </style>
 
         <paper-toolbar id="title">
@@ -120,7 +87,7 @@
 
                 <template class="row-details">
                     <div class="details">
-                        <table class="path">
+                        <table>
                             <tr>
                                 <td>Path:</td>
                                 <td>[[item.path]]</td>
@@ -150,7 +117,7 @@
                         <template class="header"></template>
                         <template>
                             <paper-checkbox aria-label="Path"
-                                            checked="{{expanded}}">
+                                            checked="{{detailsOpened}}">
                             </paper-checkbox>
                         </template>
                     </vaadin-grid-column>
@@ -173,8 +140,9 @@
                                        focus-target/>
                             </vaadin-grid-filter>
                         </template>
-                        <template><span
-                                class="actionable">[[item.pnfsId]]</span>
+                        <template>
+                            <span onclick="sendRestoresTableCellClick('1')"
+                                    class="actionable">[[item.pnfsId]]</span>
                         </template>
                     </vaadin-grid-column>
                 </vaadin-grid-column-group>
@@ -213,7 +181,8 @@
                                        focus-target/>
                             </vaadin-grid-filter>
                         </template>
-                        <template><span
+                        <template>
+                            <span onclick="sendRestoresTableCellClick('2')"
                                 class="actionable">[[item.poolCandidate]]</span>
                         </template>
                     </vaadin-grid-column>
@@ -272,8 +241,13 @@
     </template>
 
     <script>
-        class RestoresView extends Polymer.mixinBehaviors([vaadin.elements.grid.CellClickBehavior],
-            DcacheViewMixins.AdminAutoRefresh(DcacheViewMixins.AdminBase(Polymer.Element))) {
+        function sendRestoresTableCellClick(cell) {
+            window.dispatchEvent(
+                new CustomEvent(`dv-restores-table-cell-click`, {
+                    detail: {cell: parseInt(cell)}}));
+        }
+
+        class RestoresView extends DcacheViewMixins.AdminAutoRefresh(DcacheViewMixins.AdminBase(Polymer.Element)) {
 
             static get is() {
                 return 'restores-view';
@@ -290,7 +264,8 @@
                     },
 
                     cell: {
-                        type: Number
+                        type: Number,
+                        value: 0
                     },
 
                     tableSize: {
@@ -304,17 +279,18 @@
             connectedCallback() {
                 super.connectedCallback();
 
-                this.$.restores.addEventListener('cell-focus', this._handleClick.bind(this));
                 window.addEventListener('dv-vaadin-provider-reset-timeout-restores', this.resetTimeout.bind(this));
                 window.addEventListener('dv-vaadin-provider-update-table-size-restores', this.setTableSize.bind(this));
+                window.addEventListener('dv-restores-table-cell-click', this.setCell.bind(this));
 
                 this.decorator = new DvVaadinProviderDecorator(this.$.restores,
-                                                               null,
-                                                               this.handleItem.bind(this),
-                                                               (xhr) => JSON.parse(xhr.responseText).items,
-                                                               (index) => 'restores',
-                                                               (index) => '',
-                                                               'restores');
+                    null,
+                    this.handleItem.bind(this),
+                    (xhr) => JSON.parse(xhr.responseText).items,
+                    (index) => 'restores',
+                    (index) => '',
+                    'restores',
+                    4);
 
                 /*
                  * This must be assigned only after the decorator has been
@@ -325,18 +301,15 @@
 
             disconnectedCallback() {
                 super.disconnectedCallback
-                this.$.restores.removeEventListener('cell-focus', this._handleClick.bind(this));
+
                 window.removeEventListener('dv-vaadin-provider-reset-timeout-restores', this.resetTimeout.bind(this));
                 window.removeEventListener('dv-vaadin-provider-update-table-size-restores', this.setTableSize.bind(this));
+                window.removeEventListener('dv-restores-table-cell-click', this.setCell.bind(this));
+
             }
 
-            _handleClick(e) {
-                e.stopPropagation();
-                this.cell = 0;
-                const cell = e.composedPath()[0];
-                if (cell) {
-                    this.cell = parseInt(cell.order.toString().charAt(0));
-                }
+            setCell(event) {
+                this.cell = event.detail.cell;
             }
 
             /*
@@ -373,16 +346,18 @@
                 }
 
                 if (typeof this.currentItem === 'undefined' ||
-                    typeof this.cell === 'undefined' ) {
+                    typeof this.cell === 'undefined') {
                     return;
                 }
 
-                if (this.cell === 3) {
+                if (this.cell === 1) {
                     this.openFileInfoDialog(this.currentItem.pnfsId,
                         this.currentItem.poolCandidate);
-                } else if (this.cell === 5) {
+                    this.cell = 0;
+                } else if (this.cell === 2) {
                     this.openPoolInfoDialog(this.currentItem.poolCandidate,
                         this.currentItem.pnfsId);
+                    this.cell = 0;
                 }
             }
         }

--- a/src/elements/dv-elements/admin/views/selection-unit-view.html
+++ b/src/elements/dv-elements/admin/views/selection-unit-view.html
@@ -27,7 +27,7 @@
 <link rel="import"
       href="../../../../bower_components/vaadin-grid/vaadin-grid-sorter.html">
 <link rel="import"
-      href="../../../../bower_components/vaadin-grid/vaadin-grid-table-scroll-behavior.html">
+      href="../../../../elements/dv-elements/admin/dv-vaadin-theme.html">
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dv-admin-mixins.html">
 <link rel="import" href="../dialogs/pool-info-dialog.html"/>
@@ -43,34 +43,10 @@
             }
 
             vaadin-grid {
-                position: relative;
-                height: 20vh;
-                margin-bottom: 15px;
-                -webkit-font-smoothing: antialiased;
-                --divider-color: #d4d4d4;
-
-                --vaadin-grid-cell: {
-                    padding: 0 8px;
-                    height: 24px;
-                    border-right: 1px solid #d4d4d4;
-                    box-sizing: border-box;
-                    font-size: 8pt;
-                    cursor: default;
-                };
-
-                --vaadin-grid-header-cell: {
-                    height: 24px;
-                    border-bottom: 1px solid #d4d4d4;
-                    background-image: linear-gradient(to bottom, #fafafa 2%, #efefef 98%);
-                    font-size: 9pt;
-                    text-style: bold;
-                    text-align: center;
-                    cursor: default;
-                };
-
-                --vaadin-grid-body-row-odd-cell: {
-                    background-color: #f5f5f5;
-                };
+                --dv-vaadin-grid-height: 20vh;
+                --dv-vaadin-grid-cell-height: 24px;
+                --dv-vaadin-grid-header-cell-height: 24px;
+                --dv-vaadin-grid-cell-font-size: 9pt;
             }
 
             iron-list {
@@ -177,8 +153,7 @@
             }
 
             #selected {
-                margin-left: 20px;
-                width: 30%;
+                padding-left: 15%;
                 font-size: larger;
                 color: var(--dv-red-500);
             }
@@ -232,6 +207,9 @@
                     <paper-radio-button name="partitions">Partitions
                     </paper-radio-button>
                 </paper-radio-group>
+                <iron-label slot="top" id="selected">
+                    [[currentItem]]
+                </iron-label>
             </paper-toolbar>
             <div slot="content">
                 <hr/>
@@ -309,9 +287,9 @@
                         </vaadin-grid>
                     </div>
                 </div>
+                <br/>
                 <div id="center-panel">
-                    <iron-label class="item" id="selected">[[currentItem]]
-                    </iron-label>
+                    <div class="item>"></div>
                     <div class="item">
                         <vaadin-grid aria-label="Properties" id="properties"
                                      items="[[nvpairs]]" size="25">

--- a/src/elements/dv-elements/admin/views/space-management-view.html
+++ b/src/elements/dv-elements/admin/views/space-management-view.html
@@ -25,7 +25,7 @@
 <link rel="import"
       href="../../../../bower_components/vaadin-grid/vaadin-grid-sorter.html">
 <link rel="import"
-      href="../../../../bower_components/vaadin-grid/vaadin-grid-table-scroll-behavior.html">
+      href="../../../../elements/dv-elements/admin/dv-vaadin-theme.html">
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dv-admin-mixins.html">
 
@@ -39,33 +39,7 @@
             }
 
             vaadin-grid {
-                position: relative;
-                height: 50%;
-                -webkit-font-smoothing: antialiased;
-                --divider-color: #d4d4d4;
-
-                --vaadin-grid-cell: {
-                    padding: 0 8px;
-                    height: 32px;
-                    border-right: 1px solid #d4d4d4;
-                    box-sizing: border-box;
-                    font-size: 8pt;
-                    cursor: default;
-                };
-
-                --vaadin-grid-header-cell: {
-                    height: 36px;
-                    border-bottom: 1px solid #d4d4d4;
-                    background-image: linear-gradient(to bottom, #fafafa 2%, #efefef 98%);
-                    font-size: 9pt;
-                    text-style: bold;
-                    text-align: center;
-                    cursor: default;
-                };
-
-                --vaadin-grid-body-row-odd-cell: {
-                    background-color: #f5f5f5;
-                };
+                --dv-vaadin-grid-height: 50%;
             }
 
             paper-button {
@@ -105,6 +79,11 @@
             paper-checkbox {
                 margin-left: auto;
                 margin-right: auto;
+            }
+
+            table {
+                margin: 0 100px;
+                font-size: 8pt;
             }
 
             input {
@@ -153,13 +132,6 @@
             .subtitle {
                 color: var(--dv-charcoal-grey);
             }
-
-            .detailinfo {
-                width: 90%;
-                margin: 20px auto;
-                overflow: auto;
-            }
-
         </style>
 
         <iron-ajax
@@ -201,9 +173,13 @@
                          items="[[linkgroups]]" multi-sort="true" size="20">
                 <template class="row-details">
                     <div class="details">
-                        <p class="detailinfo">
-                            <strong>VOs:&nbsp;&nbsp;[[item.volist]]</strong>
-                        </p>
+                        <table>
+                            <tr>
+                                <td>
+                                    <strong>VOs:&nbsp;&nbsp;[[item.volist]]</strong>
+                                </td>
+                            </tr>
+                        </table>
                     </div>
                 </template>
                 <vaadin-grid-column-group>
@@ -248,7 +224,7 @@
                         <template class="header"></template>
                         <template>
                             <paper-checkbox aria-label="VO"
-                                            checked="{{expanded}}">
+                                            checked="{{detailsOpened}}">
                             </paper-checkbox>
                         </template>
                     </vaadin-grid-column>
@@ -365,9 +341,14 @@
                          items="[[spacetokens]]" multi-sort="true" size="20">
                 <template class="row-details">
                     <div class="details">
-                        <p class="detailinfo">
-                            <strong>[[item.description]]</strong>
-                        </p>
+                        <table>
+                            <tr>
+                                <td>
+                                    <strong>[[item.description]]</strong>
+                                </td>
+                            </tr>
+                        </table>
+                        <br/>
                     </div>
                 </template>
                 <vaadin-grid-column-group>
@@ -411,7 +392,7 @@
                         <template class="header"></template>
                         <template>
                             <paper-checkbox aria-label="Desc"
-                                            checked="{{expanded}}">
+                                            checked="{{detailsOpened}}">
                             </paper-checkbox>
                         </template>
                     </vaadin-grid-column>

--- a/src/elements/dv-elements/admin/views/transfers-view.html
+++ b/src/elements/dv-elements/admin/views/transfers-view.html
@@ -13,9 +13,7 @@
 <link rel="import"
       href="../../../../bower_components/vaadin-grid/vaadin-grid-column-group.html">
 <link rel="import"
-      href="../../../../bower_components/vaadin-grid/vaadin-grid-cell-click-behavior.html">
-<link rel="import"
-      href="../../../../bower_components/vaadin-grid/vaadin-grid-table-scroll-behavior.html">
+      href="../../../../elements/dv-elements/admin/dv-vaadin-theme.html">
 <link rel="import"
       href="../../../../elements/dv-elements/admin/dv-vaadin-provider-decorator.html">
 <link rel="import"
@@ -30,36 +28,6 @@
                 display: block;
                 height: 70vh;
                 @apply(--layout-vertical);
-            }
-
-            vaadin-grid {
-                position: relative;
-                height: 100%;
-                -webkit-font-smoothing: antialiased;
-                --divider-color: #d4d4d4;
-
-                --vaadin-grid-cell: {
-                    padding: 0 8px;
-                    height: 32px;
-                    border-right: 1px solid #d4d4d4;
-                    box-sizing: border-box;
-                    font-size: 8pt;
-                    cursor: default;
-                };
-
-                --vaadin-grid-header-cell: {
-                    height: 36px;
-                    border-bottom: 1px solid #d4d4d4;
-                    background-image: linear-gradient(to bottom, #fafafa 2%, #efefef 98%);
-                    font-size: 9pt;
-                    text-style: bold;
-                    text-align: center;
-                    cursor: default;
-                };
-
-                --vaadin-grid-body-row-odd-cell: {
-                    background-color: #f5f5f5;
-                };
             }
 
             paper-toolbar {
@@ -392,7 +360,8 @@
                             </vaadin-grid-filter>
                         </template>
                         <template>
-                            <span class="actionable">[[item.pnfsId]]</span>
+                            <span onclick="sendTransfersTableCellClick('2')"
+                                  class="actionable">[[item.pnfsId]]</span>
                         </template>
                     </vaadin-grid-column>
                 </vaadin-grid-column-group>
@@ -414,7 +383,8 @@
                             </vaadin-grid-filter>
                         </template>
                         <template>
-                            <span class="actionable">[[item.pool]]</span>
+                            <span onclick="sendTransfersTableCellClick('2')"
+                                  class="actionable">[[item.pool]]</span>
                         </template>
                     </vaadin-grid-column>
                 </vaadin-grid-column-group>
@@ -494,9 +464,14 @@
     </template>
 
     <script>
+        function sendTransfersTableCellClick(cell) {
+            window.dispatchEvent(
+                new CustomEvent(`dv-transfers-table-cell-click`, {
+                    detail: {cell: parseInt(cell)}}));
+        }
+
         class TransfersView extends
-            Polymer.mixinBehaviors([vaadin.elements.grid.CellClickBehavior],
-                DcacheViewMixins.AdminAutoRefresh(DcacheViewMixins.AdminBase(Polymer.Element))) {
+            DcacheViewMixins.AdminAutoRefresh(DcacheViewMixins.AdminBase(Polymer.Element)) {
 
             static get is() {
                 return 'transfers-view';
@@ -518,7 +493,8 @@
                     },
 
                     cell: {
-                        type: String
+                        type: Number,
+                        value: 0
                     },
 
                     count: {
@@ -552,8 +528,7 @@
                 window.addEventListener('dv-vaadin-provider-selection-column-clear-transfers', this.signalChange.bind(this));
                 window.addEventListener('dv-vaadin-provider-reset-timeout-transfers', this.resetTimeout.bind(this));
                 window.addEventListener('dv-vaadin-provider-update-table-size-transfers', this.setTableSize.bind(this));
-
-                this.$.transfers.addEventListener('cell-focus', this._handleClick.bind(this));
+                window.addEventListener('dv-transfers-table-cell-click', this.setCell.bind(this));
 
                 this.decorator = new DvVaadinProviderDecorator(this.$.transfers,
                                                                null,
@@ -561,7 +536,8 @@
                                                                (xhr) => JSON.parse(xhr.responseText).items,
                                                                (index) => 'transfers',
                                                                (index) => '',
-                                                               'transfers');
+                                                               'transfers',
+                                                                10);
 
                 /*
                  * This must be assigned only after the decorator has been
@@ -572,16 +548,15 @@
 
             disconnectedCallback() {
                 super.disconnectedCallback();
-                this.$.transfers.removeEventListener('cell-focus', this._handleClick.bind(this));
+
                 window.removeEventListener('dv-vaadin-provider-selection-column-clear-transfers', this.signalChange.bind(this));
                 window.removeEventListener('dv-vaadin-provider-reset-timeout-transfers', this.resetTimeout.bind(this));
                 window.removeEventListener('dv-vaadin-provider-update-table-size-transfers', this.setTableSize.bind(this));
+                window.removeEventListener('dv-transfers-table-cell-click', this.setCell.bind(this));
             }
 
-            _handleClick(e) {
-                const cell = e.composedPath()[0];
-                this.cell = cell ? cell.order.toString().substring(0, 3): '0';
-                e.stopPropagation();
+            setCell(event) {
+                this.cell = event.detail.cell;
             }
 
             /*
@@ -664,13 +639,15 @@
                     return;
                 }
 
-                if (this.cell === '110') {
+                if (this.cell === '1') {
                     this.openFileInfoDialog(this.currentItem.pnfsId,
                         this.currentItem.pool);
-                } else if (this.cell === '111') {
+                } else if (this.cell === '2') {
                     this.openPoolInfoDialog(this.currentItem.pool,
                         this.currentItem.pnfsId);
                 }
+
+                this.cell = 0;
             }
 
 

--- a/src/elements/elements.html
+++ b/src/elements/elements.html
@@ -51,10 +51,9 @@
 <link rel="import" href="../bower_components/vaadin-grid/vaadin-grid.html">
 <link rel="import" href="../bower_components/vaadin-grid/vaadin-grid-sorter.html">
 <link rel="import" href="../bower_components/vaadin-grid/vaadin-grid-filter.html">
-<link rel="import" href="../bower_components/vaadin-grid/vaadin-grid-cell-click-behavior.html">
 <link rel="import" href="../bower_components/vaadin-grid/vaadin-grid-column-group.html">
 <link rel="import" href="../bower_components/vaadin-grid/vaadin-grid-selection-column.html">
-<link rel="import" href="../bower_components/vaadin-grid/vaadin-grid-table-scroll-behavior.html">
+<link rel="import" href="../bower_components/vaadin-themable-mixin/vaadin-themable-mixin.html">
 
 <!-- Configure routes here -->
 <link rel="import" href="routing.html">
@@ -93,6 +92,7 @@
 <!-- dcache-view mixins and utils -->
 <link rel="import" href="dv-elements/admin/dv-admin-mixins.html">
 <link rel="import" href="dv-elements/admin/dv-vaadin-provider-decorator.html">
+<link rel="import" href="dv-elements/admin/dv-vaadin-theme.html">
 
 <!-- dcache-view elements -->
 <link rel="import" href="../bower_components/admin-page/admin-page.html">


### PR DESCRIPTION
Motivation:

Using the 3.0.2 version of the vaadin-grid components, Firefox
performs very badly, particularly in (a) scrolling, which is
very jittery, and (b) inability to load the pool queues page
which uses dom-repeat to build columns dynamically.

While there has been no acknowledgment by the vaadin developers
that this problem can or cannot be solved using version 3.0.2,
it was suggested that we migrate to 4.1.7, which is a version
more in tune with Polymer 2.0.

Modification:

The changes necessary for this upgrade are as follows:

1.  The new grid component implements a themable mixin, and
    and has removed the previous styling attribute mixins.
    Thus all custom style definitions for the vaadin grid
    elements have been removed from the dcache-view elements
    and have been replaced by a single theme component.

2.  The new vaadin-grid no longer implements the cell-click behavior.
    This means that that functionality had to be replaced.
    We have done this, where necessary, by providing a window
    function that sends a CustomEvent, and listeners for those
    events which set state as necessary.

3.  A major change in the table provider behavior seems to
    entail the fact that the provider function is called
    AS EACH FILTER ELEMENT IS ADDED TO THE SHADOW DOM. (WHY?)
    I have asked if there is a way to assign the function
    after the entire DOM is built (it is done in connectedCallback
    at present), and am awaiting response.  If this cannot
    be solved more cleanly, then the current code will
    have to be adopted.  It passes in the number of filters
    to expect in a ready state, and ignores all calls before
    that number is reached.
    Otherwise, there are problems with the table cache because
    multiple async fetches using the same offset but without
    clearing the cache take place.

Because of the new styling, I've also made a few minor adjustments
to the look of the selection and link-group pages.

Result:

The move to 4.1.7 resolves the Firefox issues and brings us
in line with the more modern implementation of vaadin-grid.

Target: master
Request: 1.4
Acked-by: Olufemi