### PR TITLE
dcache-view (gulp-tasks): ensure copy-pdfjs task successful execution

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -64,7 +64,7 @@ gulp.task('copy-scripts', function() {
 
 gulp.task('copy-pdfjs', function() {
     return gulp.src([
-        './src/bower_components/pdfjs-dist/build/*'
+        './src/bower_components/pdfjs-dist/build/**/*'
     ], {
         base: ''
     })
@@ -82,8 +82,8 @@ gulp.task('vulcanize', function() {
         .pipe(gulp.dest('./target/elements'));
 });
 
-gulp.task('build', ['copy-favicons', 'copy-index', 'copy-robots', 'copy-css', 'copy-scripts', 'copy-pdfjs']);
+gulp.task('build', ['copy-favicons', 'copy-index', 'copy-robots', 'copy-css', 'copy-scripts']);
 
 gulp.task('default', ['bower', 'build'], function () {
-    gulp.start('vulcanize','copy-webcomponents');
+    gulp.start('vulcanize','copy-webcomponents', 'copy-pdfjs');
 });


### PR DESCRIPTION
Motivation:

We need the minified version of pdfjs library and the build
needs to be in a proper order in dcache-view task list so
that the copy-pdfjs task will be executed successfully.

Modification:

- deep copy the build directory of pdfjs folder
- move the task towards the end of all tasks.

Result:

The minified version of pdfjs is included in the successful
build.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11362/

(cherry picked from commit c9e436bbd0b4f33e49850138e4aafa09d9f09ad4)