### PR TITLE
dcache-view (context-menu): fix css style in context-menu

### DIFF
--- a/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
+++ b/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
@@ -18,15 +18,24 @@
                 padding: 0;
                 background: transparent;
             }
-            paper-icon-item:hover{
+            paper-icon-item:hover {
                 background: #1565C0;
                 color: #fff;
+                font-size: 0.7em;
+                min-height: 30px;
+                font-weight: normal;
+                padding-right: 0;
+                padding-left: 5px;
                 border-radius: 4px;
                 --paper-item-icon: {
+                    width: 20px;
+                    height: 20px;
+                    margin-right: 10px;
                     color: #fff;
                 }
             }
             paper-icon-item {
+                background: transparent;
                 font-size: 0.7em;
                 min-height: 30px;
                 font-weight: normal;


### PR DESCRIPTION
Motivation:

Flickering of the context menu when mouse hover one
of the items is due to poorly written css style for
hover selector.

Modification:

Add neccessary css properties for hover selector.

Result:

No more flickering and better styling for all
browsers.

Target: master
Request: 1.5
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11386/

(cherry picked from commit 9664bdeeca02df5261ba27a2767ddcf310c7dd7e)