### PR TITLE
dcache-view (namespace): live update of QoS when changed

### DIFF
--- a/src/elements/dv-elements/contextual-content/change-qos-context-menu.html
+++ b/src/elements/dv-elements/contextual-content/change-qos-context-menu.html
@@ -31,8 +31,7 @@
         <paper-listbox class="menu-content">
             <template is="dom-repeat" items="[[possibleTransition]]">
                 <paper-item on-tap="_changeQos" class="menuItem"
-                            disabled$="[[_computedDisabled(item.backendCapability.name,currentQos)]]"
-                            data-transition-name$="[[item.backendCapability.name]]">
+                            disabled$="[[_computedDisabled(item.backendCapability.name,currentQos)]]">
                     [[item.backendCapability.name]]
                 </paper-item>
             </template>
@@ -45,7 +44,7 @@
             {
                 super();
                 this.path = t.filePath;
-                this.currentQos = t.currentQos;
+                this.currentQos = t.fileMetaData.currentQos;
                 this.targetNode = t;
             }
 
@@ -86,9 +85,10 @@
             {
                 super.connectedCallback();
                 window.addEventListener('dv-namespace-receive-item-index', e => this.index = e.detail.index);
-                this.dispatchEvent(new CustomEvent('dv-namespace-request-item-index'), {
-                    detail:{item: this.targetNode}, bubbles: true, composed: true
-                });
+
+                this.dispatchEvent(
+                    new CustomEvent('dv-namespace-request-item-index', {
+                        detail: {item: this.targetNode.fileMetaData}, bubbles: true, composed: true}));
             }
 
             disconnectedCallback()
@@ -104,29 +104,26 @@
                 const namespace = document.createElement('dcache-namespace');
                 namespace.auth = sessionStorage.upauth;
 
-                namespace.promise.then(
-                    () => {
-                        const currentQos = this.currentQos;
-                        app.$.toast.text = "Request successful! File in transition. ";
-                        app.$.toast.show();
-                        this.dispatchEvent(new CustomEvent('qos-in-transition', {detail: {options: {
-                            currentQos: currentQos,
-                            targetQos: e.target.getAttribute('data-transition-name'),
+                namespace.promise.then(() => {
+                    this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                        detail: {message: `Request successful! File in transition.`},
+                        bubbles: true, composed: true}));
+                    this.dispatchEvent(new CustomEvent('qos-in-transition', {detail: {
+                        options: {
+                            currentQos: this.currentQos,
+                            targetQos: e.model.item.backendCapability.name,
                             itemIndex: this.index,
-                            path: this.path
-                        }}}));
-                    }
-                ).catch(
-                    function(err) {
-                        app.$.toast.text = `${err.message} `;
-                        app.$.toast.show();
-                    }
-                );
+                            path: this.path}}, bubbles: true, composed: true}));
+                }).catch((err) => {
+                    this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                        detail: {message: `${err.message}`},
+                        bubbles: true, composed: true}));
+                });
 
                 namespace.qos({
                     url: `${window.CONFIG["dcache-view.endpoints.webapi"]}namespace`,
                     path: this.path,
-                    target: e.target.getAttribute('data-transition-name')
+                    target: e.model.item.backendCapability.name
                 });
             }
 

--- a/src/elements/dv-elements/utils/ajax-ls/file-metadata.html
+++ b/src/elements/dv-elements/utils/ajax-ls/file-metadata.html
@@ -206,8 +206,7 @@
                                          class="card-actions" style="height: 30px !important; padding: 5px 1px;">
                                         <template is="dom-repeat" items="[[possibleTransition]]">
                                             <paper-button on-tap="_changeQos"
-                                                          disabled$="[[_computedDisabled(item.backendCapability.name,currentQos)]]"
-                                                          data-transition-name$="[[item.backendCapability.name]]">
+                                                          disabled$="[[_computedDisabled(item.backendCapability.name,currentQos)]]">
                                                 [[item.backendCapability.name]]
                                             </paper-button>
                                         </template>
@@ -488,35 +487,30 @@
 
             _changeQos(e)
             {
-                const target = e.target.getAttribute('data-transition-name');
                 const namespace = document.createElement('dcache-namespace');
                 namespace.auth = sessionStorage.upauth;
-                const path = this.path;
 
-                namespace.promise.then(
-                    () => {
-                        const currentQos = this.currentQos;
-                        app.$.toast.text = "Request successful! File in transition. ";
-                        app.$.toast.show();
-                        //FIXME: `this.fire` is deprecated in polymer 2.x please adjust accordingly.
-                        this.fire('qos-in-transition', {options: {
-                            currentQos: currentQos,
-                            targetQos: target,
+                namespace.promise.then(() => {
+                    this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                        detail: {message: `Request successful! File in transition.`},
+                        bubbles: true, composed: true}));
+                    this.dispatchEvent(new CustomEvent('qos-in-transition', {detail: {
+                        options: {
+                            currentQos: this.currentQos,
+                            targetQos: e.model.item.backendCapability.name,
                             itemIndex: this.index,
-                            path: path
-                        }});
-                    }
-                ).catch(
-                    function(err) {
-                        app.$.toast.text = err.message + " ";
-                        app.$.toast.show();
-                    }
-                );
+                            path: this.path
+                        }}, bubbles: true, composed: true}));
+                }).catch((err) => {
+                    this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                        detail: {message: `${err.message}`},
+                        bubbles: true, composed: true}));
+                });
 
                 namespace.qos({
                     url: window.CONFIG["dcache-view.endpoints.webapi"] +'namespace',
-                    path: path,
-                    target: target
+                    path: this.path,
+                    target: e.model.item.backendCapability.name
                 });
             }
 

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -666,7 +666,7 @@
 
             _sendItemIndex(event)
             {
-                const index = this.__getItemCurrentIndex(event.detail.item.fileName);
+                const index = this.__getItemCurrentIndex(event.detail.item);
                 this.dispatchEvent(
                     new CustomEvent('dv-namespace-receive-item-index', {
                         detail: {index: index}, bubbles: true, composed: true}));

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -428,17 +428,18 @@
 
     function updateFeListAndMetaDataDrawer(status, itemIndex)
     {
-        if (app.$.metadata.selected == 'drawer'){
+        if (app.$.metadata.selected === 'drawer'){
             app.$.metadata.querySelector('file-metadata').currentQos = status;
         }
-        app.$.homeDir.querySelector('#feList')
-            .set('items.'+itemIndex+'.currentQos', status);
-        app.$.homeDir.querySelector('#feList').notifyPath('items.'+itemIndex+'.currentQos');
+        const vf = app.$.homedir.querySelector('view-file');
+        vf.shadowRoot.querySelector('#feList')
+            .set(`items.${itemIndex}.currentQos`, status);
+        vf.shadowRoot.querySelector('#feList').notifyPath(`items.${itemIndex}.currentQos`);
     }
 
     function periodicalCurrentQosRequest(options)
     {
-        let namespace = document.createElement('dcache-namespace');
+        const namespace = document.createElement('dcache-namespace');
         namespace.auth = sessionStorage.upauth;
         namespace.promise.then( (req) => {
             if (req.response.targetQos !== undefined) {
@@ -446,7 +447,7 @@
 
                 //ask every two seconds
                 setTimeout(periodicalCurrentQosRequest(options), 2000);
-            } else if (req.response.currentQos == options.targetQos) {
+            } else if (req.response.currentQos === options.targetQos) {
                 updateFeListAndMetaDataDrawer(req.response.currentQos, options.itemIndex);
 
                 app.$.toast.text = "Transition complete! ";
@@ -464,7 +465,7 @@
             }
         );
         namespace.getqos({
-            url: window.CONFIG["dcache-view.endpoints.webapi"] + 'namespace',
+            url: `${window.CONFIG["dcache-view.endpoints.webapi"]}namespace`,
             path: options.path
         });
     }


### PR DESCRIPTION
Motivation:

When user request for change in QoS, after sucessful
transition the list is not update.

Modification:

Update the elements to the latest design and some code
clean up.

Result:

The list is updated to reflect the current status of
request.

Target: master
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.de>

Reviewed at https://rb.dcache.org/r/10976/

(cherry picked from commit 29ba6dc8441b2afe578ae0537d0b99190b716eea)