### PR TITLE
dcache-view (namespace): fix the upload toast to show the current status

### DIFF
--- a/src/elements/dv-elements/drag-and-drop/dnd-upload.html
+++ b/src/elements/dv-elements/drag-and-drop/dnd-upload.html
@@ -43,9 +43,9 @@
         _scanDirectory(item, path)
         {
             return new Promise((resolve,reject)=>{
-                let dirReader = item.createReader();
-                dirReader.readEntries((entries)=> {
-                    for (let i=0; i<entries.length; i++) {
+                const dirReader = item.createReader();
+                dirReader.readEntries(entries => {
+                    for (let i=0; i < entries.length; i++) {
                         if (entries[i].isFile) {
                             try {
                                 this._subDirFileUpload(entries[i], path);
@@ -53,16 +53,12 @@
                                 reject(Error(err.message));
                             }
                         } else if (entries[i].isDirectory) {
-                            this.__createNewDirectory(entries[i].name, path).then(
-                                ()=>{
-                                    const pt = (path.endsWith("/")) ? path : path + "/";
-                                    this._scanDirectory(entries[i], pt+entries[i].name).then(
-
-                                    ).catch((err)=>{
-                                        reject(err);
-                                    });
-                                }
-                            ).catch((err)=>{
+                            this.__createNewDirectory(entries[i].name, path).then(() => {
+                                const pt = (path.endsWith("/")) ? path : `${path}/`;
+                                this._scanDirectory(entries[i], pt+entries[i].name).then().catch(err => {
+                                    reject(err);
+                                });
+                            }).catch(err => {
                                 reject(err);
                             });
                         }
@@ -70,44 +66,37 @@
                 });
                 resolve("All the contents have been uploaded.");
             });
-
         }
 
-        __createNewDirectory(name,path)
+        __createNewDirectory(name, path)
         {
-            return new Promise(
-                (resolve, reject)=>
-                {
-                    let url = window.CONFIG["dcache-view.endpoints.webapi"] + "namespace";
-                    let namespace = document.createElement('dcache-namespace');
-                    namespace.auth = sessionStorage.upauth;
-                    namespace.promise.then(
-                        ()=> {resolve(name);}
-                    ).catch(
-                        (err)=> {reject(err);}
-                    );
+            return new Promise((resolve, reject) => {
+                const url = `${window.CONFIG["dcache-view.endpoints.webapi"]}namespace`;
+                const namespace = document.createElement('dcache-namespace');
+                namespace.auth = sessionStorage.upauth;
+                namespace.promise.then(()=> {
+                    return resolve(name);
+                }).catch(err => reject(err));
 
-                    namespace.mkdir({
-                        url: url,
-                        path: path,
-                        name: name
-                    });
+                namespace.mkdir({
+                    url: url,
+                    path: path,
+                    name: name
                 });
+            });
         }
 
-        _uploadFileInCurrentView(index, file, uploadList)
+        _uploadFileInCurrentView(index, file)
         {
-            let uploadToast = new UploadToastFile(file.name, "REGULAR", file.type);
+            const uploadToast = new UploadToastFile(file.name, "REGULAR", file.type);
             uploadToast.setAttribute("id", index.toString());
-            uploadList.appendChild(uploadToast);
+            window.dispatchEvent(new CustomEvent('dv-namespace-upload-toast-append-child', {
+                detail: {child: uploadToast}, bubbles: true, composed: true}));
 
-            Polymer.dom.flush();
+            const progressBar = uploadToast.shadowRoot.querySelector('paper-progress');
+            const fileUploader = new UploadFileCommon(this.path);
 
-            let progressBar = uploadToast.shadowRoot.querySelector('paper-progress');
-            let fileUploader = new UploadFileCommon(this.path, app.checkBrowser());
-
-            fileUploader.addEventListener('complete', (e)=>
-            {
+            fileUploader.addEventListener('complete', e => {
                 progressBar.indeterminate = fileUploader.progressStatus;
                 progressBar.value = fileUploader.progressValue;
                 progressBar.classList.remove("error", "progress");
@@ -119,21 +108,13 @@
                 uploadToast.message = fileUploader.message;
 
                 if (this.isCurrentView) {
-                    let vf = app.$.homedir.querySelector('view-file');
-                    let ed = vf.shadowRoot.querySelector('empty-directory');
-                    if (ed != null) {
-                        vf.shadowRoot.querySelector('#content').removeChild(ed);
-                    }
-                    let list = vf.shadowRoot.querySelector('iron-list');
-
-                    list.unshift('items', e.detail.item);
-                    list.fire('iron-resize');
-                    Polymer.dom.flush();
+                    window.dispatchEvent(new CustomEvent('dv-namespace-add-items', {
+                        detail: {files: [e.detail.item]}, bubbles: true, composed: true
+                    }));
                 }
             });
 
-            fileUploader.addEventListener('uploading', (e)=>
-            {
+            fileUploader.addEventListener('uploading', e => {
                 progressBar.classList.remove("error", "complete");
                 progressBar.classList.add("progress");
                 progressBar.indeterminate = fileUploader.progressStatus;
@@ -143,8 +124,7 @@
                 uploadToast.hasError = fileUploader.hasError;
             });
 
-            fileUploader.addEventListener('error', (e)=>
-            {
+            fileUploader.addEventListener('error', e => {
                 progressBar.classList.remove("progress", "complete");
                 progressBar.classList.add("error");
                 progressBar.indeterminate = fileUploader.progressStatus;
@@ -159,13 +139,12 @@
 
         _subDirFileUpload (file, path)
         {
-            let fileUploader = new UploadFileCommon(path, app.checkBrowser());
-            fileUploader.addEventListener('complete', (e)=> {});
+            const fileUploader = new UploadFileCommon(path);
+            fileUploader.addEventListener('complete', e => {});
 
-            fileUploader.addEventListener('uploading', (e)=> {});
+            fileUploader.addEventListener('uploading', e => {});
 
-            fileUploader.addEventListener('error', (e)=>
-            {
+            fileUploader.addEventListener('error', e => {
                 throw new Error(e.detail.message);
             });
 
@@ -175,48 +154,42 @@
         start(event)
         {
             if (!window.CONFIG.isSomebody) {
-                app.$.toast.text = 'You need to login to perform this operation. ';
-                app.$.toast.show();
+                window.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                    detail: {message: `You need to login to perform this operation.`},
+                    bubbles: true, composed: true}));
                 return;
             }
-            app.$.uploadToast.close();
+            window.dispatchEvent(new CustomEvent('dv-namespace-close-upload-toast', {
+                bubbles: true, composed: true}));
 
-            let items = event.dataTransfer.items;
-            app.$.uploadToast.open();
-            let uploadList = app.$.uploadToast.querySelector("#uploadList");
-            uploadList.innerHTML = "";
+            const items = event.dataTransfer.items;
+            window.dispatchEvent(new CustomEvent('dv-namespace-open-upload-toast', {
+                bubbles: true, composed: true}));
+            const uploadList = app.$.uploadToast.querySelector("#uploadList");
 
             if (items === undefined) {
-                let files = event.dataTransfer.files;
+                const files = event.dataTransfer.files;
                 for (let i=0; f = files[i]; i++) {
-                    this._uploadFileInCurrentView(i,f, uploadList);
+                    this._uploadFileInCurrentView(i,f);
                 }
             } else {
                 for (let i=0; i<items.length; i++) {
-                    let item = items[i].webkitGetAsEntry();
+                    const item = items[i].webkitGetAsEntry();
 
                     if (item.isFile) {
                         item.file((file)=> {
-                            this._uploadFileInCurrentView(i,file, uploadList);
+                            this._uploadFileInCurrentView(i,file);
                         });
                     } else if (item.isDirectory) {
-                        let uploadToast = new UploadToastFile(item.name, "DIR", "application/vnd.dcache.folder");
+                        const uploadToast = new UploadToastFile(item.name, "DIR", "application/vnd.dcache.folder");
                         uploadToast.setAttribute("id", i.toString());
                         uploadList.appendChild(uploadToast);
-                        let progressBar = uploadToast.querySelector('paper-progress');
+                        const progressBar = uploadToast.shadowRoot.querySelector('paper-progress');
 
-                        this.__createNewDirectory(item.name, this.path).then((name)=>{
+                        this.__createNewDirectory(item.name, this.path).then(name => {
                             if (this.isCurrentView) {
-                                let vf = app.$.homedir.querySelector('view-file');
-                                let ed = vf.shadowRoot.querySelector('empty-directory');
-                                if (ed != null) {
-                                    vf.shadowRoot.querySelector('#content').removeChild(ed);
-                                }
-
-                                let list = vf.shadowRoot.querySelector('iron-list');
-
-                                if (list !== null) {
-                                    list.unshift('items', {
+                                window.dispatchEvent(new CustomEvent('dv-namespace-add-items', {
+                                    detail: {files: [{
                                             "fileName" : name,
                                             "fileMimeType" : "application/vnd.dcache.folder",
                                             "fileLocality" : "",
@@ -224,15 +197,10 @@
                                             "fileType" : "DIR",
                                             "mtime" : "--",
                                             "creationTime" : Date.now() //Assumption
-                                        }
-                                    );
-                                    list.fire('iron-resize');
-                                }
+                                        }]}, bubbles: true, composed: true}));
                             }
 
-
-                            this._scanDirectory(item, this.path+"/"+item.name).then((response)=>
-                            {
+                            this._scanDirectory(item, `${this.path}/${item.name}`).then(response => {
                                 progressBar.indeterminate = false;
                                 progressBar.value = 100;
                                 progressBar.classList.remove("error", "progress");
@@ -242,7 +210,7 @@
                                 uploadToast.hasError = false;
                                 uploadToast.isComplete = true;
                                 uploadToast.message = response;
-                            }).catch((err)=>{
+                            }).catch(err => {
                                 progressBar.classList.remove("progress", "complete");
                                 progressBar.classList.add("error");
                                 progressBar.indeterminate = false;
@@ -253,7 +221,7 @@
                                 uploadToast.hasError = true;
                                 uploadToast.message = err.toString();
                             });
-                        }).catch((err)=>{
+                        }).catch(err => {
                             progressBar.classList.remove("progress", "complete");
                             progressBar.classList.add("error");
                             progressBar.indeterminate = false;

--- a/src/elements/dv-elements/drag-and-drop/drag-enter-toast.html
+++ b/src/elements/dv-elements/drag-and-drop/drag-enter-toast.html
@@ -11,12 +11,10 @@
             iron-icon {
                 --iron-icon-width: 72px;
                 --iron-icon-height: 72px;
-                /*fill: #b0b0b0;*/
                 fill: #808080;
             }
             #holderParent {
                 flex: 1 1 auto;
-                /*flex-grow: 1;*/
             }
             #wrapper {
                 display: flex;
@@ -40,7 +38,6 @@
                 border-radius: 2px;
                 border: 2px solid #4a806b;
                 box-sizing: border-box;
-                /*box-shadow: 20px 20px 50px 20px rgba(0, 0, 0, 0.12);*/
                 box-shadow: 20px 20px 100px 40px rgba(0, 0, 0, 0.3);
             }
             file-icon {

--- a/src/elements/dv-elements/upload-files/upload-file-common.html
+++ b/src/elements/dv-elements/upload-files/upload-file-common.html
@@ -5,11 +5,11 @@
         `use-strict`;
         class UploadFileCommon extends Polymer.Element
         {
-            constructor(path, browser)
+            constructor(path)
             {
                 super();
-                this.path = path.endsWith("/") ? path : path + "/";
-                this.browser = browser;
+                this.path = path.endsWith("/") ? path : `${path}/`;
+                this.browser = app.checkBrowser();
             }
 
             static get is()
@@ -48,11 +48,9 @@
                     url: {
                         type: String,
                         value: function () {
-                            if (window.CONFIG["dcache-view.endpoints.webdav"] === "") {
-                                return `${window.location.protocol}//${window.location.hostname}:2880`;
-                            } else {
-                                return window.CONFIG["dcache-view.endpoints.webdav"];
-                            }
+                            return window.CONFIG["dcache-view.endpoints.webdav"] === "" ?
+                                `${window.location.protocol}//${window.location.hostname}:2880` :
+                                window.CONFIG["dcache-view.endpoints.webdav"];
                         }
                     },
                     path: {
@@ -72,21 +70,22 @@
 
             upload(file)
             {
-                const uploadUrl = this.url + this.path + file.name;
+                const uploadUrl = `${this.url}${this.path}${file.name}`;
 
                 new UploadHandler({
                     file: file,
                     upauth: sessionStorage.upauth,
                     url: uploadUrl,
-                    onComplete: (data)=>
-                    {
+                    onComplete: data => {
                         this.progressStatus = false;
                         this.progressValue = 100;
                         this.inProgress = false;
                         this.hasError = false;
                         this.isComplete = true;
                         this.message = "Uploaded";
-                        this.dispatchEvent(new CustomEvent('complete', {detail: {item: {
+                        this.dispatchEvent(new CustomEvent('complete', {
+                            detail: {
+                                item: {
                                     "fileName" : data.name,
                                     "fileMimeType" : data.type,
                                     "fileLocality" : "",
@@ -94,7 +93,8 @@
                                     "fileType" : "REGULAR",
                                     "mtime" : data.lastModified,
                                     "creationTime" : Date.now()
-                                }}})
+                                }
+                            }})
                         );
                     },
 

--- a/src/index.html
+++ b/src/index.html
@@ -183,6 +183,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             --paper-toast-background-color: transparent !important;
                             --paper-toast-box-shadow: none !important;
                             padding: 0 !important;
+                            pointer-events:none;
+                            background:none !important
                         }
                         .paper-material {
                             padding: 16px;


### PR DESCRIPTION
Motivation:

When a file/directory is upload through drag and drop
the toast shows that the file is still uploading even
though upload is complete.

Modification:

- Use es6 syntax
- Code cleaning based on the lastest design

Result:

The upload toast now works as espected.

Target: master
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Paul Millar <paul.millar@desy.desy>

Reviewed at https://rb.dcache.org/r/10975/

(cherry picked from commit 98f6f9522c8f59545c343c28a8332ab16f5dc134)