### PR TITLE
dcache-view: repair broken click/tap events

### DIFF
--- a/src/elements/dv-elements/admin/dialogs/billing-records-dialog.html
+++ b/src/elements/dv-elements/admin/dialogs/billing-records-dialog.html
@@ -234,7 +234,7 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span onclick="sendBillingRecordsCellClick('R', '4')"
+                                    <span on-tap="_openPoolInfoFromPool"
                                           class$="actionable[[item.pool.active]]">
                                         [[item.pool.name]]
                                     </span>
@@ -418,7 +418,7 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span onclick="sendBillingRecordsCellClick('W', 4)"
+                                    <span on-tap="_openPoolInfoFromPool"
                                           class$="actionable[[item.pool.active]]">
                                         [[item.pool.name]]
                                     </span>
@@ -560,7 +560,7 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span onclick="sendBillingRecordsCellClick('P', 3)"
+                                    <span on-tap="_openPoolInfoFromServerPool"
                                           class$="actionable[[item.serverPool.active]]">
                                         [[item.serverPool.name]]
                                     </span>
@@ -586,7 +586,7 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span onclick="sendBillingRecordsCellClick('P', 4)"
+                                    <span on-tap="_openPoolInfoFromClientPool"
                                           class$="actionable[[item.clientPool.active]]">
                                         [[item.clientPool.name]]
                                     </span>
@@ -686,7 +686,7 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span onclick="sendBillingRecordsCellClick('F', 3)"
+                                    <span on-tap="_openPoolInfoFromPool"
                                           class$="actionable[[item.pool.active]]">
                                         [[item.pool.name]]
                                     </span>
@@ -775,7 +775,7 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span onclick="sendBillingRecordsCellClick('S', 3)"
+                                    <span on-tap="_openPoolInfoFromPool"
                                           class$="actionable[[item.pool.active]]">
                                         [[item.pool.name]]
                                     </span>
@@ -830,12 +830,6 @@
     </template>
 
     <script>
-        function sendBillingRecordsCellClick(table, cell) {
-            window.dispatchEvent(
-                new CustomEvent(`dv-billing-records-table-cell-click`, {
-                    detail: {table: table, cell: cell}}));
-        }
-
         class BillingRecordsDialog extends Polymer.mixinBehaviors([Polymer.PaperDialogBehavior],
             DcacheViewMixins.AdminAutoRefresh(DcacheViewMixins.AdminBase(Polymer.Element))) {
 
@@ -845,6 +839,15 @@
 
             static get properties() {
                 return {
+                    activeItem: {
+                        type: Object,
+                        observer: '_setCurrentItem'
+                    },
+
+                    currentItem: {
+                        type: Object
+                    },
+
                     decorators: {
                         type: Array,
                         value: [{}, {}, {}, {}, {}]
@@ -888,11 +891,6 @@
                         type: String
                     },
 
-                    cell: {
-                        type: Number,
-                        value: 0
-                    },
-
                     table: {
                         type: String
                     },
@@ -903,9 +901,9 @@
                         notify: true,
                     },
 
-                    activeItem: {
-                        type: Object,
-                        observer: '_activeItemChanged'
+                    clicked: {
+                        type: Number,
+                        value: 0
                     }
                 }
             }
@@ -921,7 +919,6 @@
 
                 window.addEventListener('dv-vaadin-provider-reset-timeout-billing', this.resetTimeout.bind(this));
                 window.addEventListener('dv-vaadin-provider-update-table-size-billing', this.setTableSize.bind(this));
-                window.addEventListener('dv-billing-records-table-cell-click', this.setCell.bind(this));
 
                 this.decorators[0] = this._createDecorator(this.$.reads, 0, 3);
                 this.decorators[1] = this._createDecorator(this.$.writes, 1, 3);
@@ -952,12 +949,6 @@
 
                 window.removeEventListener('dv-vaadin-provider-reset-timeout-billing', this.resetTimeout.bind(this));
                 window.removeEventListener('dv-vaadin-provider-update-table-size-billing', this.setTableSize.bind(this));
-                window.removeEventListener('dv-billing-records-table-cell-click', this.setCell.bind(this));
-            }
-
-            setCell(event) {
-                this.table = event.detail.table;
-                this.cell = event.detail.cell;
             }
 
             _createDecorator(table, index, filter) {
@@ -1056,50 +1047,46 @@
                 };
             }
 
-
             /* -------------------------- Dialogs -------------------------- */
 
-            _activeItemChanged(item) {
+            _setCurrentItem(item) {
                 if (item) {
                     this.currentItem = item;
                 }
 
-                if (typeof this.currentItem === 'undefined' ||
-                    typeof this.cell === 'undefined') {
-                    return;
-                }
-
                 let pool;
 
-                switch (this.table) {
-                    case 'R':
-                    case 'W':
-                        if (this.cell === 4) {
+                if (this.currentItem) {
+                    switch(this.clicked) {
+                        case 1:
                             pool = this.currentItem.pool.name.split('@')[0];
                             this.openPoolInfoDialog(pool, this.pnfsid);
-                        }
-                        break;
-                    case 'F':
-                    case 'S':
-                        if (this.cell === 3) {
-                            pool = this.currentItem.pool.name.split('@')[0];
-                            this.openPoolInfoDialog(pool, this.pnfsid);
-                        }
-                        break;
-                    case 'P':
-                        if (this.cell === 3) {
+                            break;
+                        case 2:
                             pool = this.currentItem.serverPool.name.split('@')[0];
                             this.openPoolInfoDialog(pool, this.pnfsid);
-                        } else if (this.cell == 4) {
+                            break;
+                        case 3:
                             const address = this.currentItem.clientPool.name.split(':')[1];
                             pool = address.split('@')[0];
                             this.openPoolInfoDialog(pool, this.pnfsid);
-                        }
-                        break;
-                }
+                            break;
 
-                this.table = '';
-                this.cell = 0;
+                    }
+                    this.clicked = 0;
+                }
+            }
+
+            _openPoolInfoFromPool() {
+                this.clicked = 1;
+            }
+
+            _openPoolInfoFromServerPool() {
+                this.clicked = 2;
+            }
+
+            _openPoolInfoFromClientPool() {
+                this.clicked = 3;
             }
 
             _hideToast() {

--- a/src/elements/dv-elements/admin/dialogs/pool-activity-dialog.html
+++ b/src/elements/dv-elements/admin/dialogs/pool-activity-dialog.html
@@ -176,7 +176,7 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span onclick="sendPoolActivityCellClick()"
+                                    <span on-tap="_openFileInfo"
                                           class$="actionable[[item.pnfsId.active]]">
                                         [[item.pnfsId.id]]
                                     </span>
@@ -387,7 +387,7 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span onclick="sendPoolActivityCellClick()"
+                                    <span on-tap="_openFileInfo"
                                             class$="actionable[[item.pnfsId.active]]">
                                             [[item.pnfsId.id]]
                                     </span>
@@ -582,7 +582,7 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span onclick="sendPoolActivityCellClick()"
+                                    <span on-tap="_openFileInfo"
                                           class$="actionable[[item.pnfsId.active]]">
                                             [[item.pnfsId.id]]
                                     </span>
@@ -728,7 +728,7 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span onclick="sendPoolActivityCellClick()"
+                                    <span on-tap="_openFileInfo"
                                           class$="actionable[[item.pnfsId.active]]">
                                             [[item.pnfsId.id]]
                                     </span>
@@ -877,7 +877,7 @@
                                     </vaadin-grid-filter>
                                 </template>
                                 <template>
-                                    <span onclick="sendPoolActivityCellClick()"
+                                    <span on-tap="_openFileInfo"
                                             class$="actionable[[item.pnfsId.active]]">
                                         [[item.pnfsId.id]]
                                     </span>
@@ -977,11 +977,6 @@
     </template>
 
     <script>
-        function sendPoolActivityCellClick() {
-            window.dispatchEvent(
-                new CustomEvent(`dv-pool-activity-table-cell-click`, {}));
-        }
-
         class PoolActivityDialog extends Polymer.mixinBehaviors([Polymer.PaperDialogBehavior],
             DcacheViewMixins.AdminAutoRefresh(DcacheViewMixins.AdminBase(Polymer.Element))) {
 
@@ -991,6 +986,20 @@
 
             static get properties() {
                 return {
+
+                    activeItem: {
+                        type: Object,
+                        observer: '_setCurrentItem'
+                    },
+
+                    currentItem: {
+                        type: Object
+                    },
+
+                    pnfsidClicked: {
+                        type: Boolean
+                    },
+
                     decorators: {
                         type: Array,
                         value: [{}, {}, {}, {}, {}]
@@ -1034,20 +1043,10 @@
                         type: String
                     },
 
-                    pnfsidClicked: {
-                        type: Boolean,
-                        value: false
-                    },
-
                     selected: {
                         type: Number,
                         value: 0,
                         notify: true
-                    },
-
-                    activeItem: {
-                        type: Object,
-                        observer: '_activeItemChanged'
                     }
                 }
             }
@@ -1063,7 +1062,6 @@
 
                 window.addEventListener('dv-vaadin-provider-reset-timeout-pool', this.resetTimeout.bind(this));
                 window.addEventListener('dv-vaadin-provider-update-table-size-pool', this.setTableSize.bind(this));
-                window.addEventListener('dv-pool-activity-table-cell-click', this.setPnfsidClicked.bind(this));
 
                 this.decorators[0] = this._createDecorator(this.$.movers, 0, 6);
                 this.decorators[1] = this._createDecorator(this.$.p2ps, 1, 4);
@@ -1094,7 +1092,6 @@
 
                 window.removeEventListener('dv-vaadin-provider-reset-timeout-pool', this.resetTimeout.bind(this));
                 window.removeEventListener('dv-vaadin-provider-update-table-size-pool', this.setTableSize.bind(this));
-                window.removeEventListener('dv-pool-activity-table-cell-click', this.setPnfsidClicked.bind(this));
             }
 
             _createDecorator(table, index, filters) {
@@ -1181,10 +1178,6 @@
                 this.resetRefresh(this._refresh.bind(this), 60000);
             }
 
-            setPnfsidClicked(e) {
-                this.pnfsidClicked = true;
-            }
-
             setTableSize(e) {
                 switch (e.detail.index) {
                     case 0:
@@ -1227,19 +1220,19 @@
 
             /* -------------------------- Dialogs -------------------------- */
 
-            _activeItemChanged(item) {
+            _setCurrentItem(item) {
                 if (item) {
                     this.currentItem = item;
                 }
 
-                if (typeof this.currentItem === 'undefined' ||
-                    !this.pnfsidClicked ) {
-                    return;
+                if (this.currentItem && this.pnfsidClicked) {
+                    this.openFileInfoDialog(this.currentItem.pnfsId.id, this.pool);
+                    this.pnfsidClicked = false;
                 }
+            }
 
-                this.openFileInfoDialog(this.currentItem.pnfsId.id, this.pool);
-
-                this.pnfsidClicked = false;
+            _openFileInfo() {
+                this.pnfsidClicked = true;
             }
         }
 

--- a/src/elements/dv-elements/admin/views/restores-view.html
+++ b/src/elements/dv-elements/admin/views/restores-view.html
@@ -140,7 +140,7 @@
                             </vaadin-grid-filter>
                         </template>
                         <template>
-                            <span onclick="sendRestoresTableCellClick(1)"
+                            <span onclick="_openFileInfo"
                                     class="actionable">[[item.pnfsId]]</span>
                         </template>
                     </vaadin-grid-column>
@@ -181,7 +181,7 @@
                             </vaadin-grid-filter>
                         </template>
                         <template>
-                            <span onclick="sendRestoresTableCellClick(2)"
+                            <span onclick="_openPoolInfo"
                                 class="actionable">[[item.poolCandidate]]</span>
                         </template>
                     </vaadin-grid-column>
@@ -240,12 +240,6 @@
     </template>
 
     <script>
-        function sendRestoresTableCellClick(cell) {
-            window.dispatchEvent(
-                new CustomEvent(`dv-restores-table-cell-click`, {
-                    detail: {cell: cell}}));
-        }
-
         class RestoresView extends DcacheViewMixins.AdminAutoRefresh(DcacheViewMixins.AdminBase(Polymer.Element)) {
 
             static get is() {
@@ -258,13 +252,13 @@
                         type: Object,
                     },
 
-                    currentItem: {
-                        type: Object
+                    activeItem: {
+                        type: Object,
+                        observer: '_setCurrentItem'
                     },
 
-                    cell: {
-                        type: Number,
-                        value: 0
+                    currentItem: {
+                        type: Object
                     },
 
                     tableSize: {
@@ -272,11 +266,6 @@
                         value: 0,
                         notify: true
                     },
-
-                    activeItem: {
-                        type: Object,
-                        observer: '_activeItemChanged'
-                    }
                 }
             }
 
@@ -285,7 +274,6 @@
 
                 window.addEventListener('dv-vaadin-provider-reset-timeout-restores', this.resetTimeout.bind(this));
                 window.addEventListener('dv-vaadin-provider-update-table-size-restores', this.setTableSize.bind(this));
-                window.addEventListener('dv-restores-table-cell-click', this.setCell.bind(this));
 
                 this.decorator = new DvVaadinProviderDecorator(this.$.restores,
                     null,
@@ -308,12 +296,7 @@
 
                 window.removeEventListener('dv-vaadin-provider-reset-timeout-restores', this.resetTimeout.bind(this));
                 window.removeEventListener('dv-vaadin-provider-update-table-size-restores', this.setTableSize.bind(this));
-                window.removeEventListener('dv-restores-table-cell-click', this.setCell.bind(this));
 
-            }
-
-            setCell(event) {
-                this.cell = event.detail.cell;
             }
 
             /*
@@ -344,25 +327,28 @@
 
             /* -------------------------- Dialogs -------------------------- */
 
-            _activeItemChanged(item) {
+            _setCurrentItem(item) {
                 if (item) {
-                    this.currentItem = item.detail.value;
+                    this.currentItem = item;
                 }
+            }
 
-                if (typeof this.currentItem === 'undefined' ||
-                    typeof this.cell === 'undefined') {
+            _openFileInfo() {
+                if (typeof this.currentItem === 'undefined') {
                     return;
                 }
 
-                if (this.cell === 1) {
-                    this.openFileInfoDialog(this.currentItem.pnfsId,
-                        this.currentItem.poolCandidate);
-                    this.cell = 0;
-                } else if (this.cell === 2) {
-                    this.openPoolInfoDialog(this.currentItem.poolCandidate,
-                        this.currentItem.pnfsId);
-                    this.cell = 0;
+                this.openFileInfoDialog(this.currentItem.pnfsId,
+                    this.currentItem.poolCandidate);
+            }
+
+            _openPoolInfo() {
+                if (typeof this.currentItem === 'undefined') {
+                    return;
                 }
+
+                this.openPoolInfoDialog(this.currentItem.poolCandidate,
+                    this.currentItem.pnfsId);
             }
         }
 

--- a/src/elements/dv-elements/admin/views/transfers-view.html
+++ b/src/elements/dv-elements/admin/views/transfers-view.html
@@ -359,7 +359,7 @@
                             </vaadin-grid-filter>
                         </template>
                         <template>
-                            <span onclick="sendTransfersTableCellClick(1)"
+                            <span on-tap="_openFileInfo"
                                   class="actionable">[[item.pnfsId]]</span>
                         </template>
                     </vaadin-grid-column>
@@ -382,7 +382,7 @@
                             </vaadin-grid-filter>
                         </template>
                         <template>
-                            <span onclick="sendTransfersTableCellClick(2)"
+                            <span on-tap="_openPoolInfo"
                                   class="actionable">[[item.pool]]</span>
                         </template>
                     </vaadin-grid-column>
@@ -463,12 +463,6 @@
     </template>
 
     <script>
-        function sendTransfersTableCellClick(cell) {
-            window.dispatchEvent(
-                new CustomEvent(`dv-transfers-table-cell-click`, {
-                    detail: {cell: cell}}));
-        }
-
         class TransfersView extends
             DcacheViewMixins.AdminAutoRefresh(DcacheViewMixins.AdminBase(Polymer.Element)) {
 
@@ -487,13 +481,13 @@
                         type: Object,
                     },
 
-                    currentItem: {
-                        type: Object
+                    activeItem: {
+                        type: Object,
+                        observer: '_setCurrentItem'
                     },
 
-                    cell: {
-                        type: Number,
-                        value: 0
+                    currentItem: {
+                        type: Object
                     },
 
                     count: {
@@ -517,11 +511,6 @@
                         type: Boolean,
                         value: false,
                         notify: true
-                    },
-
-                    activeItem: {
-                        type: Object,
-                        observer: '_activeItemChanged'
                     }
                 }
             }
@@ -532,7 +521,6 @@
                 window.addEventListener('dv-vaadin-provider-selection-column-clear-transfers', this.signalChange.bind(this));
                 window.addEventListener('dv-vaadin-provider-reset-timeout-transfers', this.resetTimeout.bind(this));
                 window.addEventListener('dv-vaadin-provider-update-table-size-transfers', this.setTableSize.bind(this));
-                window.addEventListener('dv-transfers-table-cell-click', this.setCell.bind(this));
 
                 this.decorator = new DvVaadinProviderDecorator(this.$.transfers,
                                                                null,
@@ -556,11 +544,6 @@
                 window.removeEventListener('dv-vaadin-provider-selection-column-clear-transfers', this.signalChange.bind(this));
                 window.removeEventListener('dv-vaadin-provider-reset-timeout-transfers', this.resetTimeout.bind(this));
                 window.removeEventListener('dv-vaadin-provider-update-table-size-transfers', this.setTableSize.bind(this));
-                window.removeEventListener('dv-transfers-table-cell-click', this.setCell.bind(this));
-            }
-
-            setCell(event) {
-                this.cell = event.detail.cell;
             }
 
             /*
@@ -633,27 +616,30 @@
 
             /* -------------------------- Dialogs -------------------------- */
 
-            _activeItemChanged(item) {
+            _setCurrentItem(item) {
                 if (item) {
                     this.currentItem = item;
                 }
+            }
 
-                if (typeof this.currentItem === 'undefined' ||
-                    typeof this.cell === 'undefined' ) {
+            _openFileInfo() {
+                if (typeof this.currentItem === 'undefined') {
                     return;
                 }
 
-                if (this.cell === 1) {
-                    this.openFileInfoDialog(this.currentItem.pnfsId,
-                        this.currentItem.pool);
-                } else if (this.cell === 2) {
-                    this.openPoolInfoDialog(this.currentItem.pool,
-                        this.currentItem.pnfsId);
-                }
+                this.openFileInfoDialog(this.currentItem.pnfsId,
+                    this.currentItem.pool);
 
-                this.cell = 0;
             }
 
+            _openPoolInfo() {
+                if (typeof this.currentItem === 'undefined') {
+                    return;
+                }
+
+                this.openPoolInfoDialog(this.currentItem.pool,
+                    this.currentItem.pnfsId);
+            }
 
             /* --------------------- Path & Mover Kill --------------------- */
 


### PR DESCRIPTION
Motivation:

raised by changes in Vaadin Grid.

This patch eliminates listeners and event functions which
take parameters (which are not being passed).

Modification:

Use parameterless methods, compensating for the different
ordering of events.

Result:

The on-tap events are correctly propagated and handled.

Target:  master
Request: 1.4
Acked-by: Olufemi