### PR TITLE
dcache-view (namespace,authentication): fix file download

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -207,6 +207,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                             border-radius: 5px;
                             background: #e8e8e8;
                         }
+                        .none{
+                            display: none;
+                        }
                     </style>
                 </custom-style>
                 <paper-header-panel class="flex" mode="standard" shadow id="dv-main-header">
@@ -407,6 +410,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
                 <!-- PLACEHOLDER FOR STACKING INFO DIALOGS (ADMIN) -->
                 <div id="adminDialogs"></div>
+
+                <a id="download" class="none">fm</a>
             </template>
             <script src="scripts/dv.js"></script>
         </dom-bind>


### PR DESCRIPTION
Motivation:

When file download is requested by the user; this is
processed by getting the webdav url path of the file
and using the window interface's `open()` method to
load the requested file. This is equivalent to a
simple `GET` request on the provided url.

The above solution is fine as long as authentication
is not requeired. And when authorisation is mandatory,
the download operation will trigger a browser pop-up,
asking for the username and password. This become more
problematic if the user had already authentication
especially with open-id connect.

Modification:

1. Use fetch api to make a request to the webdav door.
The authentication credential will be sent along if it
available.

2. Add a single anchor tag to the main page, this will
be use as download link that will be set with all the
necessary variables when the request for download is
successful. Also, the anchor tag will not be visible
to user and it will only be clicked programatically.

Result:

Download of a file now work with the authentication
credential.

Target: master
Request: 1.4
Request: 1.3
Require-notes: no
Require-book: no
Acked-by: Albert Rossi

Reviewed at https://rb.dcache.org/r/11139/

(cherry picked from commit 96d90ececa56c178947afdcb1fbeea7fcdbca384)