### PR TITLE
dcache-view (namespace): broadcast current path in view-file

### DIFF
--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -118,6 +118,10 @@
                     new CustomEvent('dv-namespace-view-file-created', {
                         detail: {}, bubbles: true, composed: true}));
 
+                window.dispatchEvent(
+                    new CustomEvent('dv-namespace-current-path', {
+                        detail: {currentPath: path}, bubbles: true, composed: true}));
+
                 this._removeItems_ = this._removeItems.bind(this);
                 this._addItems_ = this._addItems.bind(this);
                 this._sendCurrentPath_ = this._sendCurrentPath.bind(this);


### PR DESCRIPTION
Motivation:

Each time a directory listing is requested a new view-file
created. Some elements depends on the current path value
of the directory listed. Hence they need to be notified of
any changes in the current listing.

Modification:

Broadcast the current path each time view-file is created.

Result:

- All elements listening to `dv-namespace-current-path` will
    get notified if there is any changes in the current path.
- Fixed the upload path problem.

Target: master
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10973/

(cherry picked from commit 32a51184acf65826096fa7905b807182205c35fa)