### PR TITLE
dcache-view: alter the way multiple errors are handled

### DIFF
--- a/src/elements/dv-elements/admin/dialogs/pools-of-group-dialog.html
+++ b/src/elements/dv-elements/admin/dialogs/pools-of-group-dialog.html
@@ -627,6 +627,11 @@
                         type: Boolean,
                         value: false,
                         notify: true
+                    },
+
+                    errorMessage: {
+                        type: String,
+                        value: ''
                     }
                 }
             }
@@ -695,7 +700,8 @@
             }
 
             _handlePoolsError(event) {
-                this.handleError(`Could not process pools of group request: ${event.detail.error.message}`);
+                this.errorMessage = `${this.errorMessage} ${event.detail.error.message}`;
+                this._handlePoolInfoResponse(event);
             }
 
             _handlePoolInfoResponse(event) {
@@ -829,6 +835,11 @@
                 this.pools = pools;
                 this.queues = queues;
                 this.incoming = [];
+
+                if (this.errorMessage !== '') {
+                    this.handleError(`Error processing pool requests: ${this.errorMessage}`);
+                    this.errorMessage = '';
+                }
             }
 
             _queueAttribute(queue, item, attribute) {

--- a/src/elements/dv-elements/admin/views/pool-group-view.html
+++ b/src/elements/dv-elements/admin/views/pool-group-view.html
@@ -183,7 +183,12 @@
                     incoming: {
                         type: Array,
                         value: []
-                    }
+                    },
+
+                    spaceError: {
+                        type: String,
+                        value: ''
+                    },
                 }
             }
 
@@ -220,6 +225,11 @@
 
                 this.groups = this.incoming;
                 this.incoming = [];
+
+                if (this.spaceError !== '') {
+                    this.handleError(`Error in space info request: ${this.spaceError}`);
+                    this.spaceError = '';
+                }
             }
 
             _handleGroupsError(event) {
@@ -248,8 +258,7 @@
             }
 
             _handleSpaceError(event) {
-                this.handleError(`Could not process space info request:
-                  ${message + event.detail.error.message}`);
+                this.spaceError = `${this.spaceError} ${event.detail.error.message}`;
             }
 
             _handleSpaceResponse(event) {

--- a/src/elements/dv-elements/admin/views/pool-plots-view.html
+++ b/src/elements/dv-elements/admin/views/pool-plots-view.html
@@ -347,6 +347,11 @@
                     rendering: {
                         type: Boolean,
                         notify: true
+                    },
+
+                    errorMessage: {
+                        type: String,
+                        value: ''
                     }
                 }
             }
@@ -497,8 +502,12 @@
 
             _handleHistogramError(event) {
                 this.plotDataResponses += 1;
-                this.handleError(`Could not process histogram:
-                    ${event.detail.error.message}`);
+                this.errorMessage = `${this.errorMessage} ${event.detail.error.message}`;
+
+                if (this.plotDataResponses === this.currentChildren.length) {
+                    this._setNameFilter(this.$.nameFilter.value);
+                    this.rendering = false;
+                }
             }
 
             _handlePoolsResponse(event) {
@@ -652,6 +661,11 @@
                 this.charts = [];
                 this.charts = matching;
                 this.hiddenCharts = excluded;
+
+                if (this.errorMessage !== '') {
+                    this.handleError(`Error in retrieving histograms: ${this.errorMessage}`);
+                    this.errorMessage = '';
+                }
             }
 
             _sortByTitle(a, b) {

--- a/src/elements/dv-elements/admin/views/transfers-view.html
+++ b/src/elements/dv-elements/admin/views/transfers-view.html
@@ -512,6 +512,11 @@
                         type: Boolean,
                         value: false,
                         notify: true
+                    },
+
+                    errorMessage: {
+                        type: String,
+                        value: ''
                     }
                 }
             }
@@ -609,6 +614,10 @@
 
             _refresh() {
                 this.decorator.resetProvider();
+                if (this.errorMessage !== '') {
+                    this.handleError(`Problem with mover kill: ${this.errorMessage}`);
+                    this.errorMessage = '';
+                }
             }
 
             _remoteProvider(params, callback) {
@@ -663,21 +672,17 @@
             }
 
             _handleDeleteError(event) {
-                this._handleDelete(event);
-
-                let message;
                 const errors = event.detail.request.xhr.response.errors;
 
                 if (errors && errors.length > 0) {
-                    message = '';
                     for (let i = 0; i < errors.length; i++) {
-                        message = `${message}(error ${errors[i].status}: ${errors[i].message})`;
+                        this.errorMessage = `${this.errorMessage} (error ${errors[i].status}: ${errors[i].message})`;
                     }
                 } else {
-                    message = event.detail.error.message;
+                    this.errorMessage = `${this.errorMessage} ${event.detail.error.message}`;
                 }
 
-                this.handleError(`Could not kill mover(s): ${message}`);
+                this._handleDelete(event);
             }
 
             _handleIdError(event) {


### PR DESCRIPTION
Motivation:

When errors occur on HTTP requests, they are usually handled
in the admin interfaces by passing them to a 'toast' component
for display.   This usually is fine when an error associated
with a single request is involved.

However, when there are multiple asynchronous requests involved,
the direct reporting of each one using the 'toast' is a bad
idea, for two reasons:

(A)  if there are multiple such errors, the display of the toast
     blocks the rendering thread and as such the other errors
     get lost;

(B)  even a single such asynchronous error can sometimes affect
     the processing of the remaining requests, stopping them
     from completing.

Modification:

The display of errors messages in dCache-View in general needs
to be rethought; but in the meantime, the places where the toast
could be called within the context of multiple asynchronous
requests have been altered such that the any such errors are
appended to a single message which is displayed only when
all such requests complete.

Result:

Normal operations should complete despite of asynchronous
error handler calls, and the message delivered to the user
should have information that reflects the multiple error
instances.

Target: master
Request: 1.4
Acked-by: Paul