### PR TITLE
dcache-view: show admin toolbox button only if role is asserted

### DIFF
--- a/src/elements/dv-elements/user-authentication/auth-behaviour/role-request.html
+++ b/src/elements/dv-elements/user-authentication/auth-behaviour/role-request.html
@@ -64,6 +64,8 @@
                 });
                 window.addEventListener('dv-authentication-successful', (e) => {
                     this.resolveAssertion(listOfRolesToAssert);
+                    window.CONFIG.isAdmin = listOfRolesToAssert.includes('admin');
+                    app.notifyPath('config.isAdmin');
                 });
                 userAuth.send("Basic");
 

--- a/src/elements/routing.html
+++ b/src/elements/routing.html
@@ -17,6 +17,8 @@
 
         // Middleware
         window.CONFIG.isSomebody = sessionStorage.upauth !== undefined;
+        window.CONFIG.isAdmin = sessionStorage.roles !== undefined &&
+            sessionStorage.roles.includes('admin');
         app.config = window.CONFIG;
         app.organisationName = window.CONFIG["dcache-view.org-name"];
 
@@ -43,11 +45,20 @@
         });
 
         page('/admin', function() {
+            if (!window.CONFIG.isAdmin) {
+                page.redirect(app.baseUrl);
+                return;
+            }
             app.route = 'admin';
             app.params = "";
         });
 
         page('/admin/:component', function(data) {
+            if (!window.CONFIG.isAdmin) {
+                page.redirect(app.baseUrl);
+                return;
+            }
+
             app.route = 'admin-component-page';
             app.params = data.params;
 

--- a/src/index.html
+++ b/src/index.html
@@ -244,11 +244,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                         </a>
                                     </paper-item>
 
-                                    <paper-item>
-                                        <a data-route="admin" href$="{{baseUrl}}admin"><!--dashboard-->
-                                            <paper-fab icon="supervisor-account" title="admin" class="green" mini></paper-fab>
-                                        </a>
-                                    </paper-item>
+                                    <template is="dom-if" if="[[config.isAdmin]]">
+                                        <paper-item>
+                                            <a data-route="admin" href$="{{baseUrl}}admin"><!--dashboard-->
+                                                <paper-fab icon="supervisor-account" title="admin" class="green" mini></paper-fab>
+                                            </a>
+                                        </paper-item>
+                                    </template>
 
                                     <template is="dom-if" if="[[config.isSomebody]]">
                                         <paper-item>


### PR DESCRIPTION
Motivation:

Only allow users with role 'admin' asserted to see the toolbox.

Modification:

Create config.isAdmin variable, notify when role is asserted
and use dom-if as with user icon.

Result:

Admin pages are only available to admins.

Target: master
Request: 1.4
Acked-by:  Olufemi