### PR TITLE
dcache-view: bind page refresh to routing event

### DIFF
--- a/src/elements/dv-elements/admin/dv-admin-mixins.html
+++ b/src/elements/dv-elements/admin/dv-admin-mixins.html
@@ -17,25 +17,88 @@
                 return {
                     timeoutID: {
                         type: Object
+                    },
+
+                    componentPath: {
+                        type: String
+                    },
+
+                    valid: {
+                        type: Boolean,
+                        value: true
+                    },
+
+                    callback: {
+                        type: Function
+                    },
+
+                    interval: {
+                        type: Number
+                    },
+
+                    routingChangeListener: {
+                        type: Object
                     }
                 }
+            }
+
+            constructor() {
+                super();
+                this.routingChangeListener = this.validateRoute.bind(this);
+            }
+
+            connectedCallback() {
+                super.connectedCallback();
+                window.addEventListener('dv-routing-changed', this.routingChangeListener);
+            }
+
+            disconnectedCallback() {
+                super.disconnectedCallback();
+                window.removeEventListener('dv-routing-changed', this.routingChangeListener);
             }
 
             stopRefresh() {
                 if (this.timeoutID) {
                     clearTimeout(this.timeoutID);
+                    this.timeoutID == null;
                 }
             }
 
             refreshAndReset(refreshCallback, interval) {
                 this.stopRefresh();
-                refreshCallback();
-                this.timeoutID = setInterval(refreshCallback, interval);
+                if (this.valid) {
+                    refreshCallback();
+                    this.callback = refreshCallback;
+                    this.interval = interval;
+                    this.timeoutID = setInterval(refreshCallback, interval);
+                }
             }
 
             resetRefresh(refreshCallback, interval) {
                 this.stopRefresh();
-                this.timeoutID = setInterval(refreshCallback, interval);
+                if (this.valid) {
+                    this.callback = refreshCallback;
+                    this.interval = interval;
+                    this.timeoutID = setInterval(refreshCallback, interval);
+                }
+            }
+
+            validateRoute(e) {
+                /*
+                 *  The componentName will not be set on the dialog.
+                 *  Dialog refresh is turned off when the dialog box
+                 *  is closed.
+                 */
+                const previous = this.valid;
+
+                this.valid = !this.componentPath ||
+                    this.componentPath === e.detail.route.canonicalPath;
+
+                if (!this.valid) {
+                    this.stopRefresh();
+                } else if (!previous) {
+                    this.refreshAndReset(this.callback, this.interval);
+                }
             }
         }
     }

--- a/src/elements/dv-elements/admin/views/alarms-view.html
+++ b/src/elements/dv-elements/admin/views/alarms-view.html
@@ -423,6 +423,7 @@
 
             connectedCallback() {
                 super.connectedCallback();
+                this.componentPath = '/admin/alarms';
 
                 window.addEventListener('dv-vaadin-provider-selection-column-clear-alarms', this.signalChange.bind(this));
                 window.addEventListener('dv-vaadin-provider-reset-timeout-alarms', this.resetTimeout.bind(this));

--- a/src/elements/dv-elements/admin/views/billing-plots-view.html
+++ b/src/elements/dv-elements/admin/views/billing-plots-view.html
@@ -145,6 +145,7 @@
 
             connectedCallback() {
                 super.connectedCallback();
+                this.componentPath = '/admin/billing-plots';
                 this.refreshAndReset(this._sendHistogramsRequest.bind(this), 300000);
             }
 

--- a/src/elements/dv-elements/admin/views/cell-info-view.html
+++ b/src/elements/dv-elements/admin/views/cell-info-view.html
@@ -230,6 +230,7 @@
 
             connectedCallback() {
                 super.connectedCallback();
+                this.componentPath = '/admin/cell-services';
                 this.refreshAndReset(this._requestCellInfo.bind(this), 60000);
             }
 

--- a/src/elements/dv-elements/admin/views/pool-group-view.html
+++ b/src/elements/dv-elements/admin/views/pool-group-view.html
@@ -189,6 +189,7 @@
 
             connectedCallback() {
                 super.connectedCallback();
+                this.componentPath = '/admin/pool-info';
                 this.refreshAndReset(this._sendGroupRequest.bind(this), 60000);
             }
 

--- a/src/elements/dv-elements/admin/views/pool-plots-view.html
+++ b/src/elements/dv-elements/admin/views/pool-plots-view.html
@@ -351,6 +351,11 @@
                 }
             }
 
+            connectedCallback() {
+                super.connectedCallback();
+                this.componentPath = '/admin/pool-plots';
+            }
+
             _down(e) {
                 e.stopPropagation();
                 this.selectedGroup = e.model.item.title;

--- a/src/elements/dv-elements/admin/views/restores-view.html
+++ b/src/elements/dv-elements/admin/views/restores-view.html
@@ -271,6 +271,7 @@
 
             connectedCallback() {
                 super.connectedCallback();
+                this.componentPath = '/admin/tape-transfer-queue';
 
                 window.addEventListener('dv-vaadin-provider-reset-timeout-restores', this.resetTimeout.bind(this));
                 window.addEventListener('dv-vaadin-provider-update-table-size-restores', this.setTableSize.bind(this));

--- a/src/elements/dv-elements/admin/views/transfers-view.html
+++ b/src/elements/dv-elements/admin/views/transfers-view.html
@@ -517,6 +517,7 @@
 
             connectedCallback() {
                 super.connectedCallback();
+                this.componentPath = '/admin/active-transfers';
 
                 window.addEventListener('dv-vaadin-provider-selection-column-clear-transfers', this.signalChange.bind(this));
                 window.addEventListener('dv-vaadin-provider-reset-timeout-transfers', this.resetTimeout.bind(this));

--- a/src/elements/routing.html
+++ b/src/elements/routing.html
@@ -24,6 +24,10 @@
         // Routes
         page('*', function(ctx, next) {
             next();
+            window.dispatchEvent(new CustomEvent('dv-routing-changed',
+                {
+                    detail: { route: ctx }, bubbles: true, composed: true
+                }));
         });
 
         page('/', function() {


### PR DESCRIPTION
Motivation:

Many of the admin view pages and dialogs use setInterval to
refresh the data automatically.  In terms of deactivation,
the dialogs currently behave correctly because the timer
is explicitly stopped when the dialog is closed.  For the
page views, however, the refresh continues once the page
is loaded, regardless of whether the page is the current
routing target or not.  This is suboptimal, as there is
no need to refresh data for invisible pages.

Modification:

A window event, dv-routing-changed, is now propagated from the
appropriate place on the routing page.  The mixin
implements the necessary logic for turning the refresh
on and off.  Each non-dialog component which uses
refresh now sets its component path internally so
that a validation check can be made.  Refresh
occurs only if the valid flag is true.

Result:

When switching between views, refresh is cancelled
for all but the page which is visible, if it uses
refresh.

Target: master
Request: 1.4
Issue: https://github.com/dCache/dcache-view/issues/91
Acked-by: Olufemi