### PR TITLE
dcache-view (namespace): use custom event to open and close context menu

### DIFF
--- a/src/elements/dv-elements/contextual-content/change-qos-context-menu.html
+++ b/src/elements/dv-elements/contextual-content/change-qos-context-menu.html
@@ -99,8 +99,12 @@
 
             _changeQos(e)
             {
-                app.$.centralSubContextMenu.close();
-                app.$.centralContextMenu.close();
+                this.dispatchEvent(new CustomEvent('dv-namespace-close-subcontextmenu', {
+                    bubbles: true, composed: true
+                }));
+                this.dispatchEvent(new CustomEvent('dv-namespace-close-centralcontextmenu', {
+                    bubbles: true, composed: true
+                }));
                 const namespace = document.createElement('dcache-namespace');
                 namespace.auth = sessionStorage.upauth;
 

--- a/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
+++ b/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
@@ -249,44 +249,54 @@
             {
                 if (window.CONFIG.isSomebody && e.composedPath()[0].id === "changeQos") {
                     this.dispatchEvent(
-                        new CustomEvent('dv-namespace-namespace-open-subcontextmenu', {
+                        new CustomEvent('dv-namespace-open-subcontextmenu', {
                             detail: {targetNode: this.targetNode}, bubbles: true, composed: true}));
                 }
                 if (e.composedPath()[0].id !== "changeQos") {
-                    app.$.centralSubContextMenu.close();
+                    this.dispatchEvent(new CustomEvent('dv-namespace-close-subcontextmenu', {
+                        bubbles: true, composed: true
+                    }));
                 }
             }
 
             _openOrDownload()
             {
-                app.$.centralContextMenu.close();
+                this.dispatchEvent(new CustomEvent('dv-namespace-close-centralcontextmenu', {
+                    bubbles: true, composed: true
+                }));
                 this.dispatchEvent(
-                    new CustomEvent('dv-namespace-namespace-open-file', {
+                    new CustomEvent('dv-namespace-open-file', {
                         detail: {file: this.targetNode}, bubbles: true, composed: true}));
             }
 
             _metadata()
             {
-                app.$.centralContextMenu.close();
+                this.dispatchEvent(new CustomEvent('dv-namespace-close-centralcontextmenu', {
+                    bubbles: true, composed: true
+                }));
                 if (!this.targetNode.filePath) {
                     this.targetNode.filePath = this.currentPath;
                 }
                 this.dispatchEvent(
-                    new CustomEvent('dv-namespace-namespace-open-filemetadata-panel', {
+                    new CustomEvent('dv-namespace-open-filemetadata-panel', {
                         detail: {file: this.targetNode}, bubbles: true, composed: true}));
             }
 
             _rename()
             {
-                app.$.centralContextMenu.close();
+                this.dispatchEvent(new CustomEvent('dv-namespace-close-centralcontextmenu', {
+                    bubbles: true, composed: true
+                }));
                 this.dispatchEvent(
-                    new CustomEvent('dv-namespace-namespace-open-rename-dialogbox', {
+                    new CustomEvent('dv-namespace-open-rename-dialogbox', {
                         detail: {file: this.targetNode}, bubbles: true, composed: true}));
             }
 
             _move()
             {
-                app.$.centralContextMenu.close();
+                this.dispatchEvent(new CustomEvent('dv-namespace-close-centralcontextmenu', {
+                    bubbles: true, composed: true
+                }));
                 let noOfMovedItems = 1;
                 let fileType = "item";
                 const mv = document.createElement('move-file');
@@ -305,7 +315,7 @@
                     this.dispatchEvent(new CustomEvent('dv-namespace-remove-items', {
                         detail: {files: mv.mvFiles},bubbles: true, composed: true}));
                     this.dispatchEvent(
-                        new CustomEvent('dv-namespace-namespace-close-central-dialogbox', {
+                        new CustomEvent('dv-namespace-close-central-dialogbox', {
                             bubbles: true, composed: true}));
 
                     this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast',
@@ -321,7 +331,7 @@
                 });
                 mv.addEventListener('dismiss', function (e) {
                     this.dispatchEvent(
-                        new CustomEvent('dv-namespace-namespace-close-central-dialogbox', {
+                        new CustomEvent('dv-namespace-close-central-dialogbox', {
                             bubbles: true, composed: true}));
                 });
                 mv.addEventListener('move-create', function (e) {
@@ -339,13 +349,15 @@
                 });
 
                 this.dispatchEvent(
-                    new CustomEvent('dv-namespace-namespace-open-central-dialogbox', {
+                    new CustomEvent('dv-namespace-open-central-dialogbox', {
                         detail: {node: mv}, bubbles: true, composed: true}));
             }
 
             _delete()
             {
-                app.$.centralContextMenu.close();
+                this.dispatchEvent(new CustomEvent('dv-namespace-close-centralcontextmenu', {
+                    bubbles: true, composed: true
+                }));
                 if (sessionStorage.upauth === null || sessionStorage.upauth === undefined) {
                     this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast',
                         {detail: {message: "You need to login to delete file(s)."}, bubbles: true, composed: true}));
@@ -390,7 +402,9 @@
 
             _create()
             {
-                app.$.centralContextMenu.close();
+                this.dispatchEvent(new CustomEvent('dv-namespace-close-centralcontextmenu', {
+                    bubbles: true, composed: true
+                }));
 
                 const mkdir = document.createElement('create-directory');
                 mkdir.dirFullPath = this.currentPath;
@@ -401,7 +415,7 @@
 
                     namespace.promise.then(() => {
                         this.dispatchEvent(
-                            new CustomEvent('dv-namespace-namespace-close-central-dialogbox', {
+                            new CustomEvent('dv-namespace-close-central-dialogbox', {
                                 bubbles: true, composed: true}));
                         const file = {
                             "fileName" : e.detail.newFolderName,
@@ -433,25 +447,29 @@
                 });
                 mkdir.addEventListener('close',function() {
                     this.dispatchEvent(
-                        new CustomEvent('dv-namespace-namespace-close-central-dialogbox', {
+                        new CustomEvent('dv-namespace-close-central-dialogbox', {
                             bubbles: true, composed: true}));
                 });
                 this.dispatchEvent(
-                    new CustomEvent('dv-namespace-namespace-open-central-dialogbox', {
+                    new CustomEvent('dv-namespace-open-central-dialogbox', {
                         detail: {node: mkdir}, bubbles: true, composed: true}));
             }
 
             _upload()
             {
                 //FIXME: context menu stay opened even long after the file picker appears.
-                app.$.centralContextMenu.close();
+                this.dispatchEvent(new CustomEvent('dv-namespace-close-centralcontextmenu', {
+                    bubbles: true, composed: true
+                }));
                 this.dispatchEvent(new CustomEvent('dv-namespace-upload-files', {
                     detail:{}, bubbles: true, composed: true}));
             }
 
             _qosInfo()
             {
-                app.$.centralContextMenu.close();
+                this.dispatchEvent(new CustomEvent('dv-namespace-close-centralcontextmenu', {
+                    bubbles: true, composed: true
+                }));
 
                 if (!window.CONFIG.isSomebody) {
                     this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast',
@@ -469,7 +487,7 @@
 
                 const content = document.createElement('qbi-dialog-content');
                 this.dispatchEvent(
-                    new CustomEvent('dv-namespace-namespace-open-central-dialogbox', {
+                    new CustomEvent('dv-namespace-open-central-dialogbox', {
                         detail: {node: content}, bubbles: true, composed: true}));
             }
 

--- a/src/elements/dv-elements/list-view/list-row.html
+++ b/src/elements/dv-elements/list-view/list-row.html
@@ -279,7 +279,7 @@
             _openFileLoc()
             {
                 this.dispatchEvent(
-                    new CustomEvent('dv-namespace-namespace-open-file', {
+                    new CustomEvent('dv-namespace-open-file', {
                         detail: {file: this}, bubbles: true, composed: true}));
             }
 

--- a/src/elements/dv-elements/selected-title/selected-title.html
+++ b/src/elements/dv-elements/selected-title/selected-title.html
@@ -243,7 +243,7 @@
                 path = this.isSelected ? `${path}/${this._selectedItems[0].fileName}` : path === "" ? '/' : path;
 
                 this.dispatchEvent(
-                    new CustomEvent('dv-namespace-namespace-open-filemetadata-panel', {
+                    new CustomEvent('dv-namespace-open-filemetadata-panel', {
                         detail: {file: {
                             filePath: path,
                             fileMetaData: this.isSelected ? Object.assign({}, this._selectedItems[0]): undefined
@@ -264,7 +264,7 @@
 
                     namespace.auth = app.getAuthValue();
                     namespace.promise.then(() => {
-                        this.dispatchEvent(new CustomEvent('dv-namespace-namespace-close-central-dialogbox', {
+                        this.dispatchEvent(new CustomEvent('dv-namespace-close-central-dialogbox', {
                             detail: {}, bubbles: true, composed: true})
                         );
 
@@ -298,12 +298,12 @@
                     });
                 });
                 mkdir.addEventListener('close', () => {
-                    this.dispatchEvent(new CustomEvent('dv-namespace-namespace-close-central-dialogbox', {
+                    this.dispatchEvent(new CustomEvent('dv-namespace-close-central-dialogbox', {
                         detail: {}, bubbles: true, composed: true})
                     );
                 });
 
-                this.dispatchEvent(new CustomEvent('dv-namespace-namespace-open-central-dialogbox',{
+                this.dispatchEvent(new CustomEvent('dv-namespace-open-central-dialogbox',{
                     detail: {node: mkdir}, bubbles: true, composed: true
                 }));
             }
@@ -320,7 +320,7 @@
                 mv.addEventListener('move', (e) => {
                     this.dispatchEvent(new CustomEvent('dv-namespace-remove-items', {
                         detail: {files: mv.mvFiles},bubbles: true, composed: true}));
-                    this.dispatchEvent(new CustomEvent('dv-namespace-namespace-close-central-dialogbox', {
+                    this.dispatchEvent(new CustomEvent('dv-namespace-close-central-dialogbox', {
                         detail: {}, bubbles: true, composed: true})
                     );
                     this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
@@ -335,7 +335,7 @@
                     );
                 });
                 mv.addEventListener('dismiss', function (e) {
-                    this.dispatchEvent(new CustomEvent('dv-namespace-namespace-close-central-dialogbox',{
+                    this.dispatchEvent(new CustomEvent('dv-namespace-close-central-dialogbox',{
                         detail: {}, bubbles: true, composed: true
                     }));
                 });
@@ -353,7 +353,7 @@
                             detail: {files: [file]},bubbles: true, composed: true}));
                 });
 
-                this.dispatchEvent(new CustomEvent('dv-namespace-namespace-open-central-dialogbox',{
+                this.dispatchEvent(new CustomEvent('dv-namespace-open-central-dialogbox',{
                     detail: {node: mv}, bubbles: true, composed: true
                 }));
             }

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -149,7 +149,7 @@
                 window.addEventListener('dv-namespace-request-current-path', this._sendCurrentPath_);
                 window.addEventListener('dv-namespace-request-item-index', this._sendItemIndex_);
                 window.addEventListener('dv-namespace-reset-element-internal-parameters', this._reset_);
-                window.addEventListener('dv-namespace-namespace-open-rename-dialogbox', this._renameInputStart_);
+                window.addEventListener('dv-namespace-open-rename-dialogbox', this._renameInputStart_);
             }
             disconnectedCallback()
             {
@@ -165,7 +165,7 @@
                 window.removeEventListener('dv-namespace-request-current-path', this._sendCurrentPath_);
                 window.removeEventListener('dv-namespace-request-item-index', this._sendItemIndex_);
                 window.removeEventListener('dv-namespace-reset-element-internal-parameters', this._reset_);
-                window.removeEventListener('dv-namespace-namespace-open-rename-dialogbox', this._renameInputStart_);
+                window.removeEventListener('dv-namespace-open-rename-dialogbox', this._renameInputStart_);
             }
             static get is()
             {
@@ -421,10 +421,10 @@
             _multipleSelectionShortcuts(event)
             {
                 if ((window.navigator.platform.match("Mac")
-                        ? event.metaKey : event.ctrlKey) && event.key === "ArrowUp") {
+                    ? event.metaKey : event.ctrlKey) && event.key === "ArrowUp") {
                     this.__arrowUpDown_CtrlShift('up');
                 } else if ((window.navigator.platform.match("Mac")
-                        ? event.metaKey : event.ctrlKey) && event.key === "ArrowDown") {
+                    ? event.metaKey : event.ctrlKey) && event.key === "ArrowDown") {
                     this.__arrowUpDown_CtrlShift('down');
                 } else if (event.shiftKey && event.key === "ArrowUp") {
                     this.__arrowUpDown_CtrlShift('up');
@@ -465,7 +465,7 @@
                 }
 
                 if (window.navigator.platform.match("Mac") ?
-                        event.key === "Meta" : event.key === "Control") {
+                    event.key === "Meta" : event.key === "Control") {
                     this._ctrlKeyOn = false;
                 }
 
@@ -700,7 +700,7 @@
                 const idx = this.__getItemCurrentIndex(file);
 
                 if (keyValue === 'arrow-down' && arrowType === 'up'
-                        || keyValue === 'arrow-up' && arrowType === 'down') {
+                    || keyValue === 'arrow-up' && arrowType === 'down') {
                     this._removeXSelected(idx);
                     this._temporarySelectedItemsHolder.pop();
                     this.__getAllItemsXSelected();

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -561,7 +561,7 @@
     window.addEventListener('dv-namespace-drop', (e)=>{
         app.drop(e);
     });
-    window.addEventListener('dv-namespace-namespace-open-file', function (e) {
+    window.addEventListener('dv-namespace-open-file', function (e) {
         if (e.detail.file.fileMetaData.fileType === "DIR") {
             app.ls(e.detail.file.filePath);
             Polymer.dom.flush();
@@ -571,12 +571,22 @@
             const path = webdav === "" ?
                 `${window.location.protocol}//${window.location.hostname}:2880${e.detail.file.filePath}` :
                 webdav.endsWith("/") ? `${webdav.substring(0, webdav.length - 1)}${e.detail.file.filePath}` :
-                `${webdav}${e.detail.file.filePath}`;
+                    `${webdav}${e.detail.file.filePath}`;
             window.open(path);
         }
     });
-    window.addEventListener('dv-namespace-namespace-open-subcontextmenu', e => app.subContextMenu(e));
-    window.addEventListener('dv-namespace-namespace-open-filemetadata-panel', e => {
+    window.addEventListener('dv-namespace-open-subcontextmenu', e => app.subContextMenu(e));
+    window.addEventListener('dv-namespace-close-subcontextmenu', () => {
+        app.$.centralSubContextMenu.close();
+    });
+
+    window.addEventListener('dv-namespace-open-centralcontextmenu', () => {
+        app.$.centralContextMenu.open();
+    });
+    window.addEventListener('dv-namespace-close-centralcontextmenu', () => {
+        app.$.centralContextMenu.close();
+    });
+    window.addEventListener('dv-namespace-open-filemetadata-panel', e => {
         if (app.$.metadata.selected === "main") {
             app.removeAllChildren(app.$.metadataDrawer);
             const file = e.detail.file;
@@ -589,12 +599,12 @@
             app.$.metadata.closeDrawer();
         }
     });
-    window.addEventListener('dv-namespace-namespace-open-central-dialogbox',(e)=>{
+    window.addEventListener('dv-namespace-open-central-dialogbox',(e)=>{
         app.removeAllChildren(app.$.centralDialogBox);
         app.$.centralDialogBox.appendChild(e.detail.node);
         app.$.centralDialogBox.open()
     });
-    window.addEventListener('dv-namespace-namespace-close-central-dialogbox',()=>{
+    window.addEventListener('dv-namespace-close-central-dialogbox',()=>{
         app.$.centralDialogBox.close();
     });
     window.addEventListener('dv-authentication-successful', (e) => {


### PR DESCRIPTION
Motivation:

Since updating dcache-view to polymer 2.x, we've been adjusting
our code to follow the industry standard of not accessing parent
node from a child node. This patch applies this style to the
context menu.

Modification:

1. adjust part of dcache-view to use events to open or close
context/sub-context menu.
2. correct typo errors by changing the event names from
`dv-namespace-namespace-...` to `dv-namespace-...`.

Result:

No visible changes to the user.

Target: master
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11075/

(cherry picked from commit da88fa3d64e63c6ed52962f67b4128d949076a21)