### PR TITLE
dcache-view (namespace): use worker for downloading file

### DIFF
--- a/src/elements/dv-elements/files-viewer/files-viewer.html
+++ b/src/elements/dv-elements/files-viewer/files-viewer.html
@@ -147,7 +147,7 @@
                         'url' : fileURL,
                         'mime' : this.file.fileMetaData.fileMimeType,
                         'upauth' : this.getAuthValue(),
-                        'return': this.file.fileMetaData.fileMimeType.includes('json') ? 'json' : ''
+                        'return': this.file.fileMetaData.fileMimeType.includes('json') ? 'json' : 'blob'
                     });
                 });
             }

--- a/src/scripts/tasks/download-task.js
+++ b/src/scripts/tasks/download-task.js
@@ -8,23 +8,19 @@ self.addEventListener('message', function(e) {
         headers.append("Authorization", `${e.data.upauth}`);
     }
     const request = new Request(e.data.url, {
-        headers: headers
+        headers: headers,
+        mode: "cors",
+        redirect: "follow"
     });
 
-    fetch(request).then((file) => {
+    fetch(request).then(file => {
         switch (e.data.return) {
             case 'json':
                 return file.json();
-            case 'blob':
-                return file.blob();
             default:
-                return file.arrayBuffer();
+                return file.blob();
         }
-    }).then((data)=>{
-        if (e.data.return === 'json') {
-            self.postMessage(data);
-        } else {
-            self.postMessage(data, [data])
-        }
-    }).catch((err)=>{throw new Error(err)})
+    }).then(data => {
+        self.postMessage(data);
+    }).catch(err => {setTimeout(function(){throw error;});})
 }, false);


### PR DESCRIPTION
dCache-view uses download-task worker to download a file for viewing.
Instead of having code dublication, this task can be use when user
request file download.

Modification:

- modify download task to return blob if the `return` value is not json.
Also, use setTimeout work-around to propagete the error. In the fetch
request, the mode and redirect value were explicitly set to ensure same
behaviour across all browsers.

- use the download-task worker to download file.

Result:

Reduce code dublication and provide a single point failure.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Acked-by: Vincent Garonne

Reviewed at https://rb.dcache.org/r/11366/

(cherry picked from commit 453a2d33bcd3b9c0495a934fe3a62981e586bdf6)