### PR TITLE
dcache-view (namespace): fix path request in view-file

### DIFF
--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -120,7 +120,7 @@
 
                 this._removeItems_ = this._removeItems.bind(this);
                 this._addItems_ = this._addItems.bind(this);
-                this._sendCurrentPath_ = this._sendCurrentPath(this.path);
+                this._sendCurrentPath_ = this._sendCurrentPath.bind(this);
                 this._sendItemIndex_ = this._sendItemIndex.bind(this);
                 this._reset_ = this._reset.bind(this);
                 this._renameInputStart_ = this._renameInputStart.bind(this);
@@ -637,11 +637,11 @@
                 this._updateContentElevationAttribute();
             }
 
-            _sendCurrentPath(pt)
+            _sendCurrentPath()
             {
                 this.dispatchEvent(
                     new CustomEvent('dv-namespace-current-path', {
-                        detail: {currentPath: pt}, bubbles: true, composed: true}));
+                        detail: {currentPath: this.path}, bubbles: true, composed: true}));
             }
 
             /**


### PR DESCRIPTION
Motivation:

When the current path of the listed directory is
requested, an undefined respond is returned. This
was due to the fact that the method handling the
request was not properly bind.

Modification:

Properly bind the method handling the request for
current path to the element that owns the property.

Result:

Current path is now send when requested.

Target: master
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Albert Rossi <arossi@fnal.gov>

Reviewed at https://rb.dcache.org/r/10952/

(cherry picked from commit d80048b74b37b8de005a21fc633153fe3e9a4f8b)