### PR TITLE
dcache-view (namespace): create worker for move operation

### DIFF
--- a/src/elements/dv-elements/rename-input/rename-input.html
+++ b/src/elements/dv-elements/rename-input/rename-input.html
@@ -23,20 +23,23 @@
     <script>
         class RenameInput extends Polymer.Element
         {
-            constructor(file)
+            constructor(file, auth)
             {
                 super();
                 this._node = file;
                 this._previousValue = file.fileMetaData.fileName;
                 this._pnfsId = file.fileMetaData.pnfsId;
                 this.value = file.fileMetaData.fileName;
-                this._endRenaming_ = this._endRenaming.bind(this);
+                if (auth) {
+                    this.auth = auth;
+                }
             }
             ready()
             {
                 super.ready();
                 this.target = this.$.input;
-                Polymer.RenderStatus.afterNextRender(this, function() {
+                this.$.input.addEventListener('focusout', event => this._endRenaming(event));
+                Polymer.RenderStatus.afterNextRender(this, () => {
                     this._focus();
                 });
             }
@@ -62,18 +65,9 @@
                         value: true,
                         notify: true
                     },
+                    auth: Object,
                     target: Object
                 }
-            }
-            connectedCallback()
-            {
-                super.connectedCallback();
-                this.$.input.addEventListener('focusout', this._endRenaming_);
-            }
-            disconnectedCallback()
-            {
-                super.disconnectedCallback();
-                this.$.input.removeEventListener('focusout', this._endRenaming_);
             }
             _focus()
             {
@@ -87,44 +81,51 @@
                 if (!this.flag) {
                     return;
                 }
-                this.flag = false;
-                this.dispatchEvent(new CustomEvent('dv-namespace-rename-input', {
-                    detail: {pnfsId: this._pnfsId, newFileName: this.value},
-                    bubbles: true, composed: true
-                }));
+                this._abortRename();
             }
             _rename()
             {
+                this.flag = false;
                 if (this._previousValue === this.value) {
-                    this._endRenaming();
+                    this._abortRename();
                     return;
                 }
-                const namespace = document.createElement('dcache-namespace');
-                namespace.auth = app.getAuthValue();
-                const path = this._node.parentPath.endsWith("/") ? this._node.parentPath :
-                    `${this._node.parentPath}/`;
-                namespace.mv({
-                    url: `${window.CONFIG["dcache-view.endpoints.webapi"]}namespace`,
-                    path: `${path}${this._previousValue}`,
-                    destination: `${path}${this.value}`
-                });
-
-                namespace.promise.then(() => {
+                let path;
+                if (this._node.parentPath) {
+                    path = this._node.parentPath;
+                }
+                const renameWorker = new Worker('./scripts/tasks/namespace-move-operation.js');
+                renameWorker.addEventListener('message', (e) => {
+                    renameWorker.terminate();
                     window.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast',
                         {detail: {message: `Done! File renamed.`}}
                     ));
-                    this._endRenaming();
-                }).catch((err)=> {
-                    this._abortRename();
+                    this._dispatchRename(this.value);
+                }, false);
+                renameWorker.addEventListener('error', (err) => {
+                    renameWorker.terminate();
                     window.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast',
-                        {detail: {message: `${err.message}`}}
-                    ));
+                        {detail: {message: `${err.message}`}}));
+                    this._abortRename();
+                }, false);
+                renameWorker.postMessage({
+                    "endpoint": window.CONFIG["dcache-view.endpoints.webapi"],
+                    "upauth": this.auth,
+                    "source": path.endsWith("/") ? `${path}${this._previousValue}` : `${path}/${this._previousValue}`,
+                    "destination": path.endsWith("/") ? `${path}${this.value}` : `${path}/${this.value}`
                 });
             }
             _abortRename()
             {
-                this.value = this._previousValue;
-                this._endRenaming();
+                this.flag = false;
+                this._dispatchRename(this._previousValue);
+            }
+            _dispatchRename(name)
+            {
+                this.dispatchEvent(new CustomEvent('dv-namespace-rename-input', {
+                    detail: {pnfsId: this._pnfsId, newFileName: name},
+                    bubbles: true, composed: true
+                }));
             }
         }
         window.customElements.define(RenameInput.is, RenameInput);

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -365,8 +365,7 @@
             {
                 const listRow =
                     this.$.feList.querySelector(`._dv${e.detail.file.fileMetaData.pnfsId}`);
-                const input = new RenameInput(e.detail.file);
-
+                const input = new RenameInput(e.detail.file, this.getAuthValue());
                 this.removeAllChildren(listRow.$.nameContainer);
                 listRow.$.nameContainer.appendChild(input);
             }

--- a/src/scripts/tasks/namespace-move-operation.js
+++ b/src/scripts/tasks/namespace-move-operation.js
@@ -1,0 +1,45 @@
+/**
+ * Move or rename operation.
+ *
+ * @param {
+ *     endpoint: @type {String} @required
+ *          url endpoint of dCache restful api
+ *
+ *     upauth: @type {String} @required
+ *          if set and non-empty, the Authorization header
+ *          will be set with this value.
+ *
+ *     source: @type {String} @required
+ *          absolute path of the file location.
+ *
+ *     destination: @type {String} @required
+ *          absolute path where the file should be moved to.
+ * }
+ */
+self.addEventListener('message', function(e) {
+    if (!(e.data.endpoint && e.data.upauth && e.data.source && e.data.destination)) {
+        throw new TypeError('One or more of the required parameters is not provided.');
+    }
+    const headers = new Headers({
+        "Suppress-WWW-Authenticate": "Suppress",
+        "Accept": "application/json",
+        "Content-Type": "application/json"
+    });
+    if (e.data.upauth && e.data.upauth !== "") {
+        headers.append("Authorization", `${e.data.upauth}`);
+    }
+    fetch(new Request(`${e.data.endpoint}namespace${e.data.source}`, {
+        method: "POST",
+        headers: headers,
+        body: JSON.stringify({"action": "mv", "destination": e.data.destination})
+    })).then(response => {
+        if (!response.ok) {
+            throw JSON.stringify({status: response.status, message: response.statusText})
+        }
+        return response.json();
+    }).then(successful => {
+        self.postMessage(successful);
+    }).catch(error => {
+        setTimeout(function() { throw error; });
+    })
+}, false);


### PR DESCRIPTION
Motivation:

The move operation request is one of those tasks that does
not directly involve in DOM manipulation. Hence, a perfect
candidate for a worker. The will result in making dCache-
view more responsive and the rename-input element become
even more modular.

Modification:

- Create a worker for namespace move operation. The operation
uses fetch API to send the request to dCache.This worker can
be use to either move a file or rename it.

- Update the rename-input element to use the worker and set
the authentication value at the constructor level if it is
provided.

- Adjust view-file element to use the updated rename-input
element.

Result:

Better user experience. Also, a noticed bug (which is: when
a user request is unsuccessful, the file name was updated to
the new name) is now fixed with this patch.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11383/

(cherry picked from commit ae9ebee342496cb993808db167eb6158a2af2bca)