### PR TITLE
dcache-view: fix reference to migration job in pool info dialog

### DIFF
--- a/src/elements/dv-elements/admin/dialogs/pool-info-dialog.html
+++ b/src/elements/dv-elements/admin/dialogs/pool-info-dialog.html
@@ -405,10 +405,10 @@
                             </div>
                             <div class="grid-item">
                                 <iron-list
-                                        items="[[poolData..migrationData.jobInfo]]"
+                                        items="[[poolData.migrationData.jobInfo]]"
                                         as="job">
                                     <template>
-                                        <div class="main">[[job]]</span></div>
+                                        <div class="main">[[job]]</div>
                                     </template>
                                 </iron-list>
                             </div>


### PR DESCRIPTION
items="[[poolData..migrationData.jobInfo]]"  has an extra "."
which prevents the data from loading/displaying.

Fixed, and stray "</span>" eliminated

Target: master
Request: 1.4
Acked-by: Paul