### PR TITLE
dcache-view (namespace): fix issue with role assertion

### DIFF
--- a/src/elements/dv-elements/user-authentication/auth-behaviour/role-request.html
+++ b/src/elements/dv-elements/user-authentication/auth-behaviour/role-request.html
@@ -39,17 +39,11 @@
                     return;
                 }
 
-                let newUnencodedAuth;
                 const oldAuth = window.atob(sessionStorage.upauth);
-                if (!oldAuth.startsWith(sessionStorage.name+"#")) {
-                    //first time of asserting roles
-                    window.CONFIG.salt = oldAuth.replace(sessionStorage.name,"");
-                    newUnencodedAuth = oldAuth.replace(sessionStorage.name, sessionStorage.name+"#" +
-                        listOfRolesToAssert);
-                } else {
-                    newUnencodedAuth = listOfRolesToAssert === "" ? sessionStorage.name + window.CONFIG.salt :
-                        sessionStorage.name + "#" + listOfRolesToAssert + window.CONFIG.salt;
-                }
+                const newUnencodedAuth = !oldAuth.startsWith(sessionStorage.name + "#") ?
+                    `${oldAuth.replace(sessionStorage.name, sessionStorage.name + `#${listOfRolesToAssert}`)}` :
+                    listOfRolesToAssert === "" ? `${sessionStorage.name}${sessionStorage.password}` :
+                    `${sessionStorage.name}#${listOfRolesToAssert}${sessionStorage.password}`;
                 const auth = window.btoa(newUnencodedAuth);
 
                 let userAuth = new UserAuthentication(redirectTo, auth, sessionStorage.listOfPossibleRoles, "");

--- a/src/elements/dv-elements/user-authentication/auth-behaviour/user-authentication.html
+++ b/src/elements/dv-elements/user-authentication/auth-behaviour/user-authentication.html
@@ -82,6 +82,7 @@
             {
                 this.auth = null;
                 sessionStorage.removeItem("name");
+                sessionStorage.removeItem("password");
                 let errorXHR = request.request.__data__.xhr.response.errors[0];
                 this.errorMessage = errorXHR.message+ '! Please check that you have supplied ' +
                     'the correct credentials. ';
@@ -175,4 +176,3 @@
         });
     </script>
 </dom-module>
-

--- a/src/elements/dv-elements/user-authentication/login-form.html
+++ b/src/elements/dv-elements/user-authentication/login-form.html
@@ -151,11 +151,13 @@
                 }
 
                 let up = this.username + ":" + this.password;
+                sessionStorage.setItem("password", `:${this.password}`);
                 this.auth = window.btoa(up);
                 const listOfRolesToAssert = this.assertionStatus?"*":"";
                 let userAuth = new UserAuthentication(this.redirectTo, this.auth, "", listOfRolesToAssert);
 
                 userAuth.addEventListener('error', (e) => {
+                    sessionStorage.removeItem("password");
                     this.errorMessage = e.detail.message;
                 });
 


### PR DESCRIPTION
Motivation:

When a user assert a role and reload the page; the user un-assertion
request will be rejected. The reason is because the information store
in the window during role asssertion were lost after reloading. This
issue was recently reported here:
https://github.com/dCache/dcache-view/issues/98

Modification:

Store the information inside session storage instead of window.CONFIG

Result:

Roles can be properly asserted and un-asserted.

Target: master
Request: 1.4
Request: 1.3
Require-notes: no
Require-book: no
Acked-by: Paul Millar
Fixes: https://github.com/dCache/dcache-view/issues/98

Reviewed at https://rb.dcache.org/r/11024/

(cherry picked from commit 9b9b91cca1f8224fa5ce3cefaad1fa6b863402b3)