### PR TITLE
dcache-view (authentication): minor fixes in the oic-login-form page

### DIFF
--- a/src/elements/dv-elements/user-authentication/loginform-with-openid.html
+++ b/src/elements/dv-elements/user-authentication/loginform-with-openid.html
@@ -68,7 +68,7 @@
                     margin: 10px;
                     max-height: calc(100vh - 25vh - 89px - 75px);
                     padding-bottom: 45px;
-                    overflow-y: scroll;
+                    overflow-y: auto;
                     display: flex;
                     flex-wrap: wrap;
                     justify-content: center;
@@ -153,7 +153,7 @@
                     margin: 10px;
                     max-height: calc(100vh - 25vh - 89px - 75px);
                     padding-bottom: 45px;
-                    overflow-y: scroll;
+                    overflow-y: auto;
                     display: flex;
                     flex-wrap: wrap;
                     justify-content: center;
@@ -165,6 +165,29 @@
                     padding: 0.5em 1em;
                     max-width: 300px !important; /* TODO: remember to add ellipsis */
                 }
+            }
+            .back-icon-btn-container {
+                margin-top: 7px;
+                margin-bottom: 5px
+            }
+            .back-icon-btn-inner-container {
+                width:40px;
+                height: 40px;
+                border: 2px solid #d6d6d6;
+                border-radius: 22px;
+                color: #d6d6d6;
+            }
+            .oic-provider-header {
+                color:#b5b5b5;
+                font-size: 0.9em;
+                letter-spacing: 1px;
+                line-height: 2em;
+            }
+            .oic-provider-btn {
+                text-transform: none !important;
+            }
+            .oic-provider-btn > label {
+                text-transform: capitalize !important;
             }
         </style>
         <neon-animated-pages id="pages" selected="[[selected]]" entry-animation="[[entryAnimation]]" exit-animation="[[exitAnimation]]">
@@ -180,21 +203,20 @@
                 <login-form redirect-to="[[redirectTo]]"></login-form>
             </neon-animatable>
             <neon-animatable>
-                <div style="margin-top: 7px; margin-bottom: 5px">
-                    <div style="width:40px;height: 40px; border: 2px solid #d6d6d6; border-radius: 22px; color: #d6d6d6;">
+                <div class="back-icon-btn-container">
+                    <div class="back-icon-btn-inner-container">
                         <paper-icon-button icon="chevron-left" on-tap="_backToMain">back</paper-icon-button>
                     </div>
                 </div>
-                <div style="color:#b5b5b5; font-size: 0.9em; letter-spacing: 1px;line-height: 2em;">
+                <div class="oic-provider-header">
                     Supported OpenID Providers
                 </div>
                 <br>
                 <div id="providersContainer">
                     <!-- TODO: style the buttons based on the provider's (logo/style/theme) -->
-                    <template is="dom-repeat" items="{{openIDproviders}}">
-                        <paper-button on-tap="_connect" data-id$="[[item.id]]"
-                                      data-endpoint$="[[item.endpoint]]" style="text-transform: none !important;">
-                            Login via&nbsp;<label style="text-transform: capitalize !important;">{{item.name}}</label>
+                    <template is="dom-repeat" items="[[openIDProviders]]" id="oidcList">
+                        <paper-button on-tap="_connect" class="oic-provider-btn">
+                            Login via&nbsp;<label>[[item.name]]</label>
                         </paper-button>
                     </template>
                 </div>
@@ -204,15 +226,27 @@
     <script>
         class LoginformWithOpenid extends Polymer.Element
         {
+            constructor()
+            {
+                super();
+                const a = window.CONFIG["dcache-view.oidc-provider-name-list"].trim().split(" ");
+                const b = window.CONFIG["dcache-view.oidc-client-id-list"].trim().split(" ");
+                const c = window.CONFIG["dcache-view.oidc-authz-endpoint-list"].trim().split(" ");
+                const len = a.length;
+                let jsonArray = [];
+                for (let i=0; i<len; i++) {
+                    jsonArray.push({"name": `${a[i]}`, "id": `${b[i]}`, "endpoint": `${c[i]}`});
+                }
+                this.openIDProviders = jsonArray;
+            }
             static get is()
             {
                 return "loginform-with-openid";
             }
-
             static get properties()
             {
                 return {
-                    openIDproviders: {
+                    openIDProviders: {
                         type: Array,
                         notify: true
                     },
@@ -227,23 +261,6 @@
                     }
                 };
             }
-
-            ready()
-            {
-                super.ready();
-                let a = window.CONFIG["dcache-view.oidc-provider-name-list"].trim().split(" ");
-                let b = window.CONFIG["dcache-view.oidc-client-id-list"].trim().split(" ");
-                let c = window.CONFIG["dcache-view.oidc-authz-endpoint-list"].trim().split(" ");
-                const len = a.length;
-                let jsonString = '';
-                for (let i=0; i<len; i++) {
-                    jsonString += '{"name":"' + a[i] + '", "id":"' + b[i] + '", "endpoint":"' + c[i] + '"},';
-                }
-
-                this.openIDproviders = [JSON.parse(jsonString.slice(0,-1))];
-
-            }
-
             _showAllAvailableProviders ()
             {
                 this.entryAnimation = 'slide-from-right-animation';
@@ -261,23 +278,20 @@
             _connect (e)
             {
                 sessionStorage.removeItem('nonce');
-                const id = e.target.getAttribute('data-id');
-                const endpoint = e.target.getAttribute('data-endpoint').endsWith('?')
-                    ? e.target.getAttribute('data-endpoint') : e.target.getAttribute('data-endpoint') + '?';
-                const redirecturi = encodeURIComponent(window.location.origin);
-                let nonce = this._generateNonce();
-                nonce = window.btoa(this._entropy(nonce));
+                const openIDprovider = this.$.oidcList.itemForElement(e.target);
+                const endpoint = openIDprovider.endpoint.endsWith('?')
+                    ? openIDprovider.endpoint : `${openIDprovider.endpoint}?`;
+                const nonce = window.btoa(this._entropy(this._generateNonce()));
                 sessionStorage.setItem("nonce", nonce);
 
                 sessionStorage.removeItem('redirect');
                 sessionStorage.setItem('redirect', JSON.stringify(this.redirectTo));
 
                 window.location.href = endpoint + 'response_type=id_token%20token' +
-                    '&client_id=' + id +
-                    '&redirect_uri=' + redirecturi +
+                    '&client_id=' + openIDprovider.id +
+                    '&redirect_uri=' + encodeURIComponent(window.location.origin) +
                     '&scope=openid%20profile%20email' +
-                    '&nonce=' + nonce +
-                    '&prompt=consent';
+                    '&nonce=' + nonce;
             }
 
             /**


### PR DESCRIPTION
Motivation:

Motivation:

1. If there are more than one oic providers, the json array that
suppose to form an array list based on the information from the
config file will thrown an error because the object are not
properly created.

2. When a css overflow value is set to scroll, some broswer will
not show any scroll bar if there is nothing to scroll, while
others by default will show the scrollbar. Due to this inconsident
in behaviour, the rendering of this page unharmonious across
different platform.

3. The oic provider buttons are created base on the number of
the providers known to dcache-view. At times this buttons are
unresponsive when clicked because the data are not set and data-\*
attribute behave inconsistently with dom-repeat template.

4. In the request url, dcache-view always request that the oic
provider should always request for user consent. This is
undesirable especially when the user had already consented.

Modification:

1. Set the css overflow to auto.
2. remove all inline styling
3. move the setting of oic providers to the constructor phase
and use es6 for forming the object for each provider.
4. use `itemForElement` method that come with dom-repeat
template to get the values of the providers instead of using
data-attribute.

Result:

1. Better styling and uniform interface across different platform
2. provider button now works as espected.
3. no more annoying user consent page.

Target: master
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11126/

(cherry picked from commit 919200efad41b45dc4d893a8d8586e4aab50f5c9)