### PR TITLE
dcache-view (namespace,authentication): fix file download

### DIFF
--- a/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
+++ b/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
@@ -262,20 +262,35 @@
             _download: function()
             {
                 app.$.centralContextMenu.close();
-                let path;
                 const webdav = window.CONFIG["dcache-view.endpoints.webdav"];
-                if (webdav === "") {
-                    path =
-                        window.location.protocol + "//" + window.location.hostname
-                        + ":2880" + this.targetNode.filePath;
-                } else {
-                    if (webdav.endsWith("/")) {
-                        path = webdav.substring(0, webdav.length-1) + this.targetNode.filePath;
-                    } else {
-                        path = webdav + this.targetNode.filePath;
+                const fileURL = webdav === "" ?
+                    `${window.location.protocol}//${window.location.hostname}:2880${this.targetNode.filePath}` :
+                    webdav.endsWith("/") ? `${webdav.substring(0, webdav.length - 1)}${this.targetNode.filePath}` :
+                        `${webdav}${this.targetNode.filePath}`;
+                fetch(fileURL, {
+                    mode: "cors",
+                    headers: {
+                        "Authorization": `${app.getAuthValue()}`,
+                        "Suppress-WWW-Authenticate": "Suppress",
+                        "Content-Type" : `${this.targetNode.fileMimeType}`
                     }
-                }
-                window.open(path);
+                })
+                    .then((file) => {
+                        return file.blob();
+                    })
+                    .then((blob) => {
+                        const windowUrl = window.URL || window.webkitURL;
+                        const url = windowUrl.createObjectURL(blob);
+                        const link = app.$.download;
+                        link.href = url;
+                        link.download = this.targetNode.name;
+                        link.click();
+                        windowUrl.revokeObjectURL(url);//Maybe it might be wise to delay this
+                    })
+                    .catch((err)=>{
+                        app.$.toast.text = `${err.message} `;
+                        app.$.toast.show()
+                    });
             },
 
             _metadata: function()

--- a/src/elements/dv-elements/list-view/list-row.html
+++ b/src/elements/dv-elements/list-view/list-row.html
@@ -329,18 +329,35 @@
                     Polymer.dom.flush();
                 } else {
                     //Download a file
-                    let path;
                     const webdav = window.CONFIG["dcache-view.endpoints.webdav"];
-                    if (webdav == "") {
-                        path = window.location.protocol + "//" + window.location.hostname + ":2880" + this.filePath;
-                    } else {
-                        if (webdav.endsWith("/")) {
-                            path = webdav.substring(0, webdav.length-1) + this.filePath;
-                        } else {
-                            path = webdav + this.filePath;
+                    const fileURL = webdav === "" ?
+                        `${window.location.protocol}//${window.location.hostname}:2880${this.filePath}` :
+                        webdav.endsWith("/") ? `${webdav.substring(0, webdav.length - 1)}${this.filePath}` :
+                            `${webdav}${this.filePath}`;
+                    fetch(fileURL, {
+                        mode: "cors",
+                        headers: {
+                            "Authorization": `${app.getAuthValue()}`,
+                            "Suppress-WWW-Authenticate": "Suppress",
+                            "Content-Type" : `${this.fileMimeType}`
                         }
-                    }
-                    window.open(path);
+                    })
+                        .then((file) => {
+                            return file.blob();
+                        })
+                        .then((blob) => {
+                            const windowUrl = window.URL || window.webkitURL;
+                            const url = windowUrl.createObjectURL(blob);
+                            const link = app.$.download;
+                            link.href = url;
+                            link.download = this.name;
+                            link.click();
+                            windowUrl.revokeObjectURL(url);//Maybe it might be wise to delay this
+                        })
+                        .catch((err)=>{
+                            app.$.toast.text = `${err.message} `;
+                            app.$.toast.show()
+                        });
                 }
             },
 

--- a/src/index.html
+++ b/src/index.html
@@ -238,6 +238,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                     <drag-enter-toast></drag-enter-toast>
                 </div>
             </paper-toast>
+            <a id="download" class="none">fm</a>
         </template>
 
         <script src="scripts/dv.js"></script>

--- a/src/styles/dv-theme.html
+++ b/src/styles/dv-theme.html
@@ -124,4 +124,7 @@
         --paper-toast-box-shadow: none !important;
         padding: 0 !important;
     }
+    .none {
+        display: none;
+    }
 </style>


### PR DESCRIPTION
Motivation:

When file download is requested by the user; this is
processed by getting the webdav url path of the file
and using the window interface's `open()` method to
load the requested file. This is equivalent to a
simple `GET` request on the provided url.

The above solution is fine as long as authentication
is not requeired. And when authorisation is mandatory,
the download operation will trigger a browser pop-up,
asking for the username and password. This become more
problematic if the user had already authentication
especially with open-id connect.

Modification:

1. Use fetch api to make a request to the webdav door.
The authentication credential will be sent along if it
available.

2. Add a single anchor tag to the main page, this will
be use as download link that will be set with all the
necessary variables when the request for download is
successful. Also, the anchor tag will not be visible
to user and it will only be clicked programatically.

Result:

Download of a file now work with the authentication
credential.

Request: 1.3
Require-notes: no
Require-book: no
Acked-by: Albert Rossi

Reviewed at https://rb.dcache.org/r/11139/

(cherry picked from commit 96d90ececa56c178947afdcb1fbeea7fcdbca384)