### PR TITLE
dcache-view (authentication): ensure backend qos information is set

### DIFF
--- a/src/elements/dv-elements/user-authentication/auth-behaviour/role-request.html
+++ b/src/elements/dv-elements/user-authentication/auth-behaviour/role-request.html
@@ -59,10 +59,10 @@
 
                 let userAuth = new UserAuthentication(redirectTo, auth, sessionStorage.listOfPossibleRoles, "");
 
-                userAuth.addEventListener('error', (e) => {
+                window.addEventListener('dv-authentication-error', (e) => {
                     this.rejectAssertion(e.detail.message);
                 });
-                userAuth.addEventListener('successful', (e) => {
+                window.addEventListener('dv-authentication-successful', (e) => {
                     this.resolveAssertion(listOfRolesToAssert);
                 });
                 userAuth.send("Basic");

--- a/src/elements/dv-elements/user-authentication/auth-behaviour/user-authentication.html
+++ b/src/elements/dv-elements/user-authentication/auth-behaviour/user-authentication.html
@@ -142,11 +142,13 @@
                 } else {
                     page("/"+this.redirectTo.page);
                 }
-                this.dispatchEvent(new CustomEvent('successful', {detail: {message: 'login successful'}}));
+                window.dispatchEvent(new CustomEvent('dv-authentication-successful', {
+                    detail: {message: 'login successful'}}));
             } else if (request.target.response.status === "ANONYMOUS") {
                 const errMsg = 'Login failed. Please check that you have supplied ' +
                     'the correct credentials. ';
-                this.dispatchEvent(new CustomEvent('error', {detail: {message: errMsg}}));
+                window.dispatchEvent(new CustomEvent('dv-authentication-error', {
+                    detail: {message: errMsg}}));
             }
         }
         _delayNotification(message)

--- a/src/elements/dv-elements/user-authentication/login-form.html
+++ b/src/elements/dv-elements/user-authentication/login-form.html
@@ -163,7 +163,7 @@
                 const listOfRolesToAssert = this.assertionStatus?"*":"";
                 let userAuth = new UserAuthentication(this.redirectTo, this.auth, "", listOfRolesToAssert);
 
-                userAuth.addEventListener('error', (e) => {
+                window.addEventListener('dv-authentication-error', (e) => {
                     this.errorMessage = e.detail.message;
                 });
 

--- a/src/elements/routing.html
+++ b/src/elements/routing.html
@@ -144,7 +144,7 @@
                 let redirectInfoObj = JSON.parse(sessionStorage.getItem('redirect'));
                 let userAuth = new UserAuthentication(redirectInfoObj, oidcProviderResponse.access_token, "", "");
 
-                userAuth.addEventListener('error', (e) => {
+                window.addEventListener('error', (e) => {
                     const a = '"page":'+ redirectInfoObj.page + ',"path":"' + redirectInfoObj.path + '"';
                     let pathName = '/user-login?r=' + encodeURIComponent(a);
                     page(pathName);

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -17,6 +17,11 @@
     // See https://github.com/Polymer/polymer/issues/1381
     window.addEventListener('WebComponentsReady', function() {
         // imports are loaded and elements have been registered
+        app.getQosInformation();
+    });
+
+    app.getQosInformation = function()
+    {
         const isSomebody = !(app.getAuthValue() ===
             `Basic ${window.btoa('anonymous:nopassword')}`);
         if (window.CONFIG.qos === undefined && isSomebody) {
@@ -28,7 +33,7 @@
             });
             qos.trigger();
         }
-    });
+    };
 
     app.menuAction = function(){
         app.$.dvDrawerPanel.togglePanel();
@@ -610,5 +615,8 @@
     });
     window.addEventListener('dv-namespace-namespace-close-central-dialogbox',()=>{
         app.$.centralDialogBox.close();
+    });
+    window.addEventListener('dv-authentication-successful', (e) => {
+        app.getQosInformation();
     });
 })(document);


### PR DESCRIPTION
Motivation:

The backend Qos information suppose to be requested and
set when a user have been authenticated. At the moment
this is not the case. To rectify this problem, the
user-authentication disptaches two events: one for when
the authentication is sucessful and the other for when it
is not. The backend Qos information must be set when the
authentication is sucessful.

Unfortunately, the user-authentication element which is
responsible for user authentication is not attached to any
dom node. Hence, any dispatch event will not be fire unless
they are dispatched to a registered node.

Modification:

1. Disptach all events from the user-authentication
    element with window node as the event target.
2. Rename the events dispatched from user-authentication
    element
2. Adjust all parents of user-authentication element
    accordingly.
3. create a new function called getQosInformation; this
    will set window.CONFIG.qos by creating a new
    QosBackendInformation element if the user is authenticated
    and window.CONFIG.qos is not yet set.
4. Add an eventlistener for sucessful authentication in dv.js
5. Call the new function (getQosInformation) when the page is
    loaded the first time and also when the authentication
    is sucessful.

Result:

The window.CONFIG.qos which quite a few elements used, will
always be set when the user is authenticated.

Target: master
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10865/

(cherry picked from commit 5325ed9242f9f71b816131ac093bbdc17b7ad180)