### PR TITLE
dcache-view (namespace): move pagination handling to selected-title

### DIFF
--- a/src/elements/dv-elements/selected-title/selected-title.html
+++ b/src/elements/dv-elements/selected-title/selected-title.html
@@ -133,7 +133,7 @@
         <div class$="[[_computedRowClass(isUserLogin)]]"></div>
     </template>
     <script>
-        class SelectedTitle extends Polymer.Element
+        class SelectedTitle extends DcacheViewMixins.Commons(Polymer.Element)
         {
             constructor()
             {
@@ -379,6 +379,30 @@
             {
                 this._selectedItems = [];
                 this.isSelected = false;
+
+                if (this.pgRoute === "home") {
+                    this.removeAllChildren(this.$["pagination"]);
+                    const path = e.detail.path;
+                    const elRoot = new PaginationButton("Root", "/");
+                    this.$["pagination"].appendChild(elRoot);
+                    if (path === undefined || path === "" || path === "/") {
+                        elRoot.shadowRoot.querySelector('a').classList.add("active");
+                    } else {
+                        elRoot.shadowRoot.querySelector('a').classList.remove("active");
+                        const dirNames = path.split("/");
+                        const len = dirNames.length;
+                        let pt =  "";
+                        for (let i = 1; i < len; i++) {
+                            pt += "/" + dirNames[i];
+                            const el = new PaginationButton(dirNames[i], pt);
+                            this.$["pagination"].appendChild(el);
+                            el.shadowRoot.querySelector('a').classList.remove("active");
+                            if (i === len-1) {
+                                el.shadowRoot.querySelector('a').classList.add("active");
+                            }
+                        }
+                    }
+                }
             }
             _computedClass(isSelected)
             {

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -109,7 +109,7 @@
 
                 window.dispatchEvent(
                     new CustomEvent('dv-namespace-view-file-created', {
-                        detail: {}, bubbles: true, composed: true}));
+                        detail: {path: path}, bubbles: true, composed: true}));
 
                 window.dispatchEvent(
                     new CustomEvent('dv-namespace-current-path', {

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -45,35 +45,15 @@
      * @deprecated
      * TODO: move this to the listener
      */
-    app.ls = function(path)
+    app.ls = function(path, auth)
     {
-        app.$.homedir.removeChild(app.$.homedir.querySelector('view-file'));
-        const el1 = new ViewFile(path);
-        app.$.homedir.appendChild(el1);
-
-        setTimeout(()=>{
-            app.$.selectedTitle.shadowRoot.querySelector("#pagination").innerHTML = "";
-
-            const elRoot = new PaginationButton("Root", "/");
-            app.$.selectedTitle.shadowRoot.querySelector("#pagination").appendChild(elRoot);
-            if ( path == "/" || path == null || path == undefined || path.type == 'tap') {
-                elRoot.shadowRoot.querySelector('a').classList.add("active");
-            } else {
-                elRoot.shadowRoot.querySelector('a').classList.remove("active");
-                const dirNames = path.split("/");
-                let pt =  "";
-                for (let i = 1; i < dirNames.length; i++) {
-                    pt += "/" + dirNames[i];
-                    const el = new PaginationButton(dirNames[i], pt);
-                    app.$.selectedTitle.shadowRoot.querySelector("#pagination").appendChild(el);
-                    el.shadowRoot.querySelector('a').classList.remove("active");
-                    if ( i == (dirNames.length-1) ) {
-                        el.shadowRoot.querySelector('a').classList.add("active");
-                    }
-                }
-            }
-        },100);
-        el1.__listDirectory();
+        const currentVF = findViewFile();
+        const parent = currentVF.parentNode;
+        parent.removeChild(currentVF);
+        const newVF = new ViewFile(path);
+        if (auth) newVF.authenticationParameters = auth;
+        parent.appendChild(newVF);
+        newVF.__listDirectory();
     };
 
     app.lsHomeDir = function()
@@ -430,27 +410,8 @@
 
     function findViewFile(e)
     {
-        const arr = e.path || (e.composedPath && e.composedPath());
-        const vf = arr.find(function(el) {
-            return el.tagName === "VIEW-FILE";
-        });
-        if (vf) {
-            return vf;
-        }
-        const namespace = arr.find(function(el) {
-            return el.id === "homedir";
-        });
-        const arr2 = namespace.children;
-        const len = arr2.length;
-        let j = -1;
-        for (let i = 0; i < len; i++) {
-            if (arr2[i].tagName === "VIEW-FILE") {
-                j = i;
-                break;
-            }
-        }
-        if (j > -1) {
-            return arr2[j];
+        if (app.route === "home") {
+            return app.$["homedir"].querySelector('view-file');
         }
     }
     function getFileWebDavUrl(path, operationType)


### PR DESCRIPTION
Motivation:

When a directory is listed, pagination button/s will be
created based on the file path of the directory. In the
app-shell, the same method creates both the view-file
and the pagination button/s. Although, a setTimeout
function is used to delay the creation of the pagination
button/s, this is clearly unstructured codes that makes
the usage of these two elememts difficult.

Clearly, view-file needs to be created first before the
pagination button/s. Since each view-file element created
will broadcast its creation, hence selected-title element
which is the parent of the pagination button should just
rely on this broadcast.

Modification:

1. In the app-shell, app.ls() role is now reduced to
creating view-file and listing the directory. Also,
the findViewFile function now uses the page route
to better find the view-file element instead of
looping through the whole DOM.

2. When a new view-file is created, the path of the
directory will be broadcast as part of the event
detail.

3. Move the creation of the pagination button to the
selected-title element. Therefore, this element is
now adjusted as follows:
    - use the common mixin
    - create pagination buttons immediately when a new
    view file is created and based on the file path of
    the directory.

Result:

Structured, better and faster codes.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11368/

(cherry picked from commit 5ce74dfbea08ca373bea162165e47f00467ab1d3)