### PR TITLE
dcache-view (file-sharing): add support for macaroon request

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -35,7 +35,8 @@
     "google-chart": "#2.0.0",
     "vaadin-grid": "#4.1.7",
     "web-animations-js": "#2.3.1",
-    "pdfjs-dist": "mozilla/pdfjs-dist#2.0.550"
+    "pdfjs-dist": "mozilla/pdfjs-dist#2.0.550",
+    "qr.js": "lifthrasiir/qr.js#4234f130e5137626f8193aba2132575ae1602f39"
   },
   "resolutions": {
     "dcache-namespace": "0.0.8"

--- a/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
+++ b/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
@@ -5,6 +5,7 @@
 
 <link rel="import" href="../files-viewer/files-viewer.html">
 <link rel="import" href="../qbi-dialog-content/qbi-dialog-content.html">
+<link rel="import" href="../file-sharing/shareable-file-generation/shareable-file-generation.html">
 <dom-module id="namespace-contextual-content">
     <template>
         <style>
@@ -45,7 +46,7 @@
             .none {
                 display: none;
             }
-            #open {
+            #open, #move {
                 border-bottom: 1px solid #cacaca;
             }
             #delete, #download {
@@ -83,6 +84,13 @@
                              multipleSelection, currentDir, targetNode)]]">
                 <iron-icon icon="move-icons:movefolder" slot="item-icon"></iron-icon>
                 Move to ...
+            </paper-icon-item>
+
+            <paper-icon-item  id="share"
+                              class$="[[_computedClass('share', singleSelection,
+                              multipleSelection, currentDir, targetNode)]]">
+                <iron-icon icon="social:share" slot="item-icon"></iron-icon>
+                Share
             </paper-icon-item>
             <paper-icon-item id="rename"
                              class$="[[_computedClass('rename', singleSelection,
@@ -196,6 +204,7 @@
                     this.$.move.addEventListener('tap', this._move.bind(this));
                     this.$.qosInfo.addEventListener('tap', this._qosInfo.bind(this));
                     this.$.rename.addEventListener('tap', this._rename.bind(this));
+                    this.$.share.addEventListener('tap', this._share.bind(this));
 
                     switch (this.targetNode.fileMetaData.fileType) {
                         case "DIR":
@@ -244,6 +253,7 @@
                     this.$.move.removeEventListener('tap', this._move.bind(this));
                     this.$.qosInfo.removeEventListener('tap', this._qosInfo.bind(this));
                     this.$.rename.removeEventListener('tap', this._rename.bind(this));
+                    this.$.share.removeEventListener('tap', this._share.bind(this));
 
                     switch (this.targetNode.fileMetaData.fileType) {
                         case "DIR":
@@ -298,6 +308,22 @@
                 this.dispatchEvent(
                     new CustomEvent('dv-namespace-open-file', {
                         detail: {file: this.targetNode}, bubbles: true, composed: true}));
+            }
+
+            _share()
+            {
+                this.dispatchEvent(new CustomEvent('dv-namespace-close-centralcontextmenu', {
+                    bubbles: true, composed: true
+                }));
+                const fileSharingForm = new ShareableFileGeneration(this.targetNode.fileMetaData.fileName,
+                    this.currentPath.endsWith('/') ?
+                    `${this.currentPath}${this.targetNode.fileMetaData.fileName}`:
+                    `${this.currentPath}/${this.targetNode.fileMetaData.fileName}`,
+                    this.authenticationParameters);
+                this.dispatchEvent(
+                    new CustomEvent('dv-namespace-open-central-dialogbox', {
+                        detail: {node: fileSharingForm}, bubbles: true, composed: true})
+                );
             }
 
             _metadata()
@@ -534,8 +560,9 @@
 
             _setDisabledAttribute(id, singleSelection, multipleSelection, t)
             {
-                if (multipleSelection && (id === 'open' || id === 'metadata' || id === 'webdavUrl' ||
-                    id === 'rename' || id === 'download' || id === 'changeQos' || id === 'qosInfo')) {
+                if (multipleSelection && (id === 'open' || id === 'share' ||
+                    id === 'metadata' || id === 'webdavUrl' || id === 'rename' ||
+                    id === 'download' || id === 'changeQos' || id === 'qosInfo')) {
                     this.$[id].setAttribute('disabled', "");
                 }
 

--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-error-page/shareable-error-page.html
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-error-page/shareable-error-page.html
@@ -1,0 +1,89 @@
+<link rel="import" href="../../../../../bower_components/polymer/polymer-element.html">
+<dom-module id="shareable-error-page">
+    <template>
+        <style>
+            :host {
+                display: flex;
+                width: 100%;
+                box-sizing: border-box;
+                padding: 0 10px;
+                justify-content: center;
+                align-items: center;
+            }
+            iron-icon {
+                color: #f50303;
+                height: 5em;
+                width: 5em;
+            }
+            .container {
+                display: flex;
+                width: 200px;
+                height: 250px;
+                border-radius: 50% 50% 50% 50% / 60% 60% 40% 40%;
+                background-color: #f3f3f3;
+                align-items: center;
+                justify-content: center;
+                flex-direction: column;
+                border: 20px solid #f5f5f5;
+            }
+            .message, .contact {
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                text-align: center;
+            }
+            .code {
+                border-top: solid 1px #ccc;
+                border-bottom: solid 1px #ccc;
+            }
+            .contact {
+                color: #03a9f4;
+            }
+        </style>
+        <div class="container">
+            <div>
+                <iron-icon icon="icons:warning"></iron-icon>
+            </div>
+            <div class="message">
+                <div>
+                    <div>
+                        <h4>Sharing request failed.</h4>
+                    </div>
+                    <div class="code">
+                        <code>[[error.message]]</code>
+                    </div>
+                </div>
+                <div class="contact">
+                    <span>
+                        Please contact your admin.
+                    </span>
+                </div>
+            </div>
+        </div>
+    </template>
+    <script>
+        class ShareableErrorPage extends Polymer.Element
+        {
+            constructor(e)
+            {
+                super();
+                this.error = e;
+            }
+            static get is()
+            {
+                return "shareable-error-page";
+            }
+            static get properties()
+            {
+                return {
+                    error: {
+                        type: Object,
+                        notify: true
+                    },
+                }
+            }
+        }
+        window.customElements.define(ShareableErrorPage.is, ShareableErrorPage);
+    </script>
+</dom-module>

--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-file-generation.html
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-file-generation.html
@@ -1,0 +1,82 @@
+<link rel="import" href="../../../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../../../bower_components/app-layout/app-toolbar/app-toolbar.html">
+<link rel="import" href="../../../../bower_components/paper-spinner/paper-spinner.html">
+<link rel="import" href="../../../../bower_components/paper-icon-button/paper-icon-button.html">
+
+<link rel="import" href="./shareable-request-form/shareable-request-form.html">
+<link rel="import" href="shareable-successful-page/shareable-successful-page.html">
+<link rel="import" href="./shareable-error-page/shareable-error-page.html">
+<dom-module id="shareable-file-generation">
+    <template>
+        <style>
+            :host {
+                display: flex;
+                flex-direction: column;
+                margin: 0 -24px !important;
+                width: 450px;
+                height: 340px;
+                font-size: 0.8em;
+                background: #fff;
+                box-sizing: border-box;
+                padding: 0 !important;
+            }
+            app-toolbar {
+                height: 40px;
+                min-height: 40px;
+                letter-spacing: .0125em;
+                -webkit-font-smoothing: antialiased;
+                background: #fff;
+                color: #222;
+                font-weight: normal;
+                line-height: 24px;
+                font-size: 20px;
+                padding: 0 10px;
+                border-bottom: 1px solid rgba(208,208,208,.87);
+            }
+            app-toolbar paper-icon-button {
+                color: rgba(0,0,0,.87);
+                padding: 0;
+                width: 20px;
+                height: 20px;
+            }
+            #content {
+                flex: 1 1 auto;
+                display: flex;
+            }
+            .loading, .none {
+                display: none;
+            }
+            .loading[is-loading] {
+                position: absolute;
+                height: calc(100% - 40px);
+                left: 0;
+                right: 0;
+                bottom: 0;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+                justify-content: center;
+                text-align: center;
+                font-size: 0.8em;
+            }
+            .loading paper-spinner {
+                width: 40px;
+                height: 40px;
+            }
+        </style>
+        <app-toolbar>
+            <div main-title>Share file</div>
+            <paper-icon-button icon="close" dialog-dismiss></paper-icon-button>
+        </app-toolbar>
+        <div id="content" class$="[[_computedClass(loading)]]">
+            <shareable-request-form id="form"
+                                    loading="{{loading}}"
+                                    file-path="[[fullPath]]" file-name="[[fileName]]"></shareable-request-form>
+        </div>
+        <div class="loading" is-loading$="[[loading]]">
+            <paper-spinner alt="waiting for response" active="{{loading}}"></paper-spinner>
+            <span>processing your request ...</span>
+        </div>
+    </template>
+    <script src="shareable-file-generation.js"></script>
+</dom-module>

--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-file-generation.js
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-file-generation.js
@@ -1,0 +1,80 @@
+class ShareableFileGeneration extends DcacheViewMixins.Commons(Polymer.Element)
+{
+    constructor(fn,fp,auth)
+    {
+        super();
+        this.fileName = fn;
+        this.fullPath = fp;
+        if (auth) {
+            this.authenticationParameters = auth;
+        }
+
+        this._generateListener = this._generateResponseListener.bind(this)
+    }
+    static get is()
+    {
+        return "shareable-file-generation";
+    }
+    static get properties()
+    {
+        return {
+            loading: {
+                type: Boolean,
+                value: false,
+                notify: true
+            },
+        }
+    }
+    connectedCallback()
+    {
+        super.connectedCallback();
+        window.addEventListener('dv-file-sharing-generate-response', this._generateListener);
+    }
+    disconnectedCallback()
+    {
+        super.disconnectedCallback();
+        window.removeEventListener('dv-file-sharing-generate-response', this._generateListener);
+    }
+    _computedClass(l)
+    {
+        if (l) {
+            return ' none'
+        }
+    }
+    _generateResponseListener(event)
+    {
+        const shareableLinkWorker = new Worker('./scripts/tasks/macaroon-request-task.js');
+        shareableLinkWorker.addEventListener('message', (e) => {
+            shareableLinkWorker.terminate();
+            this._handleResponse(e.data, "successful");
+        }, false);
+        shareableLinkWorker.addEventListener('error', (e) => {
+            shareableLinkWorker.terminate();
+            this._handleResponse(e)
+        }, false);
+        shareableLinkWorker.postMessage({
+            "url": this.getFileWebDavUrl(this.fullPath, "read")[0],
+            "body": {
+                "caveats": event.detail.activitiesList.length > 0 ?
+                    [`path:${this.fullPath}`, `activity: ${event.detail.activitiesList.join()}`] :
+                    [`path:${this.fullPath}`],
+                "validity":`${event.detail.validity}`
+            },
+            'upauth' : this.getAuthValue(),
+        });
+    }
+    _handleResponse(payload, type)
+    {
+        let contentChild;
+        if (type === "successful") {
+            contentChild = new ShareableSuccessfulPage(this.fileName, this.fullPath, payload.macaroon);
+        } else {
+            console.error(payload);
+            contentChild = new ShareableErrorPage(payload);
+        }
+        this.removeAllChildren(this.$["content"]);
+        this.$["content"].appendChild(contentChild);
+        this.loading = false;
+    }
+}
+window.customElements.define(ShareableFileGeneration.is, ShareableFileGeneration);

--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-request-form/shareable-request-form.html
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-request-form/shareable-request-form.html
@@ -1,0 +1,153 @@
+<link rel="import" href="../../../../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../../../../bower_components/paper-tooltip/paper-tooltip.html">
+<link rel="import" href="../../../../../bower_components/paper-checkbox/paper-checkbox.html">
+<link rel="import" href="../../../../../bower_components/paper-dropdown-menu/paper-dropdown-menu.html">
+<link rel="import" href="../../../../../bower_components/paper-listbox/paper-listbox.html">
+<link rel="import" href="../../../../../bower_components/paper-item/paper-item.html">
+<link rel="import" href="../../../../../bower_components/paper-button/paper-button.html">
+<dom-module id="shareable-request-form">
+    <template>
+        <style>
+            :host {
+                display: flex;
+                width: 100%;
+                box-sizing: border-box;
+                padding: 0 10px;
+            }
+            .container {
+                display: flex;
+                flex-direction: column;
+                width: 100%;
+            }
+            .description {
+                display: flex;
+                align-items: center;
+                height: 40px;
+                width: 100%;
+                overflow-x: auto;
+            }
+            .form {
+                flex: 1 1 auto;
+                padding-left: 10px;
+            }
+            .title {
+                height: 30px;
+                font-size: 1.25em;
+                display: flex;
+                align-items: center;
+            }
+            .activities, .time {
+                display: flex;
+                flex-direction: column;
+            }
+            .help-icon {
+                width:15px;
+                height:15px;
+                fill: #828282
+            }
+            .help-icon-container {
+                display:inline-block;
+                padding-left: 5px;
+            }
+            .in-visible {
+                visibility: hidden;
+            }
+            .body {
+                display: flex;
+                padding-left: 40px;
+            }
+            .checkboxes-container {
+                flex-wrap: wrap;
+            }
+            .checkbox-wrapper {
+                min-width: 170px;
+                margin: 13px 10px;
+            }
+            paper-checkbox {
+                --paper-checkbox-checked-color: #03a9f4;
+                --paper-checkbox-checked-ink-color: #03a9f4;
+                --paper-checkbox-unchecked-color: #0384ba;
+                --paper-checkbox-unchecked-ink-color: #0384ba;
+            }
+            paper-dropdown-menu {
+                margin-left: 10px;
+                width: 250px;
+            }
+            .buttons {
+                height: 50px;
+                display: flex;
+                justify-content: center;
+                align-items: center;
+            }
+            .btn {
+                background: #03a9f4;
+                color: white;
+                height: 40px;
+                width: 100%;
+            }
+        </style>
+        <div class="container">
+            <div class="description">
+                <span>
+                    Generate a sharable link with macaroon for the file named: <b>[[fileName]]</b>
+                </span>
+            </div>
+            <div class="form">
+                <div class="activities">
+                    <div class="title">
+                        <span>Allowed activities</span>
+                        <div class="help-icon-container">
+                            <iron-icon icon="help" class="help-icon"></iron-icon>
+                            <paper-tooltip>
+                                Select allowed operations. No selection means all available permissions are granted.
+                            </paper-tooltip>
+                        </div>
+                    </div>
+                    <div class="body checkboxes-container">
+                        <template is="dom-repeat" items="{{activities}}">
+                            <div class="checkbox-wrapper">
+                                <paper-checkbox name="activities"
+                                                checked="{{item.checked}}">[[item.name]]</paper-checkbox>
+                                <div class="help-icon-container in-visible">
+                                    <iron-icon icon="help" class="help-icon"></iron-icon>
+                                    <paper-tooltip>[[item.description]]</paper-tooltip>
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+                </div>
+                <div class="time">
+                    <div class="title">
+                        <span>Expiration time</span>
+                        <div class="help-icon-container">
+                            <iron-icon icon="help" class="help-icon"></iron-icon>
+                            <paper-tooltip>For how long do you want to share this file?</paper-tooltip>
+                        </div>
+                    </div>
+                    <div class="body">
+                        <paper-dropdown-menu label="Expiration time"
+                                             name="validity" id="validity"
+                                             vertical-align="bottom"
+                                             horizontal-align="left" required no-label-float>
+                            <paper-listbox slot="dropdown-content"
+                                           class="dropdown-content" selected="1">
+                                <paper-item value="PT1H">1 Hour</paper-item>
+                                <paper-item value="PT3H">3 Hours</paper-item>
+                                <paper-item value="PT6H">6 Hours</paper-item>
+                                <paper-item value="PT12H">12 Hours</paper-item>
+                                <paper-item value="P1D">1 Day</paper-item>
+                                <paper-item value="P2D">2 Days</paper-item>
+                                <paper-item value="P5D">5 Days</paper-item>
+                                <paper-item value="P1W">1 Week</paper-item>
+                            </paper-listbox>
+                        </paper-dropdown-menu>
+                    </div>
+                </div>
+            </div>
+            <div class="buttons">
+                <paper-button id="linkBtn" class="btn" on-tap="_getLink">Generate</paper-button>
+            </div>
+        </div>
+    </template>
+    <script src="shareable-request-form.js"></script>
+</dom-module>

--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-request-form/shareable-request-form.js
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-request-form/shareable-request-form.js
@@ -1,0 +1,47 @@
+class ShareableRequestForm extends Polymer.Element
+{
+    static get is()
+    {
+        return "shareable-request-form";
+    }
+    static get properties()
+    {
+        return {
+            fileName: {
+                type: String,
+                notify: true
+            },
+            activities: {
+                type: Array,
+                value: function () {
+                    return [
+                        {name: 'Download', description: '', checked: true},
+                        {name: 'Upload', description: '', checked: true},
+                        {name: 'Delete', description: '', checked: true},
+                        {name: 'List', description: '', checked: true},
+                    ];
+                },
+                notify: true
+            },
+            loading: {
+                type: Boolean,
+                notify: true
+            },
+        }
+    }
+    _getLink()
+    {
+        this.loading = true;
+        this.classList.add('none');
+        const activitiesList = [];
+        for (let i=0; i<4; i++) {
+            if (this.activities[i].checked) activitiesList.push(this.activities[i].name.toUpperCase());
+        }
+        this.dispatchEvent(new CustomEvent('dv-file-sharing-generate-response', {
+            detail: {
+                activitiesList: activitiesList,
+                validity: this.$.validity.selectedItem.getAttribute("value")
+            }, bubbles: true, composed: true}));
+    }
+}
+window.customElements.define(ShareableRequestForm.is, ShareableRequestForm);

--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-successful-page/shareable-successful-page.html
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-successful-page/shareable-successful-page.html
@@ -1,0 +1,150 @@
+<link rel="import" href="../../../../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../../../../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../../../../../bower_components/paper-styles/paper-styles.html">
+<script src="../../../../../bower_components/qr.js/qr.js"></script>
+<dom-module id="shareable-successful-page">
+    <template>
+        <style is="custom-style" include="paper-material-styles">
+            :host {
+                display: flex;
+                flex-direction: column;
+                width: 100%;
+                box-sizing: border-box;
+                padding: 0 10px 15px 10px;
+            }
+            .description {
+                display: flex;
+                align-items: center;
+                height: 40px;
+                width: 100%;
+                overflow-x: auto;
+            }
+            .result {
+                flex: 1 1 auto;
+                display: flex;
+                padding: 0 10px;
+                box-sizing: border-box;
+            }
+            .text-container {
+                flex: 1 1 auto;
+                box-sizing: border-box;
+                border-right: 1px solid #ccc;
+                padding-right: 10px;
+            }
+            .qr-container {
+                width: 190px;
+                margin-left: 10px;
+                box-sizing: border-box;
+                display: flex;
+                flex-direction: column;
+            }
+            .image-container {
+                flex: 1 1 auto;
+                box-sizing: border-box;
+                padding: 5%;
+            }
+            .image-container > img {
+                width: 100%;
+            }
+
+            .link, .macaroon {
+                display: flex;
+                flex-direction: column;
+                height: 48%;
+                box-sizing: border-box;
+            }
+            .link {
+                margin-bottom: 10px;
+            }
+            .macaroon {
+                margin-top: 5px;
+                border-top: 1px solid #ccc;
+            }
+            .top, .button {
+                height: 26px;
+                box-sizing: border-box;
+            }
+            .body {
+                flex: 1 1 auto;
+                display: flex;
+                box-sizing: border-box;
+            }
+            .macaroon .button, .link .button {
+                margin-top: 4px;
+            }
+            .txt {
+                flex: 1 1 auto;
+                word-wrap: break-word;
+                text-align: justify;
+                text-justify: inter-word;
+                text-indent: 0;
+                resize: none;
+                overflow-y: scroll;
+            }
+            .button paper-button {
+                height: 100%;
+                width: 100%;
+                margin: 0;
+            }
+            .blue {
+                background: #03a9f4;
+                color: white;
+                border-radius: 0;
+            }
+            .green {
+                background: #009688;
+                color: white;
+                border-radius: 0;
+            }
+            .blue iron-icon, .green iron-icon {
+                width: 18px;
+            }
+        </style>
+        <div class="description">
+            <p>
+                File name: <b>[[fileName]]</b>. Copy the generated shareable link or download the QR code.
+            </p>
+        </div>
+        <div class="result">
+            <div class="text-container">
+                <div class="link">
+                    <div class="top">
+                        <span><b>Shareable Link:</b></span>
+                    </div>
+                    <div class="body">
+                        <textarea id="linkText" class="txt" readonly title="">[[generatedLink]]</textarea>
+                    </div>
+                    <div class="button">
+                        <paper-button class="blue" on-tap="_copyLink" raised>
+                            <iron-icon icon="link"> </iron-icon>&nbsp;Copy link</paper-button>
+                    </div>
+                </div>
+                <div class="macaroon">
+                    <div class="top">
+                        <span><b>Macaroon:</b></span>
+                    </div>
+                    <div class="body">
+                        <textarea id="macaroonText" class="txt" readonly title="">[[macaroon]]</textarea>
+                    </div>
+                    <div class="button">
+                        <paper-button class="green" on-tap="_copyMacaroon" raised>
+                            <iron-icon icon="content-copy"> </iron-icon>&nbsp;Copy macaroon</paper-button>
+                    </div>
+                </div>
+            </div>
+            <div class="qr-container">
+                <div class="top">
+                    <span><b>QR Code for the shareable link:</b></span>
+                </div>
+                <div class="image-container paper-material" elevation="1">
+                    <img src$="[[src]]">
+                    <div class="button">
+                        <paper-button on-tap="_downloadQR">
+                            <iron-icon icon="file-download"></iron-icon>Download the QR code</paper-button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </template>
+    <script src="shareable-successful-page.js"></script>
+</dom-module>

--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-successful-page/shareable-successful-page.js
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-successful-page/shareable-successful-page.js
@@ -1,0 +1,82 @@
+class ShareableSuccessfulPage extends Polymer.Element
+{
+    constructor(fn, fp, m)
+    {
+        super();
+        this.fileName = fn;
+        this.fullPath = fp;
+        this.macaroon = m;
+
+        this.generatedLink =
+            `${window.location.href}#!/shared-files?p=${encodeURIComponent(this.fullPath)}&m=${this.macaroon}`;
+        this.src = QRCode.generatePNG(this.generatedLink, {
+            modulesize: 5,
+            margin: 4,
+            version: -1,
+            ecclevel: "L",
+            mask: -1,
+        });
+    }
+    static get is()
+    {
+        return "shareable-successful-page";
+    }
+    static get properties()
+    {
+        return {
+            fileName: {
+                type: String,
+                notify: true
+            },
+            fullPath: {
+                type: String,
+                notify: true
+            },
+            src: {
+                type: String,
+                notify: true
+            },
+            macaroon: {
+                type: String,
+                notify: true
+            },
+            generatedLink: {
+                type: String,
+                notify: true
+            },
+        }
+    }
+    _copy(id)
+    {
+        const copiedLink = this.$[id];
+        copiedLink.select();
+        try {
+            const successful = document.execCommand('copy');
+            const msg = successful ? 'successful' : 'unsuccessful';
+            const linkOrMacaroon = id === "linkText"? 'Shareable link' : 'Macaroon';
+            window.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast',
+                {detail: {message: `${linkOrMacaroon} copied ${msg}`}}
+            ));
+        } catch (err) {
+            window.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast',
+                {detail: {message: `Oops, unable to copy. ${err.message}`}}
+            ));
+        }
+    }
+    _copyLink()
+    {
+        this._copy("linkText");
+    }
+    _copyMacaroon()
+    {
+        this._copy("macaroonText");
+    }
+    _downloadQR()
+    {
+        const a = document.createElement('a');
+        a.href = this.src;
+        a.download = `${this.fileName}_qrcode.png`;
+        a.click();
+    }
+}
+window.customElements.define(ShareableSuccessfulPage.is, ShareableSuccessfulPage);

--- a/src/scripts/tasks/macaroon-request-task.js
+++ b/src/scripts/tasks/macaroon-request-task.js
@@ -1,0 +1,43 @@
+"use strict";
+/**
+ * @param {
+ *     url: @type {String}
+ *          file WebDav door endpoint url
+ *
+ *     body: @type {Object}
+ *          see macaroon doc.
+ *
+ *     upauth: @type {String}
+ *          if set and non-empty, the Authorization header
+ *          will be set with this value.
+ * }
+ */
+self.addEventListener('message', function(e) {
+    const body = JSON.stringify(e.data.body);
+    const headers = new Headers({
+        "Suppress-WWW-Authenticate": "Suppress",
+        "Content-Type": "application/macaroon-request"
+    });
+    if (e.data.upauth && e.data.upauth !== "") {
+        headers.append("Authorization", `${e.data.upauth}`);
+    }
+    if (!e.data.url) {
+        throw new TypeError('The WebDav door endpoint url is not provided.');
+    }
+    fetch(e.data.url, {
+        method: 'POST',
+        mode: "cors",
+        body: body,
+        headers: headers
+    }).then((response) => {
+        if(response.ok) {
+            return response.json();
+        }
+        throw new Error('Network response was not ok.');
+    }).then((rep) => {
+        self.postMessage(rep);
+    }).catch(function(err) {
+        //WORKAROUND: https://stackoverflow.com/questions/30715367/why-can-i-not-throw-inside-a-promise-catch-handler
+        setTimeout(function() { throw err; });
+    });
+}, false);


### PR DESCRIPTION
Motivation:

One of the possible usage of the new added bearer token
called Macaroon in dcache is for sharing files. To allow
dcache-view user to be able to share files, this patch
add support for macaroon request.

Modification:

1. add a share file action in the context menu
2. create a file-sharing-form element which user will use
to restrict macaroon permission.
3. create a script to request for macaroon bear token
and to generate a sharing link for dcache-view.
4. use a 3rd party library for generating QR code for
the generated link.

Result:

1. Genereate a shareable link that can be copied by the user.
2. The generated link is use to create a QR code for the
shareable link that can be downloaded to the user disk.

Note: This is for requuest a shareable link or macaroon.
The viewing of shared files will be in a different patch.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Acked-by: Albert Rossi

Reviewed at https://rb.dcache.org/r/10953/

(cherry picked from commit 96677a11bc7bfca89c75de3f57804db7c76aaee2)