### PR TITLE
dcache-view (namespace): add esc key to the accessibility features

### DIFF
--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -468,6 +468,12 @@
                         event.key === "Meta" : event.key === "Control") {
                     this._ctrlKeyOn = false;
                 }
+
+                if (event.key === "Escape" || event.key === "Esc") {
+                    window.dispatchEvent(
+                        new CustomEvent('dv-namespace-reset-element-internal-parameters', {
+                            detail: {element: 'view-file'}, bubbles: true, composed: true}));
+                }
             }
 
             __computedXselected(xSelected)


### PR DESCRIPTION
Motivation:

When `view-file` element is in focus; to deselect files that had been selected,
user will need to click outside the listed files. At times, it might be more
desirable for the user to use the escape key.

Modiification:

Dispatch an event called `dv-namespace-reset-element-internal-parameters`
when escape key is released. This will reset all the parameters for selection
process.

Result:

User can now use escape key to deselect selected files.

Target: master
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan <tigran.mkrtchyan@desy.de>

Reviewed at https://rb.dcache.org/r/10982/

(cherry picked from commit 83fdc4e5d4e7aba56ef657d0e8d16adfdf2b004c)