### PR TITLE
dcache-view (authentication): fix openid connect redirect handling

### DIFF
--- a/src/elements/routing.html
+++ b/src/elements/routing.html
@@ -143,26 +143,21 @@
 
         // 404
         page('*', function() {
-            let href = window.location.href;
-            if (href.includes("access_token") && href.includes("id_token") && href.includes("token_type")) {
+            /**
+             * Handle OpenID Connect Server Redirect
+             */
+            const url = window.location.href;
+            if (url.includes("access_token")) {
+                const accessToken = new URL(url).hash.split('&').filter(function(el) {
+                    if(el.match('access_token') !== null) return true; })[0].split('=')[1];
+                const redirectInfoObj = JSON.parse(sessionStorage.getItem('redirect'));
+                const userAuth = new UserAuthentication(redirectInfoObj, accessToken, "", "");
 
-                let arr = href.split("/#!/#");
-                let v = arr[1].split('&');
-                const len = v.length;
-                let oidcProviderResponse = {};
-
-                for (let i=0; i<len; i++) {
-                    let a = v[i].split('=');
-                    oidcProviderResponse[a[0].trim()] = a[1].trim();
-                }
-
-                let redirectInfoObj = JSON.parse(sessionStorage.getItem('redirect'));
-                let userAuth = new UserAuthentication(redirectInfoObj, oidcProviderResponse.access_token, "", "");
-
-                window.addEventListener('error', (e) => {
-                    const a = '"page":'+ redirectInfoObj.page + ',"path":"' + redirectInfoObj.path + '"';
-                    let pathName = '/user-login?r=' + encodeURIComponent(a);
-                    page(pathName);
+                window.addEventListener('dv-authentication-error', (e) => {
+                    sessionStorage.removeItem('authType');
+                    sessionStorage.removeItem('nonce');
+                    const searchParams = `"page":"${redirectInfoObj.page}","path":"${redirectInfoObj.path}"`;
+                    page(`/user-login?r=${encodeURIComponent(searchParams)}`);
                     app.$.toast.text = e.detail.message + " ";
                     app.$.toast.show();
                 });
@@ -172,7 +167,7 @@
                 return;
             }
 
-            app.$.toast.text = 'Can\'t find: ' + href  + '. Redirected you to Home Page';
+            app.$.toast.text = `Can't find: ${url}. Redirected you to Home Page`;
             app.$.toast.show();
             page.redirect(app.baseUrl);
         });


### PR DESCRIPTION
Motivation:

When an openid connect provider redirect back to dcache-view, the
access_token needs to be extracted and verified. At the moment,
before the extraction of the access_token, dcache-view checked if
the redirect url contain some other parameters which might be
problematic based on the provider response.

Also, when error occuur during the verification process of the
access_token, the was not properly handled because the name of
the event had been changed without updating this part.

Modification:

1. check if the redirect url contain only access_token since this
the only important parameter for dcache-view.
2. filer the redirect url properly to extract the only needed
access_token.
3. change the name of the `error` event listener to
`dv-authentication-error`, which is the latest name.

Result:

- Proberly handle error that might occur during verification of
access_token in dcache.

- Extract only the needed parameter from the redirect url.

Target: master
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11125/

(cherry picked from commit 8720f9f10182685be3a10c25764c59c277929af9)