### PR TITLE
dcache-view (authentication): remove state from the required parameter

### DIFF
--- a/src/elements/routing.html
+++ b/src/elements/routing.html
@@ -144,8 +144,7 @@
         // 404
         page('*', function() {
             let href = window.location.href;
-            if (href.includes("state") && href.includes("access_token") && href.includes("id_token")
-                && href.includes("token_type")) {
+            if (href.includes("access_token") && href.includes("id_token") && href.includes("token_type")) {
 
                 let arr = href.split("/#!/#");
                 let v = arr[1].split('&');


### PR DESCRIPTION
Motivation:

When handling redirect from an openID connect request, dcache-view
check if all required parameters were presented in the redirect
url. This parameters varies, depending on the request.

One of this parameter is the state parameter, which is defined as
"Opaque value used to maintain state between the request and the
callback. Typically, Cross-Site Request Forgery (CSRF, XSRF)
mitigation is done by cryptographically binding the value of this
parameter with a browser cookie". This is a recommended parameter
and shouldn't be required especially when the request doesn't
include one.

Modification:

Remove state parameter from the required parameters since it is
not part of the request send.

Result:

OpenID connect works as excepted.

Target: master
Request: 1.4
Request: 1.3
Require-book: no
Require-notes: no
Acked-by: Paul Millar
Acked-by: Albert Rossi

Reviewed at https://rb.dcache.org/r/11121/

(cherry picked from commit 75c13184b53f15641c82763ffc7653fbfd5ad27a)