### PR TITLE
dcache-view (user): make user-profile page aware of asserted roles

### DIFF
--- a/src/elements/dv-elements/user-profile/user-profile.html
+++ b/src/elements/dv-elements/user-profile/user-profile.html
@@ -197,7 +197,7 @@
                             <span> No roles to assert</span>
                         </div>
                     </div>
-                    <template is="dom-repeat" items="[[listOfPossibleRoles]]">
+                    <template is="dom-repeat" items="[[listOfAllRoles]]">
                         <div class="display-flex row vertically-align">
                             <div class="label label-addPadding">[[item]]</div>
                             <div class="value flex"></div>
@@ -267,12 +267,19 @@
                         return sessionStorage.homeDirectory;
                     }
                 },
-                listOfPossibleRoles: {
+                listOfAllRoles: {
                     type: Array,
                     notify: true,
                     value: function () {
-                        let x = sessionStorage.listOfPossibleRoles;
-                        return x === undefined || x === "" ? [] : x.split(",");
+                        const x = sessionStorage.listOfPossibleRoles === undefined ||
+                        sessionStorage.listOfPossibleRoles === "" ?
+                            [] : sessionStorage.listOfPossibleRoles.split(",");
+                        const y = sessionStorage.roles === undefined ||
+                        sessionStorage.roles === "" ? [] : sessionStorage.roles.split(",");
+
+                        return x.concat(y.filter(function (item) {
+                            return x.indexOf(item) < 0;
+                        }));
                     }
                 }
             },
@@ -285,7 +292,7 @@
 
             _computedClass: function (str)
             {
-                const listOfPossibleRoles = sessionStorage.listOfPossibleRoles;
+                const listOfPossibleRoles = this.listOfAllRoles;
 
                 if (listOfPossibleRoles === "" || listOfPossibleRoles === null ||
                     listOfPossibleRoles === undefined) {
@@ -295,11 +302,7 @@
                     if (str === "no-roles") {
                         return ' hide row';
                     } else if (str === "all-roles") {
-                        if (listOfPossibleRoles.split(",").length === 1) {
-                            return ' hide';
-                        } else {
-                            return ' toggleBtn';
-                        }
+                        return listOfPossibleRoles.split(",").length === 1 ? ' hide' : ' toggleBtn';
                     } else {
                         return ' paper-material-inner display-flex column';
                     }


### PR DESCRIPTION
Motivation:

When user asserted roles by using `<username>#<roles>` through
the username textbox of the login page, the asserted role is not
reflected in the user-profile page.

Modification:

Combine the list of un-asserted roles with the list of possible roles.
Therefore, the generated list reflect the actual list of all roles.

Result:

The user profile page show the asserted roles when asserting the roles
through the login-page.

Target: master
Request: 1.4
Request: 1.3
Require-notes: no
Require-book: no
Fixes: https://github.com/dCache/dcache-view/issues/100
Acked-by: Tigran Mkrtchyan

Reviewed at https://rb.dcache.org/r/11029/

(cherry picked from commit 870f683280e92f2abc4a364073eb12fe2756391b)