### PR TITLE
dcache-view (namespace): minor fixes in dnd upload

### DIFF
--- a/src/elements/dv-elements/drag-and-drop/dnd-upload.html
+++ b/src/elements/dv-elements/drag-and-drop/dnd-upload.html
@@ -153,19 +153,12 @@
 
         start(event)
         {
-            if (!window.CONFIG.isSomebody) {
-                window.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
-                    detail: {message: `You need to login to perform this operation.`},
-                    bubbles: true, composed: true}));
-                return;
-            }
             window.dispatchEvent(new CustomEvent('dv-namespace-close-upload-toast', {
                 bubbles: true, composed: true}));
 
             const items = event.dataTransfer.items;
             window.dispatchEvent(new CustomEvent('dv-namespace-open-upload-toast', {
                 bubbles: true, composed: true}));
-            const uploadList = app.$.uploadToast.querySelector("#uploadList");
 
             if (items === undefined) {
                 const files = event.dataTransfer.files;
@@ -183,7 +176,8 @@
                     } else if (item.isDirectory) {
                         const uploadToast = new UploadToastFile(item.name, "DIR", "application/vnd.dcache.folder");
                         uploadToast.setAttribute("id", i.toString());
-                        uploadList.appendChild(uploadToast);
+                        this.dispatchEvent(new CustomEvent('dv-namespace-upload-toast-append-child', {
+                            detail: {child: uploadToast}, bubbles: true, composed: true}));
                         const progressBar = uploadToast.shadowRoot.querySelector('paper-progress');
 
                         this.__createNewDirectory(item.name, this.path).then(name => {


### PR DESCRIPTION
Motivation:

Currently, dcache-view prevent upload of files if credential
are not supplied. This might be undesirable when a site allows
anonymous user to upload.

Modification:

- Send upload request to dcache with or with credential.
- Use events to append child to the upload toast.

Result:

Allow dcache to handle upload request as it see fit.

Target: master
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Albert Rossi

Reviewed at https://rb.dcache.org/r/10996/

(cherry picked from commit bc1a6a8dc94f0788c870620874265d368a9214fa)