### PR TITLE
dcache-view: fix regression regarding the processing of click events ...

### DIFF
--- a/src/elements/dv-elements/admin/dialogs/billing-records-dialog.html
+++ b/src/elements/dv-elements/admin/dialogs/billing-records-dialog.html
@@ -156,8 +156,7 @@
             </paper-tabs>
             <iron-pages selected="{{selected}}">
                 <div class="tablediv">
-                    <vaadin-grid on-active-item-changed="_activeItemChanged"
-                                 aria-label="Reads" id="reads"
+                    <vaadin-grid aria-label="Reads" id="reads"
                                  active-item="{{activeItem}}"
                                  multi-sort="true" size="[[readsSize]]">
 
@@ -334,8 +333,7 @@
                     </vaadin-grid>
                 </div>
                 <div class="tablediv">
-                    <vaadin-grid on-active-item-changed="_activeItemChanged"
-                                 aria-label="Writes" id="writes"
+                    <vaadin-grid aria-label="Writes" id="writes"
                                  active-item="{{activeItem}}"
                                  multi-sort="true" size="[[writesSize]]">
 
@@ -420,7 +418,7 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span onclick="sendBillingRecordsCellClick('W', '4')"
+                                    <span onclick="sendBillingRecordsCellClick('W', 4)"
                                           class$="actionable[[item.pool.active]]">
                                         [[item.pool.name]]
                                     </span>
@@ -519,8 +517,7 @@
                     </vaadin-grid>
                 </div>
                 <div class="tablediv">
-                    <vaadin-grid on-active-item-changed="_activeItemChanged"
-                                 aria-label="P2Ps" id="p2ps"
+                    <vaadin-grid aria-label="P2Ps" id="p2ps"
                                  active-item="{{activeItem}}"
                                  multi-sort="true" size="[[p2psSize]]">
                         <vaadin-grid-column-group>
@@ -563,7 +560,7 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span onclick="sendBillingRecordsCellClick('P', '3')"
+                                    <span onclick="sendBillingRecordsCellClick('P', 3)"
                                           class$="actionable[[item.serverPool.active]]">
                                         [[item.serverPool.name]]
                                     </span>
@@ -589,7 +586,7 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span onclick="sendBillingRecordsCellClick('P', '4')"
+                                    <span onclick="sendBillingRecordsCellClick('P', 4)"
                                           class$="actionable[[item.clientPool.active]]">
                                         [[item.clientPool.name]]
                                     </span>
@@ -646,8 +643,7 @@
                     </vaadin-grid>
                 </div>
                 <div class="tablediv">
-                    <vaadin-grid on-active-item-changed="_activeItemChanged"
-                                 aria-label="Stores" id="stores"
+                    <vaadin-grid aria-label="Stores" id="stores"
                                  active-item="{{activeItem}}"
                                  multi-sort="true" size="[[storesSize]]">
                         <vaadin-grid-column-group>
@@ -690,7 +686,7 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span onclick="sendBillingRecordsCellClick('F', '3')"
+                                    <span onclick="sendBillingRecordsCellClick('F', 3)"
                                           class$="actionable[[item.pool.active]]">
                                         [[item.pool.name]]
                                     </span>
@@ -737,8 +733,7 @@
                     </vaadin-grid>
                 </div>
                 <div class="tablediv">
-                    <vaadin-grid on-active-item-changed="_activeItemChanged"
-                                 aria-label="Restores" id="restores"
+                    <vaadin-grid aria-label="Restores" id="restores"
                                  active-item="{{activeItem}}"
                                  multi-sort="true" size="[[restoresSize]]">
                         <vaadin-grid-column-group>
@@ -780,7 +775,7 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span onclick="sendBillingRecordsCellClick('S', '3')"
+                                    <span onclick="sendBillingRecordsCellClick('S', 3)"
                                           class$="actionable[[item.pool.active]]">
                                         [[item.pool.name]]
                                     </span>
@@ -838,7 +833,7 @@
         function sendBillingRecordsCellClick(table, cell) {
             window.dispatchEvent(
                 new CustomEvent(`dv-billing-records-table-cell-click`, {
-                    detail: {table: table, cell: parseInt(cell)}}));
+                    detail: {table: table, cell: cell}}));
         }
 
         class BillingRecordsDialog extends Polymer.mixinBehaviors([Polymer.PaperDialogBehavior],
@@ -906,6 +901,11 @@
                         type: Number,
                         value: 0,
                         notify: true,
+                    },
+
+                    activeItem: {
+                        type: Object,
+                        observer: '_activeItemChanged'
                     }
                 }
             }
@@ -1060,8 +1060,8 @@
             /* -------------------------- Dialogs -------------------------- */
 
             _activeItemChanged(item) {
-                if (item && item.detail && item.detail.value) {
-                    this.currentItem = item.detail.value;
+                if (item) {
+                    this.currentItem = item;
                 }
 
                 if (typeof this.currentItem === 'undefined' ||

--- a/src/elements/dv-elements/admin/dialogs/pool-activity-dialog.html
+++ b/src/elements/dv-elements/admin/dialogs/pool-activity-dialog.html
@@ -148,8 +148,7 @@
             </paper-tabs>
             <iron-pages selected="{{selected}}">
                 <div class="tablediv">
-                    <vaadin-grid on-active-item-changed="_activeItemChanged"
-                                 aria-label="Movers" id="movers"
+                    <vaadin-grid aria-label="Movers" id="movers"
                                  active-item="{{activeItem}}"
                                  multi-sort="true" size="[[moversSize]]">
                         <vaadin-grid-column-group>
@@ -360,8 +359,7 @@
                     </vaadin-grid>
                 </div>
                 <div class="tablediv">
-                    <vaadin-grid on-active-item-changed="_activeItemChanged"
-                                 aria-label="P2Ps" id="p2ps"
+                    <vaadin-grid aria-label="P2Ps" id="p2ps"
                                  active-item="{{activeItem}}"
                                  multi-sort="true" size="[[p2psSize]]">
                         <vaadin-grid-column-group>
@@ -533,8 +531,7 @@
                     </vaadin-grid>
                 </div>
                 <div class="tablediv">
-                    <vaadin-grid on-active-item-changed="_activeItemChanged"
-                                 aria-label="Flush" id="flushes"
+                    <vaadin-grid aria-label="Flush" id="flushes"
                                  active-item="{{activeItem}}"
                                  multi-sort="true" size="[[flushesSize]]">
 
@@ -680,8 +677,7 @@
                     </vaadin-grid>
                 </div>
                 <div class="tablediv">
-                    <vaadin-grid on-active-item-changed="_activeItemChanged"
-                                 aria-label="Stage" id="stages"
+                    <vaadin-grid aria-label="Stage" id="stages"
                                  active-item="{{activeItem}}"
                                  multi-sort="true" size="[[stagesSize]]">
 
@@ -827,8 +823,7 @@
                     </vaadin-grid>
                 </div>
                 <div class="tablediv">
-                    <vaadin-grid on-active-item-changed="_activeItemChanged"
-                                 aria-label="Remove" id="removes"
+                    <vaadin-grid aria-label="Remove" id="removes"
                                  active-item="{{activeItem}}"
                                  multi-sort="true" size="[[removesSize]]">
 
@@ -982,7 +977,7 @@
     </template>
 
     <script>
-        function setPoolActivityCellClick() {
+        function sendPoolActivityCellClick() {
             window.dispatchEvent(
                 new CustomEvent(`dv-pool-activity-table-cell-click`, {}));
         }
@@ -1048,6 +1043,11 @@
                         type: Number,
                         value: 0,
                         notify: true
+                    },
+
+                    activeItem: {
+                        type: Object,
+                        observer: '_activeItemChanged'
                     }
                 }
             }
@@ -1228,18 +1228,16 @@
             /* -------------------------- Dialogs -------------------------- */
 
             _activeItemChanged(item) {
-                if (item && item.detail && item.detail.value) {
-                    this.currentItem = item.detail.value;
+                if (item) {
+                    this.currentItem = item;
                 }
 
                 if (typeof this.currentItem === 'undefined' ||
-                    typeof this.cell === 'undefined' ) {
+                    !this.pnfsidClicked ) {
                     return;
                 }
 
-                if (this.pnfsidClicked) {
-                    this.openFileInfoDialog(this.currentItem.pnfsId.id, this.pool);
-                }
+                this.openFileInfoDialog(this.currentItem.pnfsId.id, this.pool);
 
                 this.pnfsidClicked = false;
             }

--- a/src/elements/dv-elements/admin/views/restores-view.html
+++ b/src/elements/dv-elements/admin/views/restores-view.html
@@ -80,8 +80,7 @@
         </paper-toolbar>
         <hr/>
         <div class="tablediv">
-            <vaadin-grid on-active-item-changed="_activeItemChanged"
-                         aria-label="Tape Restores" id="restores"
+            <vaadin-grid aria-label="Tape Restores" id="restores"
                          active-item="{{activeItem}}"
                          multi-sort="true" size="[[tableSize]]">
 
@@ -141,7 +140,7 @@
                             </vaadin-grid-filter>
                         </template>
                         <template>
-                            <span onclick="sendRestoresTableCellClick('1')"
+                            <span onclick="sendRestoresTableCellClick(1)"
                                     class="actionable">[[item.pnfsId]]</span>
                         </template>
                     </vaadin-grid-column>
@@ -182,7 +181,7 @@
                             </vaadin-grid-filter>
                         </template>
                         <template>
-                            <span onclick="sendRestoresTableCellClick('2')"
+                            <span onclick="sendRestoresTableCellClick(2)"
                                 class="actionable">[[item.poolCandidate]]</span>
                         </template>
                     </vaadin-grid-column>
@@ -244,7 +243,7 @@
         function sendRestoresTableCellClick(cell) {
             window.dispatchEvent(
                 new CustomEvent(`dv-restores-table-cell-click`, {
-                    detail: {cell: parseInt(cell)}}));
+                    detail: {cell: cell}}));
         }
 
         class RestoresView extends DcacheViewMixins.AdminAutoRefresh(DcacheViewMixins.AdminBase(Polymer.Element)) {
@@ -272,6 +271,11 @@
                         type: Number,
                         value: 0,
                         notify: true
+                    },
+
+                    activeItem: {
+                        type: Object,
+                        observer: '_activeItemChanged'
                     }
                 }
             }
@@ -341,7 +345,7 @@
             /* -------------------------- Dialogs -------------------------- */
 
             _activeItemChanged(item) {
-                if (item && item.detail && item.detail.value) {
+                if (item) {
                     this.currentItem = item.detail.value;
                 }
 

--- a/src/elements/dv-elements/admin/views/transfers-view.html
+++ b/src/elements/dv-elements/admin/views/transfers-view.html
@@ -167,8 +167,7 @@
         </paper-toolbar>
         <paper-checkbox checked="{{showall}}">Show All Columns</paper-checkbox>
         <div class="tablediv">
-            <vaadin-grid on-active-item-changed="_activeItemChanged"
-                         aria-label="Disk Transfers" id="transfers"
+            <vaadin-grid aria-label="Disk Transfers" id="transfers"
                          active-item="{{activeItem}}"
                          multi-sort="true" size="[[tableSize]]">
                 <vaadin-grid-selection-column>
@@ -360,7 +359,7 @@
                             </vaadin-grid-filter>
                         </template>
                         <template>
-                            <span onclick="sendTransfersTableCellClick('2')"
+                            <span onclick="sendTransfersTableCellClick(1)"
                                   class="actionable">[[item.pnfsId]]</span>
                         </template>
                     </vaadin-grid-column>
@@ -383,7 +382,7 @@
                             </vaadin-grid-filter>
                         </template>
                         <template>
-                            <span onclick="sendTransfersTableCellClick('2')"
+                            <span onclick="sendTransfersTableCellClick(2)"
                                   class="actionable">[[item.pool]]</span>
                         </template>
                     </vaadin-grid-column>
@@ -467,7 +466,7 @@
         function sendTransfersTableCellClick(cell) {
             window.dispatchEvent(
                 new CustomEvent(`dv-transfers-table-cell-click`, {
-                    detail: {cell: parseInt(cell)}}));
+                    detail: {cell: cell}}));
         }
 
         class TransfersView extends
@@ -481,7 +480,7 @@
                 return {
                     name: {
                         type: String,
-                        value: "TRANFERS"
+                        value: "TRANSFERS"
                     },
 
                     decorator: {
@@ -518,6 +517,11 @@
                         type: Boolean,
                         value: false,
                         notify: true
+                    },
+
+                    activeItem: {
+                        type: Object,
+                        observer: '_activeItemChanged'
                     }
                 }
             }
@@ -630,8 +634,8 @@
             /* -------------------------- Dialogs -------------------------- */
 
             _activeItemChanged(item) {
-                if (item && item.detail && item.detail.value) {
-                    this.currentItem = item.detail.value;
+                if (item) {
+                    this.currentItem = item;
                 }
 
                 if (typeof this.currentItem === 'undefined' ||
@@ -639,10 +643,10 @@
                     return;
                 }
 
-                if (this.cell === '1') {
+                if (this.cell === 1) {
                     this.openFileInfoDialog(this.currentItem.pnfsId,
                         this.currentItem.pool);
-                } else if (this.cell === '2') {
+                } else if (this.cell === 2) {
                     this.openPoolInfoDialog(this.currentItem.pool,
                         this.currentItem.pnfsId);
                 }


### PR DESCRIPTION
…on vaadin-grid tables

Motivation:

Patch #10862 commit 2254e597201e99c212c1cd88cb8f8cfd4f8910c1
introduced an upgrade to Vaadin Grid 4.1.7 in order to solve
several issues.

While testing for correct behavior regarding those problems
was done, full regression testing was evidently not conducted.

As a result, a change affecting the handling of click events
on the table was not detected.  Because of this, four views
currently do not response to clicks in order to open file or
pool dialogs.

Modifcation:

Remove the no-longer supported 'on-active-item-changed'
property on the table, define the activeItem property
and its observer explicitly.

Also fixed several small undetected bugs in the related
methods.

Result:

Clicking on the designated columns on the tables now
properly opens the file and/or pool dialogs.

Target: master
Request: 1.4
Acked-by: Olufemi