### PR TITLE
dcache-view: use on-tap instead of onclick in restores view

### DIFF
--- a/src/elements/dv-elements/admin/views/restores-view.html
+++ b/src/elements/dv-elements/admin/views/restores-view.html
@@ -140,7 +140,7 @@
                             </vaadin-grid-filter>
                         </template>
                         <template>
-                            <span onclick="_openFileInfo"
+                            <span on-tap="_openFileInfo"
                                     class="actionable">[[item.pnfsId]]</span>
                         </template>
                     </vaadin-grid-column>
@@ -181,7 +181,7 @@
                             </vaadin-grid-filter>
                         </template>
                         <template>
-                            <span onclick="_openPoolInfo"
+                            <span on-tap="_openPoolInfo"
                                 class="actionable">[[item.poolCandidate]]</span>
                         </template>
                     </vaadin-grid-column>


### PR DESCRIPTION
Motivation:

The current code does not work correctly in all browsers on the restores page.
Clicking on the pnfsid or pool does not open a dialog there.

Modification:

Change the 'onclick' event definition to 'on-tap', as it is everywhere else.

Result:

Functions correctly.

Target: master
Request: 1.4
Acked-by: Dmitry