### PR TITLE
dcache-view (authentication): fix admin role assertion for showing ad…

### DIFF
--- a/src/elements/dv-elements/user-authentication/auth-behaviour/role-request.html
+++ b/src/elements/dv-elements/user-authentication/auth-behaviour/role-request.html
@@ -58,8 +58,6 @@
                 });
                 window.addEventListener('dv-authentication-successful', (e) => {
                     this.resolveAssertion(listOfRolesToAssert);
-                    window.CONFIG.isAdmin = listOfRolesToAssert.includes('admin');
-                    app.notifyPath('config.isAdmin');
                 });
                 userAuth.send("Basic");
 

--- a/src/elements/dv-elements/user-authentication/auth-behaviour/user-authentication.html
+++ b/src/elements/dv-elements/user-authentication/auth-behaviour/user-authentication.html
@@ -144,7 +144,8 @@
                     page("/"+this.redirectTo.page);
                 }
                 window.dispatchEvent(new CustomEvent('dv-authentication-successful', {
-                    detail: {message: 'login successful'}}));
+                    detail: {message: 'login successful', roles: roles}
+                }));
             } else if (request.target.response.status === "ANONYMOUS") {
                 const errMsg = 'Login failed. Please check that you have supplied ' +
                     'the correct credentials. ';

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -626,4 +626,8 @@
         app.$.toast.text = `${e.detail.message} `;
         app.$.toast.show()
     });
+    window.addEventListener('dv-authentication-successful', (e) => {
+        window.CONFIG.isAdmin = e.detail.roles.includes('admin');
+        app.notifyPath('config.isAdmin');
+    });
 })(document);


### PR DESCRIPTION
…min page

Motivation:

Roles can be asserted in dcache-view in one of these three ways, by:
 a. using the toggle botton on the user-profile page (if the user had
  already been authenticated);
 b. typing `<username>#<comma-seperated-roles-list>` in the username
  textbox of the login page; and
 c. setting the checkbox for "Assert all roles" to true.

Since the admin page will only be visible to user with admin role, hence
when user assert the admin role by using the option two, this is not
the case.

Modification:

Listen to `dv-authentication-successful` event in the dv.js and response
accordingly when admin role is asserted.

Result:

Admin page will be accessible when a admin role is asserted and
irrespective how it is asserted.

Target: master
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Paul Millar
Acked-by: Albert Rossi

Reviewed at https://rb.dcache.org/r/11091/

(cherry picked from commit 7eca23e08ff3d43286cf5f70640daa36a2c2a942)