### PR TITLE
dcache-view (authentication): make dv elements use authenticationPara…

### DIFF
--- a/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
+++ b/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
@@ -145,6 +145,9 @@
                 this.targetNode = t;
                 if (authentication) {
                     this.authenticationParameters = authentication;
+                    if (!this.targetNode.authenticationParameters) {
+                        this.targetNode.authenticationParameters = authentication;
+                    }
                 }
             }
 

--- a/src/elements/dv-elements/drag-and-drop/dnd-upload.html
+++ b/src/elements/dv-elements/drag-and-drop/dnd-upload.html
@@ -97,7 +97,7 @@
                 detail: {child: uploadToast}, bubbles: true, composed: true}));
 
             const progressBar = uploadToast.shadowRoot.querySelector('paper-progress');
-            const fileUploader = new UploadFileCommon(this.path);
+            const fileUploader = new UploadFileCommon(this.path, this.authenticationParameters);
 
             fileUploader.addEventListener('complete', e => {
                 progressBar.indeterminate = fileUploader.progressStatus;
@@ -142,7 +142,7 @@
 
         _subDirFileUpload (file, path)
         {
-            const fileUploader = new UploadFileCommon(path);
+            const fileUploader = new UploadFileCommon(path, this.authenticationParameters);
             fileUploader.addEventListener('complete', e => {});
 
             fileUploader.addEventListener('uploading', e => {});

--- a/src/elements/dv-elements/selected-title/selected-title.html
+++ b/src/elements/dv-elements/selected-title/selected-title.html
@@ -117,7 +117,7 @@
                     <paper-tooltip>create new folder</paper-tooltip>
                 </div>
                 <div>
-                    <upload-files-button></upload-files-button>
+                    <upload-files-button authentication-parameters="[[authenticationParameters]]"></upload-files-button>
                 </div>
                 <div>
                     <paper-icon-button class="info"
@@ -141,6 +141,7 @@
                 this._isSelectedChanged_ = this._isSelectedChanged.bind(this);
                 this._setCurrentPath_ = this._setCurrentPath.bind(this);
                 this._resetViewFileDependentParameters_ = this._resetViewFileDependentParameters.bind(this);
+                this._setAuthenticationParameters_ = this._setAuthenticationParameters.bind(this);
             }
             ready()
             {
@@ -163,6 +164,7 @@
                 window.addEventListener('dv-namespace-x-selected-items-changed', this._isSelectedChanged_);
                 window.addEventListener('dv-namespace-current-path', this._setCurrentPath_);
                 window.addEventListener('dv-namespace-view-file-created', this._resetViewFileDependentParameters_);
+                window.addEventListener('dv-namespace-current-authenticationParameters', this._setAuthenticationParameters_);
             }
 
             disconnectedCallback()
@@ -171,6 +173,7 @@
                 window.removeEventListener('dv-namespace-x-selected-items-changed', this._isSelectedChanged_);
                 window.removeEventListener('dv-namespace-current-path', this._setCurrentPath_);
                 window.removeEventListener('dv-namespace-view-file-created', this._resetViewFileDependentParameters_);
+                window.removeEventListener('dv-namespace-current-authenticationParameters', this._setAuthenticationParameters_);
             }
 
             static get properties()
@@ -268,7 +271,7 @@
                     const name = e.detail.newFolderName;
                     const namespace = new DcacheNamespace();
 
-                    namespace.auth = app.getAuthValue();
+                    namespace.auth = this.getAuthValue();
                     namespace.promise.then(() => {
                         this.dispatchEvent(new CustomEvent('dv-namespace-close-central-dialogbox', {
                             detail: {}, bubbles: true, composed: true})
@@ -319,7 +322,7 @@
                 const noOfMovedItems = this._selectedItems.length;
                 const fileType = this._selectedItems.length === 1 ? "item": "items";
                 const mv = new MoveFile();
-                mv.auth = app.getAuthValue();
+                mv.auth = this.getAuthValue();
                 mv.currentPath = this.currentPath;
                 mv.mvFiles = this._selectedItems;
 
@@ -411,6 +414,10 @@
             _computedRowClass(isSelected)
             {
                 return isSelected ? ` row` : ` none`;
+            }
+            _setAuthenticationParameters(e)
+            {
+                this.authenticationParameters = e.detail.authenticationParameters;
             }
         }
         window.customElements.define(SelectedTitle.is, SelectedTitle);

--- a/src/elements/dv-elements/upload-files/upload-files-button.html
+++ b/src/elements/dv-elements/upload-files/upload-files-button.html
@@ -30,9 +30,12 @@
     <script>
         class UploadFilesButton extends DcacheViewMixins.Commons(Polymer.Element)
         {
-            constructor()
+            constructor(auth)
             {
                 super();
+                if(auth) {
+                    this.authenticationParameters = auth;
+                }
                 this._handleFileSelection = this.handleFileSelection.bind(this);
                 this._openFilePicker_ = this._openFilePicker.bind(this);
                 this._setCurrentPath_ = this._setCurrentPath.bind(this);
@@ -94,7 +97,7 @@
                     const uploadURL = this.getFileWebDavUrl(`${path}${files[i].name}`, "write")[0];
                     const uploader = new UploadHandler({
                         file: files[i],
-                        upauth: app.getAuthValue(),
+                        upauth: this.getAuthValue(),
                         url: uploadURL,
                         onComplete: function (data) {
                             const progressBar = upLs.shadowRoot.querySelector('paper-progress');

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -128,6 +128,13 @@
                 super.ready();
                 this.$.feList.scrollTarget = this.$.content;
                 this.$.threshold.scrollTarget = this.$.content;
+                Polymer.RenderStatus.afterNextRender(this, () => {
+                    this.dispatchEvent(
+                        new CustomEvent('dv-namespace-current-authenticationParameters', {
+                                detail: {authenticationParameters: this.authenticationParameters},
+                            bubbles: true, composed: true})
+                    );
+                });
             }
             connectedCallback()
             {

--- a/src/elements/dv-elements/utils/dcache-view-uploader/dcache-view-uploader.js
+++ b/src/elements/dv-elements/utils/dcache-view-uploader/dcache-view-uploader.js
@@ -48,7 +48,9 @@ UploadHandler.prototype.upload = function()
     const xhr = new XMLHttpRequest();
     xhr.open(this.httpMethod, this.url, true);
     xhr.setRequestHeader('Content-Type', this.contentType);
-    xhr.setRequestHeader('Authorization', this.upauth);
+    if (this.auth && this.auth !=="") {
+        xhr.setRequestHeader('Authorization', this.upauth);
+    }
     xhr.setRequestHeader('Suppress-WWW-Authenticate', "Suppress");
     if (xhr.upload) {
         xhr.upload.addEventListener('progress', this.onProgress);

--- a/src/elements/dv-elements/utils/mixins/commons.html
+++ b/src/elements/dv-elements/utils/mixins/commons.html
@@ -16,7 +16,8 @@
             static get properties() {
                 return {
                     authenticationParameters: {
-                        type: Object
+                        type: Object,
+                        notify: true
                     }
                 };
             }


### PR DESCRIPTION
…meters

Motivation:

dCache View have a common mixin that contain an authentication
parameter. This make all elements that uses this mixin to be
able to set their individual authentication parameter. Elements
like view-file now uses this implementation and making it easy
to set the authentication value for each object of the element.

There are elements that needs to be aware of the authentication
parameter to use in other to perform their functions. Hence,
these element needs to adjusted to use the authentication
parameter property in the common mixin. Since they have already
inherited the mixin class, it is just about setting the value.

Modification:

- dispatch an event to broadcast the current authentication
    parameter when view-file element is created.
- make selected-title element listen to this event.
-  use or set the value of the authentication parameter and
    where appropriate use `getAuthValue()` instead of
    `app.getAuthValue()` in the following elements:
        i. upload-files-buttons
        ii. dnd-upload
        iii. selected-title
- set notify to true of the authenticationParameters property
- adjust the shell script to use the authenticationParameters
    value where necessary.
- set the authorization request header in the UploadHandler
    provided the upauth is set.

Result:

Make each object of element created self contained and allow
flexibility in their usage.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11388/

(cherry picked from commit 8a87856f32de19294403bc5782ae419b74de2f0c)