### PR TITLE
dcache-view: filter toggle-all on pools

### DIFF
--- a/src/elements/dv-elements/admin/dialogs/pools-of-group-dialog.html
+++ b/src/elements/dv-elements/admin/dialogs/pools-of-group-dialog.html
@@ -941,9 +941,10 @@
             }
 
             _toggleAll(cb) {
+                const filtered = this.$.cellinfo._filter(this.$.cellinfo.items);
                 this.selectAll
                     = this.toggleAllGridItems(this.selectAll,
-                                              this.$.cellinfo.items,
+                                              filtered,
                                               this.$.cellinfo);
                 this.indeterminate = this.computeIndeterminate(this.$.cellinfo);
                 this.selectionAction = !this.selectionAction;


### PR DESCRIPTION
Motivation:

The select/select all column on the vaadin-grid tables appear
on the pool dialog and on the active transfers tables.  In the
latter case, it is implemented on the back end, because
the data is lazy loaded.  On the pool dialog, however, the
built-in version is used.

For the built-in version, however, one needs to ensure
the items are first filtered based on the columns.  This
is not currently done.

Modification:

Add the necessary call to the table filter function.

Result:

Applying the filter and then clicking select all
selects only those items that are visible, not
the entire list of items.

Target: master
Request: 1.4
Bug: https://github.com/dCache/dcache-view/issues/89
Acked-by: Olufemi