### PR TITLE
dcache-view (namespace): style file-icon when list-row is selected

### DIFF
--- a/src/elements/dv-elements/list-view/list-row.html
+++ b/src/elements/dv-elements/list-view/list-row.html
@@ -76,12 +76,15 @@
                 padding-left: 15px;
                 padding-right: 10px
             }
+            file-icon[selected] {
+                fill: white !important;
+            }
             .none {
                 display: none;
             }
         </style>
         <div id="row" class="row">
-            <file-icon mime-type="[[fileMetaData.fileMimeType]]"></file-icon>
+            <file-icon mime-type="[[fileMetaData.fileMimeType]]" selected$="[[xSelected]]"></file-icon>
             <div class="cell name">
                 <div id="nameContainer">
                     <span id="fileName">[[fileMetaData.fileName]]</span>


### PR DESCRIPTION
The background and text color of selected file are changed
to indicate to the end-user that the file is selected.
Sadly, this styling doesn't apply to the file-icons' and
this make it less appealing.

Modification:

Add selected attribute to file-icon tag and when set to true
the color of the file-icon element change to white.

Result:

Better styling.

Target: master
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan

Reviewed at https://rb.dcache.org/r/10981/

(cherry picked from commit f95504879c42c863390d890549768cc6ac321859)