### PR TITLE
dcache-view (namespace): fix style issue in list-row & list-row-header

### DIFF
--- a/src/elements/dv-elements/list-view/list-row.html
+++ b/src/elements/dv-elements/list-view/list-row.html
@@ -1,13 +1,11 @@
 <link rel="import" href="../../../bower_components/polymer/polymer-element.html">
 
-<link rel="import" href="../../../bower_components/iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../../../bower_components/file-icon/file-icon.html">
-
 <dom-module id="list-row">
     <template>
         <style>
             :host {
-                @apply(--layout-block);
+                display: block;
                 font-size: 0.7em;
             }
             :host([x-selected]) {
@@ -32,36 +30,25 @@
                 border-bottom: 1px solid #6ab8f7;
             }
             .row {
-                @apply(--layout-horizontal);
-                @apply(--layout-center);
+                width: 100%;
+                max-width: 100%;
                 height: 40px;
                 border-bottom: 1px solid #e5e5e5;
-                text-decoration: none !important;
+                text-decoration: none;
+                display: flex;
+                align-items: center;
             }
-            .name{
-                @apply(--layout-flex-3);
-            }
-            .ctime, .qos {
-                @apply(--layout-flex);
-            }
-            .size {
-                @apply(--layout-flex);
-                text-align: right;
-            }
-            .size > span {
+            .file-icon {
+                padding-left: 15px;
                 padding-right: 10px;
+                width: 50px;
+                max-width: 50px;
+                min-width: 50px;
             }
-            .fit {
-                @apply(--layout-fit);
-            }
-            @keyframes blink-animation {
-                to {visibility: hidden;}
-            }
-            @-webkit-keyframes blink-animation {
-                to {visibility: hidden;}
+            .file-icon[selected] {
+                fill: white !important;
             }
             #fileName {
-                min-width:10px;
                 white-space: nowrap;
                 overflow: hidden;
                 text-overflow: ellipsis;
@@ -72,19 +59,49 @@
                 align-items: center;
                 padding-right: 24px;
             }
-            file-icon {
-                padding-left: 15px;
-                padding-right: 10px
+            .cell {
+                box-sizing: border-box;
             }
-            file-icon[selected] {
-                fill: white !important;
+
+            @media only screen and (min-width: 960px) {
+                /* larger screen: */
+                .name {
+                    flex: 1 1 auto;
+                    max-width: calc(100% - 410px);
+                }
+                .ctime, .qos {
+                    width: 150px;
+                    max-width: 150px;
+                    min-width: 150px;
+                }
+                .size {
+                    width: 60px;
+                    max-width: 60px;
+                    min-width: 60px;
+                    text-align: right;
+                }
+                .size > span {
+                    padding-right: 10px;
+                }
+            }
+            @media only screen and (max-width: 960px) {
+                /* smaller screen: */
+                .name {
+                    flex: 1 1 auto;
+                    max-width: calc(100% - 50px);
+                }
+                .ctime, .qos, .size {
+                    display: none;
+                }
             }
             .none {
                 display: none;
             }
         </style>
         <div id="row" class="row">
-            <file-icon mime-type="[[fileMetaData.fileMimeType]]" selected$="[[xSelected]]"></file-icon>
+            <file-icon class="cell file-icon"
+                       mime-type="[[fileMetaData.fileMimeType]]"
+                       selected$="[[xSelected]]"></file-icon>
             <div class="cell name">
                 <div id="nameContainer">
                     <span id="fileName">[[fileMetaData.fileName]]</span>

--- a/src/elements/dv-elements/table-header/list-row-header.html
+++ b/src/elements/dv-elements/table-header/list-row-header.html
@@ -1,35 +1,71 @@
 <link rel="import" href="../../../bower_components/polymer/polymer-element.html">
-
-<link rel="import" href="../../../bower_components/iron-flex-layout/iron-flex-layout.html">
-
 <dom-module id="list-row-header">
     <template>
         <style>
             :host {
                 display: block;
                 font-size: 0.75em;
-                @apply(--layout-block);
-                @apply(--layout-fit);
-                margin: 0px 30px;
+                margin: 0 15px;
+                color: #fff;
+                width: 100%;
             }
             .row {
-                @apply(--layout-horizontal);
-                @apply(--layout-center);
+                width: 100%;
+                max-width: 100%;
                 height: 40px;
+                text-decoration: none;
+                display: flex;
+                align-items: center;
             }
-            .flex {
-                @apply(--layout-flex);
+            .cell {
+                box-sizing: border-box;
             }
-            .flex3 {
-                @apply(--layout-flex-3);
+            .file-icon {
+                padding-left: 15px;
+                padding-right: 10px;
+                width: 50px;
+                max-width: 50px;
+                min-width: 50px;
             }
+            @media only screen and (min-width: 960px) {
+                /* larger screen: */
+                .name {
+                    flex: 1 1 auto;
+                    max-width: calc(100% - 418px); /*This is weird, I don't know where the 8px is coming from*/
+                }
+                .ctime, .qos {
+                    width: 150px;
+                    max-width: 150px;
+                    min-width: 150px;
+                }
+                .size {
+                    width: 60px;
+                    max-width: 60px;
+                    min-width: 60px;
+                    text-align: right;
+                }
+            }
+            @media only screen and (max-width: 960px) {
+                /* smaller screen: */
+                .name {
+                    flex: 1 1 auto;
+                    max-width: calc(100% - 50px);
+                }
+                .ctime, .qos, .size {
+                    display: none;
+                }
+            }
+            .none {
+                display: none;
+            }
+
         </style>
-        <div class="row">
-            <div style="padding-left: 15px; padding-right: 10px">Type</div>
-            <div class="flex3" style="padding-left:5px;">Name</div>
-            <div class="flex">Creation time</div>
-            <div class="flex">File location</div>
-            <div class="flex" style="text-align: right; padding-right: 10px;">Size</div>
+        <div class="row cell">
+            <div class="cell file-icon">Type</div>
+            <div class="cell name">Name</div>
+            <div class="cell ctime">Creation time</div>
+            <div class="cell qos">File location</div>
+            <div class="cell size">Size</div>
         </div>
     </template>
     <script>


### PR DESCRIPTION
Motivation:

dCache View uses list-row element to represent and show a
file in a list. It contain 5 columns: file icon, file name,
creation time, file location and file size.

But there are two problems with list-row element:

1. When the screen size is small, all the 5 columns are still
shown even when the client screen width is not sufficient.
2. If the text length of each name of all the files in
a directory were greatly varies from each other; this
will result in the distortion of the uniformity and the
consistency that should be maintained for each columns in
the list.

Modification:

For both list-row and list-row-header:

1. use media queries to create flexible layout for list-row
element. If the screen is less than 960px, only two columns
(which are the file icon and file name colums) will be shown.

2. set the columns to a particular fixed width and make the
file name column flexible but with a set max-width. The
max-width of the file name column is based on the size of the
screen. Hence, if the text length of file name is greater than
the max-width assigned, the css text-overflow and text-overflow
properties of the column will ensure that text is trunctated
with an appended ellipsis.

Target: master
Request: 1.4
Request: 1.3
Require-notes: no
Require-book: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11174/

(cherry picked from commit 06a50f11c52ea7403a64b0929471c1ae1ac41e55)