### PR TITLE
dcache-view (namespace): update upload components

### DIFF
--- a/src/elements/dv-elements/upload-files/upload-file-common.html
+++ b/src/elements/dv-elements/upload-files/upload-file-common.html
@@ -8,7 +8,7 @@
             constructor(path, browser)
             {
                 super();
-                this.path = (path.endsWith("/")) ? path : path + "/";
+                this.path = path.endsWith("/") ? path : path + "/";
                 this.browser = browser;
             }
 
@@ -48,7 +48,7 @@
                     url: {
                         type: String,
                         value: function () {
-                            if (window.CONFIG["dcache-view.endpoints.webdav"] == "") {
+                            if (window.CONFIG["dcache-view.endpoints.webdav"] === "") {
                                 return `${window.location.protocol}//${window.location.hostname}:2880`;
                             } else {
                                 return window.CONFIG["dcache-view.endpoints.webdav"];
@@ -86,16 +86,16 @@
                         this.hasError = false;
                         this.isComplete = true;
                         this.message = "Uploaded";
-                        let item = {
-                            "fileName" : data.name,
-                            "fileMimeType" : data.type,
-                            "fileLocality" : "",
-                            "size" : data.size,
-                            "fileType" : "REGULAR",
-                            "mtime" : data.lastModified,
-                            "creationTime" : Date.now()
-                        };
-                        this.dispatchEvent(new CustomEvent('complete', {detail: {item: item}}));
+                        this.dispatchEvent(new CustomEvent('complete', {detail: {item: {
+                                    "fileName" : data.name,
+                                    "fileMimeType" : data.type,
+                                    "fileLocality" : "",
+                                    "size" : data.size,
+                                    "fileType" : "REGULAR",
+                                    "mtime" : data.lastModified,
+                                    "creationTime" : Date.now()
+                                }}})
+                        );
                     },
 
                     onProgress: (evt)=>

--- a/src/elements/dv-elements/upload-files/upload-files-button.html
+++ b/src/elements/dv-elements/upload-files/upload-files-button.html
@@ -1,4 +1,6 @@
 <link rel="import" href="../../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../../bower_components/paper-icon-button/paper-icon-button.html">
+<link rel="import" href="../../../bower_components/paper-tooltip/paper-tooltip.html">
 <script src="../utils/dcache-view-uploader/dcache-view-uploader.js"></script>
 
 <link rel="import" href="upload-toast-file.html">
@@ -9,8 +11,8 @@
                 display: inline-block;
             }
             #files {
-                width: 0.1px;
-                height: 0.1px;
+                width: 0;
+                height: 0;
                 opacity: 0;
                 overflow: hidden;
                 position: absolute;
@@ -28,66 +30,78 @@
     <script>
         class UploadFilesButton extends Polymer.Element
         {
+            constructor()
+            {
+                super();
+                this._handleFileSelection = this.handleFileSelection.bind(this);
+                this._openFilePicker_ = this._openFilePicker.bind(this);
+                this._setCurrentPath_ = this._setCurrentPath.bind(this);
+            }
             static get is()
             {
                 return 'upload-files-button';
             }
-
+            static get properties()
+            {
+                return {
+                    currentPath: {
+                        type: String
+                    }
+                };
+            }
             connectedCallback()
             {
                 super.connectedCallback();
-                this.$.files.addEventListener('change', this.handleFileSelection.bind(this));
-                window.addEventListener('dv-namespace-upload-files', ()=>{
-                    this.$.files.click();
-                });
+                window.addEventListener('dv-namespace-upload-files', this._openFilePicker_);
+                window.addEventListener('dv-namespace-current-path', this._setCurrentPath_);
+
+                this.$.files.addEventListener('change', this._handleFileSelection);
+                this.dispatchEvent(
+                    new CustomEvent('dv-namespace-request-current-path', {bubbles: true, composed: true}));
             }
             disconnectedCallback()
             {
                 super.disconnectedCallback();
-                this.$.files.removeEventListener('change', this.handleFileSelection);
-                window.removeEventListener('dv-namespace-upload-files', ()=>{
-                    this.$.files.click();
-                });
-            }
+                window.removeEventListener('dv-namespace-upload-files', this._openFilePicker_);
+                window.removeEventListener('dv-namespace-current-path', this._setCurrentPath_);
 
+                this.$.files.removeEventListener('change', this._handleFileSelection);
+            }
             handleFileSelection(e)
             {
                 e.stopPropagation();
                 e.preventDefault();
-                app.$.uploadToast.close();
                 if (window.File && window.FileReader && window.FileList && window.Blob) {
-                    app.$.uploadToast.open();
+                    this.dispatchEvent(new CustomEvent('dv-namespace-open-upload-toast', {
+                        bubbles: true, composed: true}));
                     this.uploadFile(e.target.files);
                 } else {
-                    app.$.toast.text = 'No support for the File API in this web browser. ';
-                    app.$.toast.show();
+                    this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                        detail: {message: `No support for the File API in this web browser.`},
+                        bubbles: true, composed: true}));
                 }
             }
-
             uploadFile(files)
             {
-                var uploadList = app.$.uploadToast.querySelector("#uploadList");
-                uploadList.innerHTML ="";
-                var path = ((app.$.homedir.querySelector('view-file').path).endsWith("/"))
-                    ? app.$.homedir.querySelector('view-file').path
-                    : app.$.homedir.querySelector('view-file').path + "/";
-                var f;
-                for (var i=0; f = files[i]; i++) {
-                    var el = new UploadToastFile(f.name, "REGULAR", f.type);
+                const path = this.currentPath.endsWith("/") ? this.currentPath: `${this.currentPath}/`;
+                const len = files.length;
+                for (let i=0; i < len; i++) {
+                    const el = new UploadToastFile(files[i].name, "REGULAR", files[i].type);
                     el.setAttribute("id", i.toString());
-                    uploadList.appendChild(el);
+                    this.dispatchEvent(new CustomEvent('dv-namespace-upload-toast-append-child', {
+                            detail: {child: el}, bubbles: true, composed: true}));
                     const upLs = el;
                     const uploadURL = window.CONFIG["dcache-view.endpoints.webdav"] === "" ?
-                        `${window.location.protocol}//${window.location.hostname}:2880${path}${f.name}` :
+                        `${window.location.protocol}//${window.location.hostname}:2880${path}${files[i].name}` :
                         path.startsWith('/') ?
-                        `${window.CONFIG["dcache-view.endpoints.webdav"]}${path.slice(1)}${f.name}` :
-                        `${window.CONFIG["dcache-view.endpoints.webdav"]}${path}${f.name}`;
-                    var uploader = new UploadHandler({
-                        file: f,
+                        `${window.CONFIG["dcache-view.endpoints.webdav"]}${path.slice(1)}${files[i].name}` :
+                        `${window.CONFIG["dcache-view.endpoints.webdav"]}${path}${files[i].name}`;
+                    const uploader = new UploadHandler({
+                        file: files[i],
                         upauth: app.getAuthValue(),
                         url: uploadURL,
                         onComplete: function (data) {
-                            var progressBar = upLs.shadowRoot.querySelector('paper-progress');
+                            const progressBar = upLs.shadowRoot.querySelector('paper-progress');
                             progressBar.indeterminate = false;
                             progressBar.value = 100;
                             progressBar.classList.remove("error", "progress");
@@ -97,14 +111,8 @@
                             upLs.hasError = false;
                             upLs.isComplete = true;
                             upLs.message = "Uploaded";
-                            var vf = document.querySelector('view-file');
-                            var ed = vf.shadowRoot.querySelector('empty-directory');
-                            if (ed != null) {
-                                vf.shadowRoot.querySelector('#content').removeChild(ed);
-                            }
-                            var list = vf.shadowRoot.querySelector('iron-list');
-                            list.unshift('items',
-                                    {
+                            this.dispatchEvent(new CustomEvent('dv-namespace-add-items', {
+                                detail: {files: [{
                                         "fileName" : data.name,
                                         "fileMimeType" : data.type,
                                         "fileLocality" : "",
@@ -112,13 +120,13 @@
                                         "fileType" : "REGULAR",
                                         "mtime" : data.lastModified,
                                         "creationTime" : Date.now()
-                                    }
-                            );
+                                    }]},
+                                bubbles: true, composed: true}));
                         }.bind(this),
 
                         onProgress: function (evt) {
+                            const progressBar = upLs.shadowRoot.querySelector('paper-progress');
                             if (evt.lengthComputable) {
-                                var progressBar = upLs.shadowRoot.querySelector('paper-progress');
                                 progressBar.classList.remove("error", "complete");
                                 progressBar.classList.add("progress");
                                 progressBar.indeterminate = false;
@@ -131,7 +139,7 @@
                         }.bind(this),
 
                         onError: function (evt) {
-                            var progressBar = upLs.shadowRoot.querySelector('paper-progress');
+                            const progressBar = upLs.shadowRoot.querySelector('paper-progress');
                             progressBar.classList.remove("progress", "complete");
                             progressBar.classList.add("error");
                             progressBar.indeterminate = false;
@@ -143,9 +151,15 @@
                         }.bind(this)
                     });
                     uploader.upload();
-                    Polymer.dom.flush();
                 }
-                Polymer.dom.flush();
+            }
+            _openFilePicker()
+            {
+                this.$.files.click();
+            }
+            _setCurrentPath(e)
+            {
+                this.currentPath = e.detail.currentPath;
             }
         }
         window.customElements.define(UploadFilesButton.is, UploadFilesButton);

--- a/src/elements/dv-elements/upload-files/upload-toast-file.html
+++ b/src/elements/dv-elements/upload-files/upload-toast-file.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../../../bower_components/polymer/polymer-element.html">
 
+<link rel="import" href="../../../bower_components/paper-progress/paper-progress.html">
 <link rel="import" href="../../../bower_components/iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../../../bower_components/iron-label/iron-label.html">
 <link rel="import" href="../../../bower_components/file-icon/file-icon.html">
@@ -11,7 +12,7 @@
                 display: block;
                 width: 420px;
                 height: 65px;
-                padding: 0px;
+                padding: 0;
                 border-bottom: 10px solid #323232;
                 background-color: #fff;
             }
@@ -21,8 +22,8 @@
             }
             .main {
                 @apply(--layout-horizontal);
-                padding: 0px;
-                margin: 0px;
+                padding: 0;
+                margin: 0;
             }
             .main > #fileStatusInfo {
                 @apply(--layout-flex);
@@ -105,13 +106,20 @@
             paper-progress.progress {
                 --paper-progress-active-color: #ffc925 !important;
             }
-
+            #fileIcon file-icon {
+                padding-left: 10px;
+            }
+            #statusMessage span {
+                background: #373737;
+                color:#fff;
+                font-size: 1em !important;
+            }
         </style>
         <div class="main">
             <div id="fileStatusInfo">
                 <div id="uploadFile">
                     <div id="fileIcon">
-                        <file-icon mime-type="[[fileMimeType]]" style="padding-left: 10px;"></file-icon>
+                        <file-icon mime-type="[[fileMimeType]]"></file-icon>
                     </div>
                     <div id="fileInfo">
                         <div id="fileName">
@@ -120,7 +128,7 @@
                             </div>
                         </div>
                         <div id="statusMessage">
-                            <span style="background: #373737;color:#fff; font-size: 1em !important;">Status:</span>
+                            <span>Status:</span>
                             <label class$="[[_computedClass(hasError,isComplete,inProgress)]]"> {{message}}</label>
                         </div>
                     </div>
@@ -206,7 +214,7 @@
 
             _computedClass(hasError,isComplete,inProgress)
             {
-                var classes = '';
+                let classes = '';
                 if (hasError) {
                     classes += ' error';
                 } else if (isComplete) {

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -595,4 +595,20 @@
     window.addEventListener('dv-authentication-successful', (e) => {
         app.getQosInformation();
     });
+    window.addEventListener('dv-namespace-open-upload-toast', (e) => {
+        app.$.uploadToast.close();
+        app.removeAllChildren(app.$.uploadToast.querySelector("#uploadList"));
+        app.$.uploadToast.open();
+    });
+    window.addEventListener('dv-namespace-close-upload-toast', (e) => {
+        app.$.uploadToast.close();
+    });
+    window.addEventListener('dv-namespace-upload-toast-append-child', (e) => {
+        const child = e.detail.child;
+        app.$.uploadToast.querySelector("#uploadList").appendChild(child);
+    });
+    window.addEventListener('dv-namespace-show-message-toast', (e) => {
+        app.$.toast.text = `${e.detail.message} `;
+        app.$.toast.show()
+    });
 })(document);


### PR DESCRIPTION
Motivation:

Following the new design paradigm dcache-view have
embarked on recently, it is prudent to adjust some
other key component like the upload feature. This
will help in seamless interoperability of all part
of dcache-view and make them update to with the
latest javascript syntax.

Modification:

1. use es6 syntax
2. remove units in a stylying property with 0 value.
3. remove inline-styling
4. response to existing events where neccessary
5. disptach and use event listner to communicate and
exchange property/value.

Result:

1. fix some rendering issue when a user upload a file
to an empty directory.
2. better memory management for using eventlisteners
3. new eventlistners were created for the general toast
and upload toast.

Target: master
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Albert Rossi <arossi@fnal.gov>

Reviewed at https://rb.dcache.org/r/10871/

(cherry picked from commit e51e1f3cd093405b5eb15d72ee73b06d63380086)