### PR TITLE
dcache-view (file-sharing): add capability to view shared files

### DIFF
--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-successful-page/shareable-successful-page.js
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-successful-page/shareable-successful-page.js
@@ -7,8 +7,7 @@ class ShareableSuccessfulPage extends Polymer.Element
         this.fullPath = fp;
         this.macaroon = m;
 
-        this.generatedLink =
-            `${window.location.href}#!/shared-files?p=${encodeURIComponent(this.fullPath)}&m=${this.macaroon}`;
+        this.generatedLink = `${window.location.href}#!/shared-link?m=${this.macaroon}`;
         this.src = QRCode.generatePNG(this.generatedLink, {
             modulesize: 5,
             margin: 4,

--- a/src/elements/dv-elements/file-sharing/shared-files-page/context-menu/shared-file-list-contextual-content.html
+++ b/src/elements/dv-elements/file-sharing/shared-files-page/context-menu/shared-file-list-contextual-content.html
@@ -1,0 +1,98 @@
+<link rel="import" href="../../../../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../../../../bower_components/paper-listbox/paper-listbox.html">
+<link rel="import" href="../../../../../bower_components/paper-item/paper-item.html">
+<link rel="import" href="../../../../../bower_components/paper-item/paper-icon-item.html">
+
+<link rel="import" href="../../../files-viewer/files-viewer.html">
+<link rel="import" href="../../shareable-file-generation/shareable-request-form/shareable-request-form.html">
+<dom-module id="shared-file-list-contextual-content">
+    <template>
+        <style>
+            :host {
+                display: block;
+                box-sizing: border-box;
+                max-width:100%;
+            }
+            :host paper-listbox {
+                margin: -20px;
+                padding: 0;
+                background: transparent;
+            }
+            paper-icon-item:hover{
+                background: #1565C0;
+                color: #fff;
+                border-radius: 4px;
+                --paper-item-icon: {
+                    color: #fff;
+                }
+            }
+            paper-icon-item {
+                font-size: 0.7em;
+                min-height: 30px;
+                font-weight: normal;
+                padding-right: 0;
+                padding-left: 5px;
+                --paper-item-icon: {
+                    width: 20px;
+                    height: 20px;
+                    margin-right: 10px;
+                    color: #4e4e4e;
+                }
+            }
+            paper-icon-item[disabled] > iron-icon {
+                color: #b7b7b7;
+            }
+            .none {
+                display: none;
+            }
+            #open {
+                border-bottom: 1px solid #cacaca;
+            }
+            #delete, #download {
+                border-top: 1px solid #cacaca;
+            }
+            #arrow {
+                --iron-icon-width: 20px;
+                --iron-icon-height: 20px;
+                margin-left: 75px;
+            }
+        </style>
+        <paper-listbox>
+            <paper-icon-item  id="open" disabled>
+                <iron-icon icon="visibility" slot="item-icon"></iron-icon>
+                [[openOrView]]
+            </paper-icon-item>
+
+            <paper-icon-item id="changeQos" disabled>
+                <iron-icon icon="settings-input-composite" slot="item-icon"></iron-icon>
+                Change QoS
+                <iron-icon id="arrow" icon="av:play-arrow"></iron-icon>
+            </paper-icon-item>
+
+            <paper-icon-item  id="share" disabled>
+                <iron-icon icon="social:share" slot="item-icon"></iron-icon>
+                Share
+            </paper-icon-item>
+            <paper-icon-item id="rename" disabled>
+                <iron-icon icon="editor:border-color" slot="item-icon"></iron-icon>
+                Rename
+            </paper-icon-item>
+
+            <paper-icon-item id="download" disabled>
+                <iron-icon icon="cloud-download" slot="item-icon"></iron-icon>
+                Download
+            </paper-icon-item>
+
+            <paper-icon-item id="metadata" disabled>
+                <iron-icon icon="info" slot="item-icon"></iron-icon>
+                View details
+            </paper-icon-item>
+
+            <paper-icon-item id="delete">
+                <iron-icon icon="delete" slot="item-icon"></iron-icon>
+                Remove from the list
+            </paper-icon-item>
+        </paper-listbox>
+    </template>
+    <script src="shared-file-list-contextual-content.js"></script>
+</dom-module>

--- a/src/elements/dv-elements/file-sharing/shared-files-page/context-menu/shared-file-list-contextual-content.js
+++ b/src/elements/dv-elements/file-sharing/shared-files-page/context-menu/shared-file-list-contextual-content.js
@@ -1,0 +1,169 @@
+class SharedFileListContextualContent extends Polymer.Element
+{
+    constructor(t)
+    {
+        super();
+        this.targetNode = t;
+        this.isExpired = new Date().getTime() - new Date(t.before).getTime() > 0;
+    }
+    static get is()
+    {
+        return 'shared-file-list-contextual-content';
+    }
+    static get properties()
+    {
+        return {
+            targetNode: {
+                type: Object
+            },
+            openOrView: {
+                type: String,
+                notify: true
+            },
+            isExpired: {
+                type: Boolean,
+                notify: true
+            }
+        }
+    }
+    connectedCallback()
+    {
+        super.connectedCallback();
+        this.$.delete.addEventListener('tap', this._delete.bind(this));
+        if (!this.isExpired) {
+            this.$.metadata.addEventListener('tap', this._metadata.bind(this));
+            this.$.rename.addEventListener('tap', this._rename.bind(this));
+            this.$.share.addEventListener('tap', this._share.bind(this));
+
+            this.$['metadata'].removeAttribute('disabled');
+            this.$['share'].removeAttribute('disabled');
+            this.$['open'].removeAttribute('disabled');
+
+            switch (this.targetNode.fileMetaData.fileType) {
+                case "DIR":
+                    this.openOrView = 'Open';
+                    this.$.open.addEventListener('tap', this._openOrDownload.bind(this));
+                    break;
+                case "REGULAR":
+                    if (this.targetNode.fileMetaData.fileMimeType.includes('video') ||
+                        this.targetNode.fileMetaData.fileMimeType.includes('audio')) {
+                        this.openOrView = 'Play';
+                    } else {
+                        this.openOrView = 'View';
+                    }
+                    this.$.download.addEventListener('tap', this._openOrDownload.bind(this));
+                    this.$.open.addEventListener('tap', this._view.bind(this));
+                    this.$['download'].removeAttribute('disabled');
+                    break;
+            }
+        } else {
+            this.openOrView = "Open/View/Play";
+        }
+
+        [...this.shadowRoot.querySelectorAll('paper-icon-item')].forEach(nd => {
+            nd.addEventListener('mouseenter', (e)=>{this._mouseEnter(e)});
+        });
+    }
+    disconnectedCallback()
+    {
+        super.disconnectedCallback();
+        this.$.delete.removeEventListener('tap', this._delete.bind(this));
+        if (!this.isExpired) {
+            this.$.metadata.removeEventListener('tap', this._metadata.bind(this));
+            this.$.rename.removeEventListener('tap', this._rename.bind(this));
+            this.$.share.removeEventListener('tap', this._share.bind(this));
+
+            switch (this.targetNode.fileMetaData.fileType) {
+                case "DIR":
+                    this.$.open.removeEventListener('tap', this._openOrDownload.bind(this));
+                    break;
+                case "REGULAR":
+                    this.$.download.removeEventListener('tap', this._openOrDownload.bind(this));
+                    this.$.open.removeEventListener('tap', this._view.bind(this));
+                    break;
+            }
+        }
+
+        [...this.shadowRoot.querySelectorAll('paper-icon-item')].forEach(nd => {
+            nd.removeEventListener('mouseenter', (e)=>{this._mouseEnter(e)});
+        });
+    }
+    _mouseEnter(e)
+    {
+        if (window.CONFIG.isSomebody && e.composedPath()[0].id === "changeQos") {
+            this.dispatchEvent(
+                new CustomEvent('dv-namespace-open-subcontextmenu', {
+                    detail: {targetNode: this.targetNode}, bubbles: true, composed: true}));
+        }
+        if (e.composedPath()[0].id !== "changeQos") {
+            this.dispatchEvent(new CustomEvent('dv-namespace-close-subcontextmenu', {
+                bubbles: true, composed: true
+            }));
+        }
+    }
+
+    _openOrDownload()
+    {
+        this.dispatchEvent(new CustomEvent('dv-namespace-close-centralcontextmenu', {
+            bubbles: true, composed: true
+        }));
+        this.dispatchEvent(
+            new CustomEvent('dv-file-sharing-open-file', {
+                detail: {file: this.targetNode}, bubbles: true, composed: true}));
+    }
+
+    _rename()
+    {
+        this.dispatchEvent(new CustomEvent('dv-namespace-close-centralcontextmenu', {
+            bubbles: true, composed: true
+        }));
+        this.dispatchEvent(
+            new CustomEvent('dv-file-sharing-open-rename-dialogbox', {
+                detail: {file: this.targetNode}, bubbles: true, composed: true}));
+    }
+    _share()
+    {
+        this.dispatchEvent(new CustomEvent('dv-namespace-close-centralcontextmenu', {
+            bubbles: true, composed: true
+        }));
+        const fileSharingForm =
+            new ShareableRequestForm(this.targetNode.fileMetaData.fileName, this.targetNode.filePath);
+        this.dispatchEvent(
+            new CustomEvent('dv-namespace-open-central-dialogbox', {
+                detail: {node: fileSharingForm}, bubbles: true, composed: true})
+        );
+    }
+    _metadata()
+    {
+        this.dispatchEvent(new CustomEvent('dv-namespace-close-centralcontextmenu', {
+            bubbles: true, composed: true
+        }));
+
+        this.dispatchEvent(
+            new CustomEvent('dv-namespace-open-filemetadata-panel', {
+                detail: {file: this.targetNode}, bubbles: true, composed: true}));
+    }
+    _delete()
+    {
+        this.dispatchEvent(new CustomEvent('dv-namespace-close-centralcontextmenu', {
+            bubbles: true, composed: true
+        }));
+        this.dispatchEvent(new CustomEvent('dv-namespace-file-sharing-remove-items', {
+            detail: {files: [this.targetNode]}, bubbles: true, composed: true
+        }));
+    }
+    _view()
+    {
+        //FIXME: partially done. At least PDF viewer is not working
+        this.dispatchEvent(new CustomEvent('dv-namespace-close-centralcontextmenu', {
+            bubbles: true, composed: true
+        }));
+        const viewer = new FilesViewer(this.targetNode, {"scheme": "Bearer", "value": this.targetNode.macaroon});
+        this.dispatchEvent(
+            new CustomEvent('dv-namespace-open-files-viewer', {
+                detail: {node: viewer}, bubbles: true, composed: true
+            })
+        );
+    }
+}
+window.customElements.define(SharedFileListContextualContent.is, SharedFileListContextualContent);

--- a/src/elements/dv-elements/file-sharing/shared-files-page/shared-files-page.html
+++ b/src/elements/dv-elements/file-sharing/shared-files-page/shared-files-page.html
@@ -1,0 +1,31 @@
+<link rel="import" href="../../../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="view/shared-file-list/shared-file-list.html">
+<link rel="import" href="view/shared-directory-view/shared-directory-view.html">
+<link rel="import" href="context-menu/shared-file-list-contextual-content.html">
+<dom-module id="shared-files-page">
+    <template>
+        <style>
+            :host {
+                width: 100%;
+                height: 100%;
+                display: flex;
+                box-sizing: border-box;
+            }
+            .none {
+                display: none;
+            }
+            #shared-directory-view {
+                width: 100%;
+                height: 100%;
+            }
+        </style>
+        <shared-file-list
+                id="shared-file-list"
+                class="normal"
+                on-contextmenu="_openContextMenu"></shared-file-list>
+        <shared-directory-view
+                id="shared-directory-view"
+                class="none"></shared-directory-view>
+    </template>
+    <script src="shared-files-page.js"></script>
+</dom-module>

--- a/src/elements/dv-elements/file-sharing/shared-files-page/shared-files-page.js
+++ b/src/elements/dv-elements/file-sharing/shared-files-page/shared-files-page.js
@@ -1,0 +1,84 @@
+class SharedFilesPage extends DcacheViewMixins.Commons(Polymer.Element)
+{
+    static get is()
+    {
+        return "shared-files-page";
+    }
+    constructor()
+    {
+        super();
+        this._openFileListener = this._openFile.bind(this);
+        this._showSharedFileListListener = this._showSharedFileList.bind(this);
+    }
+    connectedCallback()
+    {
+        super.connectedCallback();
+        window.addEventListener('dv-file-sharing-open-file', this._openFileListener);
+        window.addEventListener('dv-file-sharing-show-file-list-page', this._showSharedFileListListener);
+    }
+    disconnectedCallback()
+    {
+        super.disconnectedCallback();
+        window.removeEventListener('dv-file-sharing-open-file', this._openFileListener);
+        window.removeEventListener('dv-file-sharing-show-file-list-page', this._showSharedFileListListener);
+    }
+    _openContextMenu(e)
+    {
+        if (e.screenX === 0 && e.screenY === 0) {
+            //FIXME - use dispatchEvent
+            const cc = new SharedFileListContextualContent(this.$['shared-file-list'].selectionMonitoring[0]);
+            app.buildAndOpenContextMenu(e, cc, 245);
+        }
+    }
+    _openFile(e)
+    {
+        if (e.detail.file.fileMetaData.fileType === "DIR") {
+            //open
+            this.$['shared-file-list'].classList.replace('normal', 'none');
+            this.$['shared-directory-view'].classList.replace('none', 'normal');
+            this.dispatchEvent(
+                new CustomEvent('dv-file-sharing-page-switch', {
+                    detail: {page: 'shared-directory-view'}, bubbles: true, composed: true}));
+            this.$['shared-directory-view'].authenticationParameters = {
+                "scheme": "Bearer",
+                "value": e.detail.file.macaroon
+            };
+            this.$['shared-directory-view'].path = e.detail.file.filePath;
+        } else if (e.detail.file.fileMetaData.fileType === "REGULAR") {
+            //download
+            const worker = new Worker('./scripts/tasks/download-task.js');
+            const fileURL = this.getFileWebDavUrl(e.detail.file.filePath, "read")[0];
+            worker.addEventListener('message', (file) => {
+                worker.terminate();
+                const windowUrl = window.URL || window.webkitURL;
+                const url = windowUrl.createObjectURL(file.data);
+                const link = app.$.download;
+                link.href = url;
+                link.download = e.detail.file.fileMetaData.fileName;
+                link.click();
+                windowUrl.revokeObjectURL(url);
+            }, false);
+            worker.addEventListener('error', (e)=> {
+                console.info(e);
+                worker.terminate();
+                this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                    detail: {message: e.message}, bubbles: true, composed: true
+                }));
+            }, false);
+            this.authenticationParameters = {"scheme": "Bearer", "value": e.detail.file.macaroon};
+            worker.postMessage({
+                'url' : fileURL,
+                'mime' : e.detail.file.fileMetaData.fileMimeType,
+                'upauth' : this.getAuthValue(),
+                'return': 'blob'
+            });
+        }
+    }
+    _showSharedFileList()
+    {
+        this.$['shared-directory-view'].path = undefined;
+        this.$['shared-file-list'].classList.replace('none', 'normal');
+        this.$['shared-directory-view'].classList.replace('normal', 'none');
+    }
+}
+window.customElements.define(SharedFilesPage.is, SharedFilesPage);

--- a/src/elements/dv-elements/file-sharing/shared-files-page/view/add-macaroon-form/add-macaroon-form.html
+++ b/src/elements/dv-elements/file-sharing/shared-files-page/view/add-macaroon-form/add-macaroon-form.html
@@ -1,0 +1,97 @@
+<link rel="import" href="../../../../../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../../../../../bower_components/paper-button/paper-button.html">
+<link rel="import" href="../../../../../../bower_components/paper-icon-button/paper-icon-button.html">
+<dom-module id="add-macaroon-form">
+    <template>
+        <style>
+            :host {
+                display: flex;
+                flex-direction: column;
+                margin-top: -8px !important;
+                margin-bottom: 0 !important;
+                padding: 0 !important;
+            }
+            .header {
+                display: flex;
+                align-items: center;
+                padding-left: 10px;
+                padding-right: 10px;
+            }
+            .main-title {
+                flex: 1 1 auto;
+                font-size: 14px;
+                line-height: 4;
+            }
+            .content {
+                margin: auto;
+                padding: 10px;
+                width: 500px;
+            }
+            .textarea-container {
+                border: 1px solid #bdbdbd;
+                width: 500px;
+                height: 60px;
+                box-sizing: border-box;
+                border-radius: 4px;
+                padding: 2px;
+                transition: border-color 1s;
+            }
+            .textarea-container-error {
+                border-color: #ff3620;
+            }
+            textarea {
+                width: 99%;
+                height: 90%;
+                overflow-y: auto;
+                border: none;
+                resize: none;
+                outline: none;
+            }
+            textarea :focus{
+                outline: none;
+            }
+            .button {
+                display: flex;
+                justify-content: flex-end;
+                padding: 10px;
+            }
+            paper-button {
+                text-transform: capitalize;
+                height: 30px;
+                margin: 0;
+            }
+            paper-button + paper-button {
+                margin-left: 10px;
+            }
+            .add {
+                background: #3284e1;
+                color: #fff;
+            }
+            paper-icon-button {
+                padding: 0;
+                width: 20px;
+                height: 20px;
+            }
+            paper-icon-button + paper-icon-button {
+                margin-left: 10px;
+            }
+        </style>
+        <div class="header">
+            <div class="main-title"><b>Add a Shared File</b></div>
+            <paper-icon-button icon="content-paste" title="paste" on-tap="_paste"></paper-icon-button>
+            <paper-icon-button icon="delete-forever" title="clear textarea" on-tap="_delete"></paper-icon-button>
+            <paper-icon-button icon="close" title="cancel" dialog-dismiss></paper-icon-button>
+        </div>
+        <div class="content">
+            <div class="textarea-container" id="macaroon-textarea-container">
+                <textarea id="macaroon-textarea" contenteditable="true"
+                          placeholder="Paste the macaroon here ..."></textarea>
+            </div>
+        </div>
+        <div class="button">
+            <paper-button dialog-dismiss>Cancel</paper-button>
+            <paper-button class="add" on-tap="_add">Add</paper-button>
+        </div>
+    </template>
+    <script src="add-macaroon-form.js"></script>
+</dom-module>

--- a/src/elements/dv-elements/file-sharing/shared-files-page/view/add-macaroon-form/add-macaroon-form.js
+++ b/src/elements/dv-elements/file-sharing/shared-files-page/view/add-macaroon-form/add-macaroon-form.js
@@ -1,0 +1,45 @@
+class AddMacaroonForm extends Polymer.Element
+{
+    static get is()
+    {
+        return 'add-macaroon-form';
+    }
+    constructor()
+    {
+        super();
+        this._errorListener = this._error.bind(this);
+    }
+    connectedCallback()
+    {
+        super.connectedCallback();
+        window.addEventListener('dv-namespace-file-sharing-add-macaroon-error', this._errorListener);
+    }
+    disconnectedCallback()
+    {
+        super.disconnectedCallback();
+        window.removeEventListener('dv-namespace-file-sharing-add-macaroon-error', this._errorListener);
+    }
+    _add()
+    {
+        const macaroon = this.$['macaroon-textarea'].value;
+        this.dispatchEvent(new CustomEvent('dv-namespace-file-sharing-add-macaroon', {
+            detail: {macaroon: macaroon}, bubbles: true, composed: true}));
+    }
+    _error()
+    {
+        this.$['macaroon-textarea-container'].classList.add('textarea-container-error');
+    }
+    _delete()
+    {
+        this.$['macaroon-textarea'].value = "";
+    }
+    _paste()
+    {
+        navigator.clipboard.readText()
+            .then(clipText => this.$['macaroon-textarea'].value = clipText)
+            .catch(() => this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                detail: {message: "Your browser does not support this action."}, bubbles: true,
+                composed: true})));
+    }
+}
+window.customElements.define(AddMacaroonForm.is, AddMacaroonForm);

--- a/src/elements/dv-elements/file-sharing/shared-files-page/view/shared-directory-view/shared-directory-view.html
+++ b/src/elements/dv-elements/file-sharing/shared-files-page/view/shared-directory-view/shared-directory-view.html
@@ -1,0 +1,41 @@
+<link rel="import" href="../../../../../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../../../../../bower_components/app-layout/app-header-layout/app-header-layout.html">
+<link rel="import" href="../../../../../../bower_components/app-layout/app-header/app-header.html">
+<<link rel="import" href="../../../../utils/ajax-ls/view-file.html">
+<dom-module id="shared-directory-view">
+    <template>
+        <style>
+            :host {
+                width: 100%;
+                height: 100%;
+                display: flex;
+                box-sizing: border-box;
+            }
+            #container, app-header-layout, view-file {
+                width: 100%;
+                height: 100%;
+            }
+            .app-header {
+                padding: 0 30px;
+                background: var(--dv-charcoal-grey);
+                height: 45px;
+                border-bottom: solid 1px #ccc;
+                color: #fafafa;
+            }
+            #container {
+                padding: 0 30px;
+                box-sizing: border-box;
+            }
+            list-row-header {
+                margin: 0 !important;
+            }
+        </style>
+        <app-header-layout has-scrolling-region>
+            <app-header slot="header" class="app-header" fixed>
+                <list-row-header></list-row-header>
+            </app-header>
+            <div id="container"></div>
+        </app-header-layout>
+    </template>
+    <script src="shared-directory-view.js"></script>
+</dom-module>

--- a/src/elements/dv-elements/file-sharing/shared-files-page/view/shared-directory-view/shared-directory-view.js
+++ b/src/elements/dv-elements/file-sharing/shared-files-page/view/shared-directory-view/shared-directory-view.js
@@ -1,0 +1,33 @@
+class SharedDirectoryView extends DcacheViewMixins.Commons(Polymer.Element)
+{
+    static get is()
+    {
+        return 'shared-directory-view';
+    }
+    constructor()
+    {
+        super();
+    }
+    static get properties()
+    {
+        return {
+            path: {
+                type: String,
+                notify: true,
+                observer: '_update'
+            }
+        }
+    }
+    _update(path)
+    {
+        this.removeAllChildren(this.$.container);
+        if (path) {
+            this.removeAllChildren(this.$.container);
+            const vf = new ViewFile(path);
+            vf.authenticationParameters = this.authenticationParameters;
+            this.$.container.appendChild(vf);
+            vf.__listDirectory();
+        }
+    }
+}
+window.customElements.define(SharedDirectoryView.is, SharedDirectoryView);

--- a/src/elements/dv-elements/file-sharing/shared-files-page/view/shared-file-list/shared-file-list.html
+++ b/src/elements/dv-elements/file-sharing/shared-files-page/view/shared-file-list/shared-file-list.html
@@ -1,0 +1,224 @@
+<link rel="import" href="../../../../../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../../../../../bower_components/paper-styles/element-styles/paper-material-styles.html">
+<link rel="import" href="../add-macaroon-form/add-macaroon-form.html">
+<link rel="import" href="../../../../rename-input/rename-input.html">
+<dom-module id="shared-file-list">
+    <template>
+        <style include="paper-material-styles">
+            :host {
+                display: flex;
+                width: 100%;
+                flex-direction: column;
+                background: #f9f9f9;
+                box-sizing: border-box;
+                -moz-user-select: none;
+                -webkit-user-select: none;
+                -ms-user-select: none;
+                user-select: none;
+            }
+            .list {
+                width: 100%;
+                height: 100%;
+                overflow: hidden;
+                background: #fff;
+
+            }
+            .add {
+                position: absolute;
+                bottom: 7px;
+                right: 7px;
+                --paper-fab-background: #607D8B;
+                --paper-fab-keyboard-focus-background: #263238;
+            }
+            .none {
+                display: none;
+            }
+            .empty {
+                margin: auto;
+            }
+            .empty-container {
+                display: flex;
+                width: 350px;
+                height: 400px;
+                border-radius: 50% 50% 50% 50% / 60% 60% 40% 40%;
+                background-color: #f3f3f3;
+                align-items: center;
+                justify-content: center;
+                flex-direction: column;
+                border: 50px solid #f5f5f5;
+            }
+            .empty-icon {
+                width: 160px;
+                height: 160px;
+                color: #c3c3c3;
+            }
+            .empty-text {
+                font-size: 0.8em;
+                -webkit-font-smoothing: antialiased;
+                color: #909090;
+                line-height: 1.5;
+            }
+
+
+
+            /*list item styles*/
+            .row[header] {
+                background: #f3f3f3;
+                font-weight: bold;
+            }
+            .header-icon {
+                color: #202124;
+                width: 16px;
+                height: 16px;
+                transition: transform .2s linear, width .2s linear, color .2s linear;
+            }
+            .sort {
+                transform: rotate(180deg);
+            }
+            .content {
+                height: calc(100% - 40px);
+                overflow: auto;
+            }
+            .row + .row {
+                border-top: 1px solid #e8eaed;
+            }
+            .row {
+                display: flex;
+                flex-direction: row;
+                height: 40px;
+                width: 100%;
+                font-size: 0.7em;
+                -webkit-font-smoothing: antialiased;
+                line-height: 40px;
+                align-items: center;
+                box-sizing: border-box;
+                transition: background 2s;
+            }
+            .row[header] .cell {
+                color: #202124;
+                cursor: pointer;
+                border-bottom: 2px solid #f3f3f3;
+                padding-bottom: 0;
+                padding-top: 0;
+                transition: border-bottom-color 500ms;
+            }
+            .row[header] .sorting {
+                border-bottom-color: #80b0ff;
+            }
+            .row[expired] .cell {
+                color: #f30722;
+            }
+
+            .cell {
+                color: rgba(0, 0, 0, 0.541176);
+                white-space: nowrap;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                width: 25%;
+                box-sizing: border-box;
+                padding: 10px;
+            }
+
+            file-icon {
+                padding-right: 5px;
+                padding-left: 5px;
+            }
+            .name {
+                display: flex;
+                flex-direction: row;
+                align-items: center;
+            }
+            .row:not([header]) .owner {
+                display: flex;
+                flex-direction: row;
+            }
+            .user-image {
+                display: flex;
+                align-items: center;
+                margin-right: 5px;
+                --user-image-border-radius: 50%;
+            }
+            .expiring-date {}
+            .row[header] .activities {
+                text-transform: none;
+                font-style: normal;
+            }
+            .row .activities {
+                text-transform: lowercase;
+                font-style: italic;
+            }
+            .selected {
+                background: #e8f0fe;;
+            }
+            .selected .cell {
+                color: #1967d2
+            }
+            #fileName {
+                box-sizing: border-box;
+                flex: 1 1 auto;
+                padding-right: 5px;
+            }
+        </style>
+
+        <div id="list" class="list">
+            <div class="row" id="header" header>
+                <div class="name cell"
+                     on-click="_sortByName" id="name-header"
+                     on-mouseover="_overName" on-mouseout="_outName">
+                    <iron-icon icon="arrow-upward" class="none"></iron-icon> Name
+                </div>
+                <div class="owner cell"
+                     on-click="_sortByOwner" id="owner-header"
+                     on-mouseover="_overOwner" on-mouseout="_outOwner">
+                    <iron-icon icon="arrow-upward" class="none"></iron-icon> Owner
+                </div>
+                <div class="expiring-date cell"
+                     on-click="_sortByExpiringDate" id="expiring-date-header"
+                     on-mouseover="_overExpiringDate" on-mouseout="_outExpiringDate">
+                    <iron-icon icon="arrow-upward" class="none"></iron-icon> Expiration date
+                </div>
+                <div class="activities cell"
+                     on-click="_sortByActivities" id="activities-header"
+                     on-mouseover="_overActivities" on-mouseout="_outActivities">
+                    <iron-icon icon="arrow-upward" class="none"></iron-icon> Allowed activities
+                </div>
+            </div>
+            <div class="content" id="content">
+                <dom-repeat items="{{sharedFiles}}" id="dom-repeat">
+                    <template>
+                        <div class$="[[_computedClass(item.selected)]]" expired$="[[_isExpired(item.before)]]"
+                             on-tap="_select" on-dblclick="_openFile" on-contextmenu="_openContextMenu">
+                            <div class="name cell">
+                                <file-icon></file-icon>
+                                <div id="fileName"><span>[[item.fileName]]</span></div>
+                            </div>
+                            <div class="owner cell">
+                                <div class="user-image">
+                                    <user-image size="20"
+                                                email="[[email]]"
+                                                fallback-value="[[item.owner.name]]"></user-image>
+                                </div>
+                                <div>[[_checkOwner(item.owner.name)]]</div>
+                            </div>
+                            <div class="expiring-date cell">
+                                [[_convertTime(item.before)]]
+                            </div>
+                            <div class="activities cell">
+                                [[_styleActivities(item.activity)]]
+                            </div>
+                        </div>
+                    </template>
+                </dom-repeat>
+            </div>
+        </div>
+        <div id="empty" class="none">
+            <div class="empty-container">
+                <iron-icon class="empty-icon" icon="folder-shared"></iron-icon>
+                <span class="empty-text"><b>Empty! You have no shared file.</b></span>
+                <span class="empty-text">Use the add button below to add a shared file.</span>
+            </div>
+        </div>
+        <paper-fab class="add" icon="add" on-tap="_openAddMacaroonForm"></paper-fab>
+    </template>
+    <script src="shared-file-list.js"></script>
+</dom-module>

--- a/src/elements/dv-elements/file-sharing/shared-files-page/view/shared-file-list/shared-file-list.js
+++ b/src/elements/dv-elements/file-sharing/shared-files-page/view/shared-file-list/shared-file-list.js
@@ -1,0 +1,479 @@
+class SharedFileList extends DcacheViewMixins.Commons(Polymer.Element)
+{
+    static get is()
+    {
+        return 'shared-file-list';
+    }
+    constructor()
+    {
+        super();
+        this._addSharedFileListener = this._addSharedFile.bind(this);
+        this.macaroonList = !!sessionStorage.macaroonList ? sessionStorage.macaroonList.split(" ") : [];
+        this._reset_ = this._clearSelection.bind(this);
+        this._removeItemsListener = this._removeItems.bind(this);
+        this._renameListener = this._renameInputStart.bind(this);
+    }
+    connectedCallback()
+    {
+        super.connectedCallback();
+        this.addEventListener('dv-namespace-rename-input', this._renameInputEnd);
+        window.addEventListener('dv-namespace-file-sharing-add-macaroon', this._addSharedFileListener);
+        window.addEventListener('dv-namespace-reset-element-internal-parameters', this._reset_);
+        window.addEventListener('dv-namespace-file-sharing-remove-items', this._removeItemsListener);
+        window.addEventListener('dv-file-sharing-open-rename-dialogbox', this._renameListener);
+    }
+    disconnectedCallback()
+    {
+        super.disconnectedCallback();
+        this.removeEventListener('dv-namespace-rename-input', this._renameInputEnd);
+        window.removeEventListener('dv-namespace-file-sharing-add-macaroon', this._addSharedFileListener);
+        window.removeEventListener('dv-namespace-reset-element-internal-parameters', this._reset_);
+        window.removeEventListener('dv-namespace-file-sharing-remove-items', this._removeItemsListener);
+        window.removeEventListener('dv-file-sharing-open-rename-dialogbox', this._renameListener);
+    }
+    static get properties()
+    {
+        return {
+            macaroonList: {
+                type: Array,
+                notify: true,
+                observer: '_macaroonListChanged'
+            },
+            sharedFiles: {
+                type: Array,
+                value: [],
+                notify: true
+            },
+            sort: {
+                type: Object,
+                value: {isSorted: false, columnKey : null},
+                notify: true
+            },
+            selectionMonitoring: {
+                type: Array,
+                value: [],
+                notify: true,
+            },
+            multipleSelection: {
+                type: Boolean,
+                value: false,
+                notify: true,
+            }
+        }
+    }
+    static get observers() {
+        return [
+            '_update(sharedFiles.length)'
+        ]
+    }
+    _macaroonListChanged(macaroons)
+    {
+        if (macaroons.length > 0) {
+            this._deserialiseMacaroons(macaroons).then((response) => {
+                response.forEach((child) => {
+                    this.push('sharedFiles', child);
+                    this._appendFM(child);
+                });
+            }).catch((err) => {
+                this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                    detail: {message: err.message}, bubbles: true, composed: true}));
+            })
+        }
+    }
+    _deserialiseMacaroons(macaroonsArray)
+    {
+        return new Promise((resolve, reject) => {
+            if (macaroonsArray.length > 0) {
+                const macaroonDeserialiserWorker = new Worker('./scripts/tasks/macaroon-deserialise-task.js');
+
+                macaroonDeserialiserWorker.addEventListener('message', (e) => {
+                    resolve(e.data);
+                    macaroonDeserialiserWorker.terminate();
+                }, false);
+                macaroonDeserialiserWorker.addEventListener('error', (e)=> {
+                    macaroonDeserialiserWorker.terminate();
+                    reject(e);
+                }, false);
+                macaroonDeserialiserWorker.postMessage({
+                    'macaroons' : macaroonsArray
+                });
+            } else {
+                reject("The argument must be array and must not be empty.");
+            }
+        });
+    }
+    _openAddMacaroonForm()
+    {
+        const addMacaroonDialog = new AddMacaroonForm();
+        this.dispatchEvent(
+            new CustomEvent('dv-namespace-open-central-dialogbox', {
+                detail: {node: addMacaroonDialog}, bubbles: true, composed: true}));
+    }
+    _addSharedFile(e)
+    {
+        if (!!sessionStorage.macaroonList && sessionStorage.macaroonList.includes(e.detail.macaroon)) {
+            if (e.detail.macaroon === "") {
+                this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                    detail: {message: "Please paste the macaroon you want to add to your list."},
+                    bubbles: true, composed: true}));
+            } else {
+                this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                    detail: {message: "This macaroon is already added on the shared file list."},
+                    bubbles: true, composed: true}));
+            }
+
+            this.dispatchEvent(new CustomEvent('dv-namespace-file-sharing-add-macaroon-error', {
+                bubbles: true, composed: true
+            }));
+            return
+        }
+        this._deserialiseMacaroons([e.detail.macaroon]).then((response) => {
+            response.forEach((child) => {
+                if (this.sort.isSorted) {
+                    const index = this.sharedFiles.findIndex((file) => {
+                        return this._getSubPropertyValue(file, this.sort.columnKey, this.sort.type) >
+                            this._getSubPropertyValue(child, this.sort.columnKey, this.sort.type)
+                    });
+                    this.splice('sharedFiles', index === -1 ? this.sharedFiles.length: index, 0, child);
+                } else {
+                    this.push('sharedFiles', child);
+                }
+                this._appendFM(child);
+            });
+
+            this.dispatchEvent(new CustomEvent('dv-namespace-close-central-dialogbox', {
+                bubbles: true, composed: true
+            }));
+            sessionStorage.macaroonList = !!sessionStorage.macaroonList ?
+                `${sessionStorage.macaroonList} ${e.detail.macaroon}` : e.detail.macaroon;
+        }).catch((err) => {
+            this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                detail: {message: err.message}, bubbles: true, composed: true}));
+            this.dispatchEvent(new CustomEvent('dv-namespace-file-sharing-add-macaroon-error', {
+                bubbles: true, composed: true
+            }));
+        });
+    }
+    _update(ls)
+    {
+        if (ls > 0 && this.$['list'].classList.contains('none')) {
+            this.$['list'].classList.replace('none', 'list');
+            this.$['empty'].classList.replace('empty', 'none');
+        } else if (!sessionStorage.macaroonList) {
+            this.$['list'].classList.replace('list', 'none');
+            this.$['empty'].classList.replace('none', 'empty');
+        }
+    }
+    _isExpired(date)
+    {
+        const present =  new Date().getTime();
+        const expirationDate = new Date(date).getTime();
+        return present - expirationDate > 0;
+    }
+    _convertTime(time)
+    {
+        return new Date(time);
+    }
+    _checkOwner(owner)
+    {
+        return owner === sessionStorage.name ? 'me' : owner;
+    }
+    _styleActivities(activities)
+    {
+        return activities === "" || activities === undefined ?
+            "all available activities are allowed" : activities.replace(/,/g, ", ");
+    }
+    _compare(columnKey, dataType)
+    {
+        this.sharedFiles.sort((a, b) => {
+            const A = this._getSubPropertyValue(a, columnKey, dataType);
+            const B = this._getSubPropertyValue(b, columnKey, dataType);
+
+            if (A < B) {
+                return -1;
+            } else if (A > B) {
+                return 1;
+            } else {
+                return 0;
+            }
+        });
+    }
+    _getSubPropertyValue(object, keys, dataType)
+    {
+        const properties = keys.split(".");
+        const type = dataType.split(".").pop();
+        const len = properties.length;
+        let value = object[properties[0]];
+        if (len > 1) {
+            for (let i = 1; i < len; i++) {
+                value = value[properties[i]];
+            }
+        }
+
+        if (type === "date") {
+            return new Date(value).getTime()
+        } else if (type === "string") {
+            return value === "" || value === undefined ? "" : value.toUpperCase();
+        } else {
+            return value;
+        }
+    }
+    _sortByName(e)
+    {
+        this._sort(e, 'name-header', 'fileName', 'string');
+    }
+    _sortByOwner(e)
+    {
+        this._sort(e, 'owner-header', 'owner.name', 'object.string');
+    }
+    _sortByExpiringDate(e)
+    {
+        this._sort(e, 'expiring-date-header', 'before', 'date');
+    }
+    _sortByActivities(e)
+    {
+        this._sort(e, 'activities-header', 'activity', 'string');
+    }
+    _sort(event, nodeName, key, dataType)
+    {
+        this.sort.isSorted = true;
+        this.sort.columnKey = key;
+        this.sort.type = dataType;
+        if (this.$[nodeName].querySelector('iron-icon').classList.contains('header-icon-sorted')) {
+            this.sharedFiles.reverse();
+            this.$['dom-repeat'].items = [];
+            this.$['dom-repeat'].items = this.sharedFiles;
+            this.$[nodeName].querySelector('iron-icon').classList.toggle('sort');
+        } else {
+            this._compare(key, dataType);
+            this.$['dom-repeat'].items = [];
+            this.$['dom-repeat'].items = this.sharedFiles;
+            this.$[nodeName].querySelector('iron-icon').classList.add('header-icon-sorted');
+            this.$[nodeName].classList.add('sorting');
+            const ids = ['name-header', 'owner-header', 'expiring-date-header', 'activities-header'];
+            for (let i =0 ; i < 4; i++) {
+                if (ids[i] !== nodeName &&
+                    this.$[ids[i]].querySelector('iron-icon').classList.contains('header-icon')) {
+                    this.$[ids[i]].querySelector('iron-icon').classList.replace('header-icon', 'none');
+                    this.$[ids[i]].querySelector('iron-icon').classList.remove('header-icon-sorted');
+                    this.$[ids[i]].classList.remove('sorting');
+                }
+            }
+        }
+        event.stopPropagation();
+    }
+    _overName()
+    {
+        this._over(this.$['name-header']);
+    }
+    _outName()
+    {
+        this._out(this.$['name-header']);
+    }
+    _overOwner()
+    {
+        this._over(this.$['owner-header']);
+    }
+    _outOwner()
+    {
+        this._out(this.$['owner-header']);
+    }
+    _overExpiringDate()
+    {
+        this._over(this.$['expiring-date-header']);
+    }
+    _outExpiringDate()
+    {
+        this._out(this.$['expiring-date-header']);
+    }
+    _overActivities()
+    {
+        this._over(this.$['activities-header']);
+    }
+    _outActivities()
+    {
+        this._out(this.$['activities-header']);
+    }
+    _over(node)
+    {
+        if (node.querySelector('iron-icon').classList.contains('none')) {
+            node.querySelector('iron-icon').classList.replace('none', 'header-icon');
+        }
+    }
+    _out(node)
+    {
+        if (node.querySelector('iron-icon').classList.contains('header-icon-sorted')) {
+            return;
+        }
+        if (node.querySelector('iron-icon').classList.contains('header-icon')) {
+            node.querySelector('iron-icon').classList.replace('header-icon', 'none');
+        }
+    }
+    _getFileMetaData(item)
+    {
+        return new Promise((resolve, reject) => {
+            const fileMetaDataWorker = new Worker('./scripts/tasks/file-metadata-task.js');
+            fileMetaDataWorker.addEventListener('message', (e) => {
+                resolve(e.data);
+                fileMetaDataWorker.terminate();
+            }, false);
+            fileMetaDataWorker.addEventListener('error', (e)=> {
+                fileMetaDataWorker.terminate();
+                reject(e);
+            }, false);
+            this.authenticationParameters = {"scheme": "Bearer", "value": item.macaroon};
+            fileMetaDataWorker.postMessage({
+                'endpoint' : `${window.location.origin}${window.CONFIG['dcache-view.endpoints.webapi']}`,
+                'file' : item,
+                'filePath' : item.filePath,
+                'scope' : 'full',
+                'limit' : 100,
+                'upauth' : this.getAuthValue()
+            });
+        });
+    }
+    _appendFM(file)
+    {
+        this._getFileMetaData(file).then((fm) => {
+            const index = this.sharedFiles.indexOf(file);
+            //FIXME - this a very bad workaround - needs to be investigated
+            this.set(`sharedFiles.${index}.fileMetaData`, fm);
+            this.$.content.querySelectorAll('.row')[index].querySelector('file-icon').mimeType =
+                fm.fileMimeType;
+        }).catch(err => {
+            //TODO - use expired style
+            console.info(err.message);
+        });
+    }
+    _select(e)
+    {
+        const initSelectedState = e.model.item.selected;
+        this.set(`sharedFiles.${e.model.index}.selected`, !e.model.item.selected);
+        if (this.multipleSelection) {
+            if (initSelectedState) {
+                const index = this.selectionMonitoring.findIndex((sf) => {
+                    return sf.macaroon === e.model.item.macaroon;
+                });
+                this.splice('selectionMonitoring', index, 1);
+            } else {
+                this.push('selectionMonitoring', e.model.item);
+            }
+        } else {
+            this.selectionMonitoring = [];
+            this.sharedFiles.forEach((sf, i) => {
+                if (sf.macaroon !== e.model.item.macaroon && sf.selected === true) {
+                    this.set(`sharedFiles.${i}.selected`, false);
+                }
+            });
+            if (!initSelectedState) {
+                this.push('selectionMonitoring', e.model.item);
+            }
+        }
+    }
+    _computedClass(isSelected)
+    {
+        let classes = 'row';
+        if (isSelected) {
+            classes += ' selected';
+        }
+        this.updateStyles();
+        return classes;
+    }
+    _clearSelection(event)
+    {
+        if (event.detail.element === "view-file"
+            && event.type === "dv-namespace-reset-element-internal-parameters") {
+            this.sharedFiles.forEach((shareFile, index) => {
+                if (shareFile.selected === true) {
+                    this.set(`sharedFiles.${index}.selected`, false);
+                }
+            });
+            this.selectionMonitoring = [];
+        }
+    }
+    _openFile(e)
+    {
+        const item = e.model.item || e.detail.item;
+
+        if (this._isExpired(item.before)) {
+            this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                detail: {message: "You can not access this file anymore, the macaroon has expired."},
+                bubbles: true, composed: true}));
+            return;
+        }
+        if (item.fileMetaData.fileType) {
+            this.dispatchEvent(
+                new CustomEvent('dv-file-sharing-open-file', {
+                    detail: {file: item}, bubbles: true, composed: true}));
+        }
+    }
+    _openContextMenu(e)
+    {
+        if (!e.model.item.selected) {this._select(e);}
+        e.preventDefault();
+        e.stopPropagation();
+        /**
+         * A WORKAROUND for firefox
+         * TODO: When firefox support web components fully, revisit.
+         */
+        this.dispatchEvent(new MouseEvent('contextmenu', {
+            view: window,
+            bubbles: true,
+            composed: true,
+            cancelable: true,
+            clientX: e.clientX,
+            clientY: e.clientY
+        }));
+    }
+    _removeItems(event)
+    {
+        const files = event.detail.files;
+        const len = this.sharedFiles.length;
+        files.forEach( (file) => {
+            for (let i=0; i < len; i++) {
+                if (this.sharedFiles[i].macaroon === file.macaroon) {
+                    const macaroons = sessionStorage.macaroonList.split(" ");
+                    sessionStorage.macaroonList =
+                        macaroons.filter(macaroon => macaroon !== file.macaroon).join(" ");
+                    this.splice('sharedFiles', i, 1);
+                    if (this.selectionMonitoring.length > 0) {
+                        const idx = this.selectionMonitoring.indexOf(file);
+                        this.splice('selectionMonitoring', idx, 1);
+                    }
+                    break;
+                }
+            }
+        });
+        this._update(this.sharedFiles.length);
+    }
+    _renameInputStart(e)
+    {
+        const index = this.sharedFiles.findIndex((file) => {
+            return file.macaroon === e.detail.file.macaroon;
+        });
+        if (index > -1) {
+            const node = this.$['content'].querySelectorAll('.row')[index];
+            const listRow = node.querySelector('#fileName');
+            const input = new RenameInput(e.detail.file, `Bearer ${e.detail.file.macaroon}`);
+            this.removeAllChildren(listRow);
+            listRow.appendChild(input);
+        }
+    }
+
+    _renameInputEnd(e)
+    {
+        const index = this.sharedFiles.findIndex((file) => {
+            return file.fileMetaData.pnfsId === e.detail.pnfsId;
+        });
+        if (index > -1) {
+            const node = this.$['content'].querySelectorAll('.row')[index];
+            const listRow = node.querySelector('#fileName');
+            const span = document.createElement('span');
+            const t = document.createTextNode(`${e.detail.newFileName}`);
+            span.appendChild(t);
+            this.removeAllChildren(listRow);
+            listRow.appendChild(t);
+        }
+    }
+}
+window.customElements.define(SharedFileList.is, SharedFileList);

--- a/src/elements/dv-elements/rename-input/rename-input.html
+++ b/src/elements/dv-elements/rename-input/rename-input.html
@@ -93,6 +93,11 @@
                 let path;
                 if (this._node.parentPath) {
                     path = this._node.parentPath;
+                } else if (this._node.filePath) {
+                    path = this._node.filePath.slice(0, 1-this._node.filePath.lastIndexOf("/"))
+                } else {
+                    this._abortRename();
+                    return;
                 }
                 const renameWorker = new Worker('./scripts/tasks/namespace-move-operation.js');
                 renameWorker.addEventListener('message', (e) => {

--- a/src/elements/dv-elements/selected-title/selected-title.html
+++ b/src/elements/dv-elements/selected-title/selected-title.html
@@ -60,13 +60,13 @@
             .pagination > div {
                 display:inline-flex;
             }
-            #pagination {
+            #pagination, #shared-pagination {
                 display: inline-block;
                 padding: 0;
                 margin: 0;
                 @apply(--layout-horizontal);
             }
-            #pagination pagination-button {
+            #pagination pagination-button, #shared-pagination pagination-button {
                 display: inline;
             }
             paper-tooltip {
@@ -94,6 +94,11 @@
                 color:#b8b8b8;
                 margin-right:8px;
                 font-size:0.7em;
+            }
+            .shared {
+                text-transform: none;
+                font-size:0.87em;
+                color: #36476c;
             }
         </style>
         <div class="row" class$="[[_computedRowClass(isNamespace)]]">
@@ -131,6 +136,37 @@
             <div class="stamp">dCache.org</div>
         </div>
         <div class$="[[_computedRowClass(isUserLogin)]]"></div>
+        <div class="row" class$="[[_computedRowClass(isSharedPage)]]">
+            <div class="stamp">dCache.org</div>
+            <div class="flex3 pagination">
+                <paper-button class="shared"
+                              on-tap="_shared">Shared with me</paper-button>
+                <div id="shared-pagination"></div>
+            </div>
+            <div class="standardTools flex" id="sharing-standardTools">
+                <div class$="[[_computedClass(isSelected)]]">
+                    <paper-icon-button class="move"
+                                       icon="move-icons:movefolder"
+                                       on-tap="_move"></paper-icon-button>
+                    <paper-tooltip>move the selected file to another directory</paper-tooltip>
+                </div>
+                <div>
+                    <paper-icon-button class="create"
+                                       icon="create-new-folder"
+                                       on-tap="_create"></paper-icon-button>
+                    <paper-tooltip>create new folder</paper-tooltip>
+                </div>
+                <div>
+                    <upload-files-button></upload-files-button>
+                </div>
+                <div>
+                    <paper-icon-button class="info"
+                                       icon="icons:info"
+                                       on-tap="_metadataInfo"></paper-icon-button>
+                    <paper-tooltip>metadata information</paper-tooltip>
+                </div>
+            </div>
+        </div>
     </template>
     <script>
         class SelectedTitle extends DcacheViewMixins.Commons(Polymer.Element)
@@ -142,6 +178,7 @@
                 this._setCurrentPath_ = this._setCurrentPath.bind(this);
                 this._resetViewFileDependentParameters_ = this._resetViewFileDependentParameters.bind(this);
                 this._setAuthenticationParameters_ = this._setAuthenticationParameters.bind(this);
+                this._sharingPageSwitch_ = this._sharingPageSwitchListener.bind(this);
             }
             ready()
             {
@@ -161,10 +198,12 @@
             connectedCallback()
             {
                 super.connectedCallback();
+                this.$["sharing-standardTools"].style.visibility = "hidden";
                 window.addEventListener('dv-namespace-x-selected-items-changed', this._isSelectedChanged_);
                 window.addEventListener('dv-namespace-current-path', this._setCurrentPath_);
                 window.addEventListener('dv-namespace-view-file-created', this._resetViewFileDependentParameters_);
                 window.addEventListener('dv-namespace-current-authenticationParameters', this._setAuthenticationParameters_);
+                window.addEventListener('dv-file-sharing-page-switch', this._sharingPageSwitch_);
             }
 
             disconnectedCallback()
@@ -174,6 +213,7 @@
                 window.removeEventListener('dv-namespace-current-path', this._setCurrentPath_);
                 window.removeEventListener('dv-namespace-view-file-created', this._resetViewFileDependentParameters_);
                 window.removeEventListener('dv-namespace-current-authenticationParameters', this._setAuthenticationParameters_);
+                window.removeEventListener('dv-file-sharing-page-switch', this._sharingPageSwitch_);
             }
 
             static get properties()
@@ -205,6 +245,11 @@
                         notify: true
                     },
 
+                    isSharedPage: {
+                        type: Boolean,
+                        notify: true
+                    },
+
                     _selectedItems: {
                         type: Array,
                         value: [],
@@ -230,18 +275,27 @@
                     case "home":
                         this.isUserLogin = false;
                         this.isAdmin = false;
+                        this.isSharedPage = false;
                         this.isNamespace = true;
                         break;
                     case "admin":
                     case "user-profile":
                         this.isUserLogin = false;
                         this.isNamespace = false;
+                        this.isSharedPage = false;
                         this.isAdmin = true;
                         break;
                     case "user-login":
                         this.isNamespace = false;
                         this.isAdmin = false;
+                        this.isSharedPage = false;
                         this.isUserLogin = true;
+                        break;
+                    case "shared-files":
+                        this.isUserLogin = false;
+                        this.isAdmin = false;
+                        this.isNamespace = false;
+                        this.isSharedPage = true;
                         break;
                 }
             }
@@ -254,6 +308,7 @@
                 this.dispatchEvent(
                     new CustomEvent('dv-namespace-open-filemetadata-panel', {
                         detail: {file: {
+                            authenticationParameters: this.authenticationParameters,
                             filePath: path,
                             fileMetaData: this.isSelected ? Object.assign({}, this._selectedItems[0]): undefined
                         }}, bubbles: true, composed: true
@@ -418,6 +473,18 @@
             _setAuthenticationParameters(e)
             {
                 this.authenticationParameters = e.detail.authenticationParameters;
+            }
+            _shared()
+            {
+                this.$["sharing-standardTools"].style.visibility = "hidden";
+                this.dispatchEvent(
+                    new CustomEvent('dv-file-sharing-show-file-list-page', {bubbles: true, composed: true}));
+            }
+            _sharingPageSwitchListener(e)
+            {
+                if (e.detail.page === "shared-directory-view") {
+                    this.$["sharing-standardTools"].style.visibility = "visible";
+                }
             }
         }
         window.customElements.define(SelectedTitle.is, SelectedTitle);

--- a/src/elements/elements.html
+++ b/src/elements/elements.html
@@ -79,6 +79,7 @@
 <link rel="import" href="dv-elements/user-profile/user-profile.html">
 <link rel="import" href="dv-elements/drag-and-drop/drag-enter-toast.html">
 <link rel="import" href="dv-elements/drag-and-drop/dnd-upload.html">
+<link rel="import" href="dv-elements/file-sharing/shared-files-page/shared-files-page.html">
 <link rel="import" href="dv-elements/admin/charts/billing-chart.html">
 <link rel="import" href="dv-elements/admin/charts/pool-info-chart.html">
 <link rel="import" href="dv-elements/admin/charts/layout-bar.html">

--- a/src/elements/routing.html
+++ b/src/elements/routing.html
@@ -134,8 +134,35 @@
             app.params = "";
         });
 
+        page('/shared-link', function (dt) {
+            if (dt.querystring) {
+                const arr = dt.querystring.split('&');
+                if (arr.length === 0 || !dt.querystring.includes("m=")) {
+                    page.redirect(app.baseUrl);
+                    window.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                        detail: {
+                            message: "Bad Request. The query parameter of the shareable link must contain the macaroon."
+                        }, bubbles: true,
+                        composed: true
+                    }));
+                    return;
+                }
+                const macaroon = arr.filter(function(el) {
+                    if(el.match('m') !== null) return true; })[0].split('=')[1];
+                app.$['selectedTitle']._shared();
+                window.dispatchEvent(new CustomEvent('dv-namespace-file-sharing-add-macaroon', {
+                    detail: {macaroon: macaroon}}));
+            }
+            page.redirect("/shared-files");
+        });
+
+        page('/shared-files', function () {
+            app.route = 'shared-files';
+            app.params = "";
+        });
+
         // 404
-        page('*', function() {
+        page('*', function(dt) {
             /**
              * Handle OpenID Connect Server Redirect
              */
@@ -184,6 +211,9 @@
 
                 userAuth.send("Bearer");
                 sessionStorage.removeItem('redirect');
+                return;
+            } else if (dt.pathname === "/#!/shared-link") {
+                page(`/shared-link?${dt.querystring}`);
                 return;
             }
 

--- a/src/index.html
+++ b/src/index.html
@@ -250,6 +250,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                     </paper-item>
 
                                     <paper-item>
+                                        <a data-route="shared-files" href$="{{baseUrl}}shared-files">
+                                            <paper-fab icon="folder-shared"
+                                                       title="shared files" class="orange" mini></paper-fab>
+                                        </a>
+                                    </paper-item>
+
+                                    <paper-item>
                                         <a data-route="admin" href$="{{baseUrl}}admin"><!--dashboard-->
                                             <paper-fab icon="supervisor-account" title="admin" class="green" mini></paper-fab>
                                         </a>
@@ -294,6 +301,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                         <view-file id="homeDir"></view-file>
                                                     </div>
                                                 </paper-header-panel>
+                                            </section>
+
+                                            <section data-route="shared-files"
+                                                     class="fit" style="background-color:#ececec;">
+                                                <shared-files-page id="shared-with-me" on-click="click"
+                                                                   on-contextmenu="currentDirContext"></shared-files-page>
                                             </section>
 
                                             <section data-route="admin" class="fit"

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -51,7 +51,13 @@
         const parent = currentVF.parentNode;
         parent.removeChild(currentVF);
         const newVF = new ViewFile(path);
-        if (auth) newVF.authenticationParameters = auth;
+        if (auth) {
+            newVF.authenticationParameters = auth;
+        } else {
+            if (app.route === "shared-file") {
+                newVF.authenticationParameters = parent.__dataHost.authenticationParameters;
+            }
+        }
         parent.appendChild(newVF);
         newVF.__listDirectory();
     };
@@ -412,6 +418,22 @@
     {
         if (app.route === "home") {
             return app.$["homedir"].querySelector('view-file');
+        } else if (app.route === "shared-files") {
+            const fileSharingPage = app.$["shared-with-me"];
+            const sharedDirectoryView = fileSharingPage.$["shared-directory-view"];
+            if (!sharedDirectoryView.classList.contains("none")) {
+                const len = sharedDirectoryView.$["container"].children.length;
+                let j = -1;
+                for (let i = 0; i < len; i++) {
+                    if (sharedDirectoryView.$["container"].children[i].tagName === "VIEW-FILE") {
+                        j = i;
+                        break;
+                    }
+                }
+                if (j > -1) {
+                    return sharedDirectoryView.$["container"].children[j];
+                }
+            }
         }
     }
     function getFileWebDavUrl(path, operationType)
@@ -622,6 +644,8 @@
             let auth;
             if (e.detail.file.authenticationParameters) {
                 auth = e.detail.file.authenticationParameters;
+            } else if (e.detail.file.macaroon) {
+                auth = {"scheme": "Bearer", "value": e.detail.file.macaroon};
             }
             app.removeAllChildren(app.$.metadataDrawer);
             const file = e.detail.file;

--- a/src/scripts/lazy-loads/macaroon-deserialiser.js
+++ b/src/scripts/lazy-loads/macaroon-deserialiser.js
@@ -1,0 +1,2105 @@
+class Base64
+{
+    //source: https://github.com/beatgammit/base64-js
+    constructor()
+    {
+        this.lookup = [];
+        this.revLookup = [];
+        this.Arr = typeof Uint8Array !== 'undefined' ? Uint8Array : Array;
+
+        this.code = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+        for (var i = 0, len = this.code.length; i < len; ++i) {
+            this.lookup[i] = this.code[i];
+            this.revLookup[this.code.charCodeAt(i)] = i;
+        }
+        this.revLookup['-'.charCodeAt(0)] = 62;
+        this.revLookup['_'.charCodeAt(0)] = 63;
+    }
+    getLens(b64) {
+        const len = b64.length;
+
+        if (len % 4 > 0) {
+            throw new Error('Invalid string. Length must be a multiple of 4');
+        }
+        const validLen = b64.indexOf('=') === -1 ? len : b64.indexOf('=');
+        const placeHoldersLen = validLen === len ? 0 : 4 - (validLen % 4);
+        return [validLen, placeHoldersLen];
+    }
+
+    byteLength(b64)
+    {
+        const lens = this.getLens(b64);
+        const validLen = lens[0];
+        const placeHoldersLen = lens[1];
+        return ((validLen + placeHoldersLen) * 3 / 4) - placeHoldersLen
+    }
+    _byteLength(b64, validLen, placeHoldersLen)
+    {
+        return ((validLen + placeHoldersLen) * 3 / 4) - placeHoldersLen
+    }
+    toByteArray(b64)
+    {
+        let tmp;
+        const lens = this.getLens(b64);
+        const validLen = lens[0];
+        const placeHoldersLen = lens[1];
+        const arr = new this.Arr(this._byteLength(b64, validLen, placeHoldersLen));
+        let curByte = 0;
+        const len = placeHoldersLen > 0 ? validLen - 4 : validLen;
+        for (let i = 0; i < len; i += 4) {
+            tmp = (this.revLookup[b64.charCodeAt(i)] << 18) |
+                (this.revLookup[b64.charCodeAt(i + 1)] << 12) |
+                (this.revLookup[b64.charCodeAt(i + 2)] << 6) |
+                this.revLookup[b64.charCodeAt(i + 3)];
+            arr[curByte++] = (tmp >> 16) & 0xFF;
+            arr[curByte++] = (tmp >> 8) & 0xFF;
+            arr[curByte++] = tmp & 0xFF;
+        }
+
+        //FIXME: issue filed: https://github.com/beatgammit/base64-js/issues/50
+        /*if (placeHoldersLen === 2) {
+            tmp =
+                (this.revLookup[b64.charCodeAt(i)] << 2) |
+                (this.revLookup[b64.charCodeAt(i + 1)] >> 4);
+            arr[curByte++] = tmp & 0xFF
+        }
+
+        if (placeHoldersLen === 1) {
+            tmp =
+                (this.revLookup[b64.charCodeAt(i)] << 10) |
+                (this.revLookup[b64.charCodeAt(i + 1)] << 4) |
+                (this.revLookup[b64.charCodeAt(i + 2)] >> 2);
+            arr[curByte++] = (tmp >> 8) & 0xFF;
+            arr[curByte++] = tmp & 0xFF;
+        }*/
+
+        return arr
+    }
+    tripletToBase64(num)
+    {
+        return lookup[num >> 18 & 0x3F] +
+            lookup[num >> 12 & 0x3F] +
+            lookup[num >> 6 & 0x3F] +
+            lookup[num & 0x3F]
+    }
+    encodeChunk(uint8, start, end)
+    {
+        const output = [];
+        for (let i = start; i < end; i += 3) {
+            const tmp =
+                ((uint8[i] << 16) & 0xFF0000) +
+                ((uint8[i + 1] << 8) & 0xFF00) +
+                (uint8[i + 2] & 0xFF);
+            output.push(this.tripletToBase64(tmp))
+        }
+        return output.join('')
+    }
+    fromByteArray(uint8)
+    {
+        let tmp;
+        const len = uint8.length;
+        const extraBytes = len % 3;
+        const parts = [];
+        const maxChunkLength = 16383;
+
+        for (let i = 0, len2 = len - extraBytes; i < len2; i += maxChunkLength) {
+            parts.push(this.encodeChunk(
+                uint8, i, (i + maxChunkLength) > len2 ? len2 : (i + maxChunkLength)
+            ))
+        }
+
+        // pad the end with zeros, but make sure to not forget the extra bytes
+        if (extraBytes === 1) {
+            tmp = uint8[len - 1];
+            parts.push(
+                lookup[tmp >> 2] +
+                lookup[(tmp << 4) & 0x3F] +
+                '=='
+            )
+        } else if (extraBytes === 2) {
+            tmp = (uint8[len - 2] << 8) + uint8[len - 1];
+            parts.push(
+                lookup[tmp >> 10] +
+                lookup[(tmp >> 4) & 0x3F] +
+                lookup[(tmp << 2) & 0x3F] +
+                '='
+            )
+        }
+
+        return parts.join('')
+    }
+}
+
+//Source: https://github.com/feross/buffer
+const base64 = new Base64();
+const K_MAX_LENGTH = 0x7fffffff;
+Buffer.TYPED_ARRAY_SUPPORT = typedArraySupport()
+
+if (!Buffer.TYPED_ARRAY_SUPPORT && typeof console !== 'undefined' &&
+    typeof console.error === 'function') {
+    console.error(
+        'This browser lacks typed array (Uint8Array) support which is required by ' +
+        '`buffer` v5.x. Use `buffer` v4.x if you require old browser support.'
+    )
+}
+
+function typedArraySupport () {
+    // Can typed array instances can be augmented?
+    try {
+        var arr = new Uint8Array(1)
+        arr.__proto__ = { __proto__: Uint8Array.prototype, foo: function () { return 42 } }
+        return arr.foo() === 42
+    } catch (e) {
+        return false
+    }
+}
+
+Object.defineProperty(Buffer.prototype, 'parent', {
+    enumerable: true,
+    get: function () {
+        if (!Buffer.isBuffer(this)) return undefined
+        return this.buffer
+    }
+})
+
+Object.defineProperty(Buffer.prototype, 'offset', {
+    enumerable: true,
+    get: function () {
+        if (!Buffer.isBuffer(this)) return undefined
+        return this.byteOffset
+    }
+})
+
+function createBuffer (length) {
+    if (length > K_MAX_LENGTH) {
+        throw new RangeError('The value "' + length + '" is invalid for option "size"')
+    }
+    // Return an augmented `Uint8Array` instance
+    var buf = new Uint8Array(length)
+    buf.__proto__ = Buffer.prototype
+    return buf
+}
+
+/**
+ * The Buffer constructor returns instances of `Uint8Array` that have their
+ * prototype changed to `Buffer.prototype`. Furthermore, `Buffer` is a subclass of
+ * `Uint8Array`, so the returned instances will have all the node `Buffer` methods
+ * and the `Uint8Array` methods. Square bracket notation works as expected -- it
+ * returns a single octet.
+ *
+ * The `Uint8Array` prototype remains unmodified.
+ */
+
+function Buffer (arg, encodingOrOffset, length) {
+    // Common case.
+    if (typeof arg === 'number') {
+        if (typeof encodingOrOffset === 'string') {
+            throw new TypeError(
+                'The "string" argument must be of type string. Received type number'
+            )
+        }
+        return allocUnsafe(arg)
+    }
+    return from(arg, encodingOrOffset, length)
+}
+
+// Fix subarray() in ES2016. See: https://github.com/feross/buffer/pull/97
+if (typeof Symbol !== 'undefined' && Symbol.species != null &&
+    Buffer[Symbol.species] === Buffer) {
+    Object.defineProperty(Buffer, Symbol.species, {
+        value: null,
+        configurable: true,
+        enumerable: false,
+        writable: false
+    })
+}
+
+Buffer.poolSize = 8192 // not used by this implementation
+
+function from (value, encodingOrOffset, length) {
+    if (typeof value === 'string') {
+        return fromString(value, encodingOrOffset)
+    }
+
+    if (ArrayBuffer.isView(value)) {
+        return fromArrayLike(value)
+    }
+
+    if (value == null) {
+        throw TypeError(
+            'The first argument must be one of type string, Buffer, ArrayBuffer, Array, ' +
+            'or Array-like Object. Received type ' + (typeof value)
+        )
+    }
+
+    if (isInstance(value, ArrayBuffer) ||
+        (value && isInstance(value.buffer, ArrayBuffer))) {
+        return fromArrayBuffer(value, encodingOrOffset, length)
+    }
+
+    if (typeof value === 'number') {
+        throw new TypeError(
+            'The "value" argument must not be of type number. Received type number'
+        )
+    }
+
+    var valueOf = value.valueOf && value.valueOf()
+    if (valueOf != null && valueOf !== value) {
+        return Buffer.from(valueOf, encodingOrOffset, length)
+    }
+
+    var b = fromObject(value)
+    if (b) return b
+
+    if (typeof Symbol !== 'undefined' && Symbol.toPrimitive != null &&
+        typeof value[Symbol.toPrimitive] === 'function') {
+        return Buffer.from(
+            value[Symbol.toPrimitive]('string'), encodingOrOffset, length
+        )
+    }
+
+    throw new TypeError(
+        'The first argument must be one of type string, Buffer, ArrayBuffer, Array, ' +
+        'or Array-like Object. Received type ' + (typeof value)
+    )
+}
+
+/**
+ * Functionally equivalent to Buffer(arg, encoding) but throws a TypeError
+ * if value is a number.
+ * Buffer.from(str[, encoding])
+ * Buffer.from(array)
+ * Buffer.from(buffer)
+ * Buffer.from(arrayBuffer[, byteOffset[, length]])
+ **/
+Buffer.from = function (value, encodingOrOffset, length) {
+    return from(value, encodingOrOffset, length)
+}
+
+// Note: Change prototype *after* Buffer.from is defined to workaround Chrome bug:
+// https://github.com/feross/buffer/pull/148
+Buffer.prototype.__proto__ = Uint8Array.prototype
+Buffer.__proto__ = Uint8Array
+
+function assertSize (size) {
+    if (typeof size !== 'number') {
+        throw new TypeError('"size" argument must be of type number')
+    } else if (size < 0) {
+        throw new RangeError('The value "' + size + '" is invalid for option "size"')
+    }
+}
+
+function alloc (size, fill, encoding) {
+    assertSize(size)
+    if (size <= 0) {
+        return createBuffer(size)
+    }
+    if (fill !== undefined) {
+        // Only pay attention to encoding if it's a string. This
+        // prevents accidentally sending in a number that would
+        // be interpretted as a start offset.
+        return typeof encoding === 'string'
+            ? createBuffer(size).fill(fill, encoding)
+            : createBuffer(size).fill(fill)
+    }
+    return createBuffer(size)
+}
+
+/**
+ * Creates a new filled Buffer instance.
+ * alloc(size[, fill[, encoding]])
+ **/
+Buffer.alloc = function (size, fill, encoding) {
+    return alloc(size, fill, encoding)
+}
+
+function allocUnsafe (size) {
+    assertSize(size)
+    return createBuffer(size < 0 ? 0 : checked(size) | 0)
+}
+
+/**
+ * Equivalent to Buffer(num), by default creates a non-zero-filled Buffer instance.
+ * */
+Buffer.allocUnsafe = function (size) {
+    return allocUnsafe(size)
+}
+/**
+ * Equivalent to SlowBuffer(num), by default creates a non-zero-filled Buffer instance.
+ */
+Buffer.allocUnsafeSlow = function (size) {
+    return allocUnsafe(size)
+}
+
+function fromString (string, encoding) {
+    if (typeof encoding !== 'string' || encoding === '') {
+        encoding = 'utf8'
+    }
+
+    if (!Buffer.isEncoding(encoding)) {
+        throw new TypeError('Unknown encoding: ' + encoding)
+    }
+
+    var length = byteLength(string, encoding) | 0
+    var buf = createBuffer(length)
+
+    var actual = buf.write(string, encoding)
+
+    if (actual !== length) {
+        // Writing a hex string, for example, that contains invalid characters will
+        // cause everything after the first invalid character to be ignored. (e.g.
+        // 'abxxcd' will be treated as 'ab')
+        buf = buf.slice(0, actual)
+    }
+
+    return buf
+}
+
+function fromArrayLike (array) {
+    var length = array.length < 0 ? 0 : checked(array.length) | 0
+    var buf = createBuffer(length)
+    for (var i = 0; i < length; i += 1) {
+        buf[i] = array[i] & 255
+    }
+    return buf
+}
+
+function fromArrayBuffer (array, byteOffset, length) {
+    if (byteOffset < 0 || array.byteLength < byteOffset) {
+        throw new RangeError('"offset" is outside of buffer bounds')
+    }
+
+    if (array.byteLength < byteOffset + (length || 0)) {
+        throw new RangeError('"length" is outside of buffer bounds')
+    }
+
+    var buf
+    if (byteOffset === undefined && length === undefined) {
+        buf = new Uint8Array(array)
+    } else if (length === undefined) {
+        buf = new Uint8Array(array, byteOffset)
+    } else {
+        buf = new Uint8Array(array, byteOffset, length)
+    }
+
+    // Return an augmented `Uint8Array` instance
+    buf.__proto__ = Buffer.prototype
+    return buf
+}
+
+function fromObject (obj) {
+    if (Buffer.isBuffer(obj)) {
+        var len = checked(obj.length) | 0
+        var buf = createBuffer(len)
+
+        if (buf.length === 0) {
+            return buf
+        }
+
+        obj.copy(buf, 0, 0, len)
+        return buf
+    }
+
+    if (obj.length !== undefined) {
+        if (typeof obj.length !== 'number' || numberIsNaN(obj.length)) {
+            return createBuffer(0)
+        }
+        return fromArrayLike(obj)
+    }
+
+    if (obj.type === 'Buffer' && Array.isArray(obj.data)) {
+        return fromArrayLike(obj.data)
+    }
+}
+
+function checked (length) {
+    // Note: cannot use `length < K_MAX_LENGTH` here because that fails when
+    // length is NaN (which is otherwise coerced to zero.)
+    if (length >= K_MAX_LENGTH) {
+        throw new RangeError('Attempt to allocate Buffer larger than maximum ' +
+            'size: 0x' + K_MAX_LENGTH.toString(16) + ' bytes')
+    }
+    return length | 0
+}
+
+function SlowBuffer (length) {
+    if (+length != length) { // eslint-disable-line eqeqeq
+        length = 0
+    }
+    return Buffer.alloc(+length)
+}
+
+Buffer.isBuffer = function isBuffer (b) {
+    return b != null && b._isBuffer === true &&
+        b !== Buffer.prototype // so Buffer.isBuffer(Buffer.prototype) will be false
+}
+
+Buffer.compare = function compare (a, b) {
+    if (isInstance(a, Uint8Array)) a = Buffer.from(a, a.offset, a.byteLength)
+    if (isInstance(b, Uint8Array)) b = Buffer.from(b, b.offset, b.byteLength)
+    if (!Buffer.isBuffer(a) || !Buffer.isBuffer(b)) {
+        throw new TypeError(
+            'The "buf1", "buf2" arguments must be one of type Buffer or Uint8Array'
+        )
+    }
+
+    if (a === b) return 0
+
+    var x = a.length
+    var y = b.length
+
+    for (var i = 0, len = Math.min(x, y); i < len; ++i) {
+        if (a[i] !== b[i]) {
+            x = a[i]
+            y = b[i]
+            break
+        }
+    }
+
+    if (x < y) return -1
+    if (y < x) return 1
+    return 0
+}
+
+Buffer.isEncoding = function isEncoding (encoding) {
+    switch (String(encoding).toLowerCase()) {
+        case 'hex':
+        case 'utf8':
+        case 'utf-8':
+        case 'ascii':
+        case 'latin1':
+        case 'binary':
+        case 'base64':
+        case 'ucs2':
+        case 'ucs-2':
+        case 'utf16le':
+        case 'utf-16le':
+            return true
+        default:
+            return false
+    }
+}
+
+Buffer.concat = function concat (list, length) {
+    if (!Array.isArray(list)) {
+        throw new TypeError('"list" argument must be an Array of Buffers')
+    }
+
+    if (list.length === 0) {
+        return Buffer.alloc(0)
+    }
+
+    var i
+    if (length === undefined) {
+        length = 0
+        for (i = 0; i < list.length; ++i) {
+            length += list[i].length
+        }
+    }
+
+    var buffer = Buffer.allocUnsafe(length)
+    var pos = 0
+    for (i = 0; i < list.length; ++i) {
+        var buf = list[i]
+        if (isInstance(buf, Uint8Array)) {
+            buf = Buffer.from(buf)
+        }
+        if (!Buffer.isBuffer(buf)) {
+            throw new TypeError('"list" argument must be an Array of Buffers')
+        }
+        buf.copy(buffer, pos)
+        pos += buf.length
+    }
+    return buffer
+}
+
+function byteLength (string, encoding) {
+    if (Buffer.isBuffer(string)) {
+        return string.length
+    }
+    if (ArrayBuffer.isView(string) || isInstance(string, ArrayBuffer)) {
+        return string.byteLength
+    }
+    if (typeof string !== 'string') {
+        throw new TypeError(
+            'The "string" argument must be one of type string, Buffer, or ArrayBuffer. ' +
+            'Received type ' + typeof string
+        )
+    }
+
+    var len = string.length
+    var mustMatch = (arguments.length > 2 && arguments[2] === true)
+    if (!mustMatch && len === 0) return 0
+
+    // Use a for loop to avoid recursion
+    var loweredCase = false
+    for (;;) {
+        switch (encoding) {
+            case 'ascii':
+            case 'latin1':
+            case 'binary':
+                return len
+            case 'utf8':
+            case 'utf-8':
+                return utf8ToBytes(string).length
+            case 'ucs2':
+            case 'ucs-2':
+            case 'utf16le':
+            case 'utf-16le':
+                return len * 2
+            case 'hex':
+                return len >>> 1
+            case 'base64':
+                return base64ToBytes(string).length
+            default:
+                if (loweredCase) {
+                    return mustMatch ? -1 : utf8ToBytes(string).length // assume utf8
+                }
+                encoding = ('' + encoding).toLowerCase()
+                loweredCase = true
+        }
+    }
+}
+Buffer.byteLength = byteLength
+
+function slowToString (encoding, start, end) {
+    var loweredCase = false
+
+    // No need to verify that "this.length <= MAX_UINT32" since it's a read-only
+    // property of a typed array.
+
+    // This behaves neither like String nor Uint8Array in that we set start/end
+    // to their upper/lower bounds if the value passed is out of range.
+    // undefined is handled specially as per ECMA-262 6th Edition,
+    // Section 13.3.3.7 Runtime Semantics: KeyedBindingInitialization.
+    if (start === undefined || start < 0) {
+        start = 0
+    }
+    // Return early if start > this.length. Done here to prevent potential uint32
+    // coercion fail below.
+    if (start > this.length) {
+        return ''
+    }
+
+    if (end === undefined || end > this.length) {
+        end = this.length
+    }
+
+    if (end <= 0) {
+        return ''
+    }
+
+    // Force coersion to uint32. This will also coerce falsey/NaN values to 0.
+    end >>>= 0
+    start >>>= 0
+
+    if (end <= start) {
+        return ''
+    }
+
+    if (!encoding) encoding = 'utf8'
+
+    while (true) {
+        switch (encoding) {
+            case 'hex':
+                return hexSlice(this, start, end)
+
+            case 'utf8':
+            case 'utf-8':
+                return utf8Slice(this, start, end)
+
+            case 'ascii':
+                return asciiSlice(this, start, end)
+
+            case 'latin1':
+            case 'binary':
+                return latin1Slice(this, start, end)
+
+            case 'base64':
+                return base64Slice(this, start, end)
+
+            case 'ucs2':
+            case 'ucs-2':
+            case 'utf16le':
+            case 'utf-16le':
+                return utf16leSlice(this, start, end)
+
+            default:
+                if (loweredCase) throw new TypeError('Unknown encoding: ' + encoding)
+                encoding = (encoding + '').toLowerCase()
+                loweredCase = true
+        }
+    }
+}
+
+// This property is used by `Buffer.isBuffer` (and the `is-buffer` npm package)
+// to detect a Buffer instance. It's not possible to use `instanceof Buffer`
+// reliably in a browserify context because there could be multiple different
+// copies of the 'buffer' package in use. This method works even for Buffer
+// instances that were created from another copy of the `buffer` package.
+// See: https://github.com/feross/buffer/issues/154
+Buffer.prototype._isBuffer = true
+
+function swap (b, n, m) {
+    var i = b[n]
+    b[n] = b[m]
+    b[m] = i
+}
+
+Buffer.prototype.swap16 = function swap16 () {
+    var len = this.length
+    if (len % 2 !== 0) {
+        throw new RangeError('Buffer size must be a multiple of 16-bits')
+    }
+    for (var i = 0; i < len; i += 2) {
+        swap(this, i, i + 1)
+    }
+    return this
+}
+
+Buffer.prototype.swap32 = function swap32 () {
+    var len = this.length
+    if (len % 4 !== 0) {
+        throw new RangeError('Buffer size must be a multiple of 32-bits')
+    }
+    for (var i = 0; i < len; i += 4) {
+        swap(this, i, i + 3)
+        swap(this, i + 1, i + 2)
+    }
+    return this
+}
+
+Buffer.prototype.swap64 = function swap64 () {
+    var len = this.length
+    if (len % 8 !== 0) {
+        throw new RangeError('Buffer size must be a multiple of 64-bits')
+    }
+    for (var i = 0; i < len; i += 8) {
+        swap(this, i, i + 7)
+        swap(this, i + 1, i + 6)
+        swap(this, i + 2, i + 5)
+        swap(this, i + 3, i + 4)
+    }
+    return this
+}
+
+Buffer.prototype.toString = function toString () {
+    var length = this.length
+    if (length === 0) return ''
+    if (arguments.length === 0) return utf8Slice(this, 0, length)
+    return slowToString.apply(this, arguments)
+}
+
+Buffer.prototype.toLocaleString = Buffer.prototype.toString
+
+Buffer.prototype.equals = function equals (b) {
+    if (!Buffer.isBuffer(b)) throw new TypeError('Argument must be a Buffer')
+    if (this === b) return true
+    return Buffer.compare(this, b) === 0
+}
+
+Buffer.prototype.inspect = function inspect () {
+    var str = ''
+    var max = 50
+    str = this.toString('hex', 0, max).replace(/(.{2})/g, '$1 ').trim()
+    if (this.length > max) str += ' ... '
+    return '<Buffer ' + str + '>'
+}
+
+Buffer.prototype.compare = function compare (target, start, end, thisStart, thisEnd) {
+    if (isInstance(target, Uint8Array)) {
+        target = Buffer.from(target, target.offset, target.byteLength)
+    }
+    if (!Buffer.isBuffer(target)) {
+        throw new TypeError(
+            'The "target" argument must be one of type Buffer or Uint8Array. ' +
+            'Received type ' + (typeof target)
+        )
+    }
+
+    if (start === undefined) {
+        start = 0
+    }
+    if (end === undefined) {
+        end = target ? target.length : 0
+    }
+    if (thisStart === undefined) {
+        thisStart = 0
+    }
+    if (thisEnd === undefined) {
+        thisEnd = this.length
+    }
+
+    if (start < 0 || end > target.length || thisStart < 0 || thisEnd > this.length) {
+        throw new RangeError('out of range index')
+    }
+
+    if (thisStart >= thisEnd && start >= end) {
+        return 0
+    }
+    if (thisStart >= thisEnd) {
+        return -1
+    }
+    if (start >= end) {
+        return 1
+    }
+
+    start >>>= 0
+    end >>>= 0
+    thisStart >>>= 0
+    thisEnd >>>= 0
+
+    if (this === target) return 0
+
+    var x = thisEnd - thisStart
+    var y = end - start
+    var len = Math.min(x, y)
+
+    var thisCopy = this.slice(thisStart, thisEnd)
+    var targetCopy = target.slice(start, end)
+
+    for (var i = 0; i < len; ++i) {
+        if (thisCopy[i] !== targetCopy[i]) {
+            x = thisCopy[i]
+            y = targetCopy[i]
+            break
+        }
+    }
+
+    if (x < y) return -1
+    if (y < x) return 1
+    return 0
+}
+
+// Finds either the first index of `val` in `buffer` at offset >= `byteOffset`,
+// OR the last index of `val` in `buffer` at offset <= `byteOffset`.
+//
+// Arguments:
+// - buffer - a Buffer to search
+// - val - a string, Buffer, or number
+// - byteOffset - an index into `buffer`; will be clamped to an int32
+// - encoding - an optional encoding, relevant is val is a string
+// - dir - true for indexOf, false for lastIndexOf
+function bidirectionalIndexOf (buffer, val, byteOffset, encoding, dir) {
+    // Empty buffer means no match
+    if (buffer.length === 0) return -1
+
+    // Normalize byteOffset
+    if (typeof byteOffset === 'string') {
+        encoding = byteOffset
+        byteOffset = 0
+    } else if (byteOffset > 0x7fffffff) {
+        byteOffset = 0x7fffffff
+    } else if (byteOffset < -0x80000000) {
+        byteOffset = -0x80000000
+    }
+    byteOffset = +byteOffset // Coerce to Number.
+    if (numberIsNaN(byteOffset)) {
+        // byteOffset: it it's undefined, null, NaN, "foo", etc, search whole buffer
+        byteOffset = dir ? 0 : (buffer.length - 1)
+    }
+
+    // Normalize byteOffset: negative offsets start from the end of the buffer
+    if (byteOffset < 0) byteOffset = buffer.length + byteOffset
+    if (byteOffset >= buffer.length) {
+        if (dir) return -1
+        else byteOffset = buffer.length - 1
+    } else if (byteOffset < 0) {
+        if (dir) byteOffset = 0
+        else return -1
+    }
+
+    // Normalize val
+    if (typeof val === 'string') {
+        val = Buffer.from(val, encoding)
+    }
+
+    // Finally, search either indexOf (if dir is true) or lastIndexOf
+    if (Buffer.isBuffer(val)) {
+        // Special case: looking for empty string/buffer always fails
+        if (val.length === 0) {
+            return -1
+        }
+        return arrayIndexOf(buffer, val, byteOffset, encoding, dir)
+    } else if (typeof val === 'number') {
+        val = val & 0xFF // Search for a byte value [0-255]
+        if (typeof Uint8Array.prototype.indexOf === 'function') {
+            if (dir) {
+                return Uint8Array.prototype.indexOf.call(buffer, val, byteOffset)
+            } else {
+                return Uint8Array.prototype.lastIndexOf.call(buffer, val, byteOffset)
+            }
+        }
+        return arrayIndexOf(buffer, [ val ], byteOffset, encoding, dir)
+    }
+
+    throw new TypeError('val must be string, number or Buffer')
+}
+
+function arrayIndexOf (arr, val, byteOffset, encoding, dir) {
+    var indexSize = 1
+    var arrLength = arr.length
+    var valLength = val.length
+
+    if (encoding !== undefined) {
+        encoding = String(encoding).toLowerCase()
+        if (encoding === 'ucs2' || encoding === 'ucs-2' ||
+            encoding === 'utf16le' || encoding === 'utf-16le') {
+            if (arr.length < 2 || val.length < 2) {
+                return -1
+            }
+            indexSize = 2
+            arrLength /= 2
+            valLength /= 2
+            byteOffset /= 2
+        }
+    }
+
+    function read (buf, i) {
+        if (indexSize === 1) {
+            return buf[i]
+        } else {
+            return buf.readUInt16BE(i * indexSize)
+        }
+    }
+
+    var i
+    if (dir) {
+        var foundIndex = -1
+        for (i = byteOffset; i < arrLength; i++) {
+            if (read(arr, i) === read(val, foundIndex === -1 ? 0 : i - foundIndex)) {
+                if (foundIndex === -1) foundIndex = i
+                if (i - foundIndex + 1 === valLength) return foundIndex * indexSize
+            } else {
+                if (foundIndex !== -1) i -= i - foundIndex
+                foundIndex = -1
+            }
+        }
+    } else {
+        if (byteOffset + valLength > arrLength) byteOffset = arrLength - valLength
+        for (i = byteOffset; i >= 0; i--) {
+            var found = true
+            for (var j = 0; j < valLength; j++) {
+                if (read(arr, i + j) !== read(val, j)) {
+                    found = false
+                    break
+                }
+            }
+            if (found) return i
+        }
+    }
+
+    return -1
+}
+
+Buffer.prototype.includes = function includes (val, byteOffset, encoding) {
+    return this.indexOf(val, byteOffset, encoding) !== -1
+}
+
+Buffer.prototype.indexOf = function indexOf (val, byteOffset, encoding) {
+    return bidirectionalIndexOf(this, val, byteOffset, encoding, true)
+}
+
+Buffer.prototype.lastIndexOf = function lastIndexOf (val, byteOffset, encoding) {
+    return bidirectionalIndexOf(this, val, byteOffset, encoding, false)
+}
+
+function hexWrite (buf, string, offset, length) {
+    offset = Number(offset) || 0
+    var remaining = buf.length - offset
+    if (!length) {
+        length = remaining
+    } else {
+        length = Number(length)
+        if (length > remaining) {
+            length = remaining
+        }
+    }
+
+    var strLen = string.length
+
+    if (length > strLen / 2) {
+        length = strLen / 2
+    }
+    for (var i = 0; i < length; ++i) {
+        var parsed = parseInt(string.substr(i * 2, 2), 16)
+        if (numberIsNaN(parsed)) return i
+        buf[offset + i] = parsed
+    }
+    return i
+}
+
+function utf8Write (buf, string, offset, length) {
+    return blitBuffer(utf8ToBytes(string, buf.length - offset), buf, offset, length)
+}
+
+function asciiWrite (buf, string, offset, length) {
+    return blitBuffer(asciiToBytes(string), buf, offset, length)
+}
+
+function latin1Write (buf, string, offset, length) {
+    return asciiWrite(buf, string, offset, length)
+}
+
+function base64Write (buf, string, offset, length) {
+    return blitBuffer(base64ToBytes(string), buf, offset, length)
+}
+
+function ucs2Write (buf, string, offset, length) {
+    return blitBuffer(utf16leToBytes(string, buf.length - offset), buf, offset, length)
+}
+
+Buffer.prototype.write = function write (string, offset, length, encoding) {
+    // Buffer#write(string)
+    if (offset === undefined) {
+        encoding = 'utf8'
+        length = this.length
+        offset = 0
+        // Buffer#write(string, encoding)
+    } else if (length === undefined && typeof offset === 'string') {
+        encoding = offset
+        length = this.length
+        offset = 0
+        // Buffer#write(string, offset[, length][, encoding])
+    } else if (isFinite(offset)) {
+        offset = offset >>> 0
+        if (isFinite(length)) {
+            length = length >>> 0
+            if (encoding === undefined) encoding = 'utf8'
+        } else {
+            encoding = length
+            length = undefined
+        }
+    } else {
+        throw new Error(
+            'Buffer.write(string, encoding, offset[, length]) is no longer supported'
+        )
+    }
+
+    var remaining = this.length - offset
+    if (length === undefined || length > remaining) length = remaining
+
+    if ((string.length > 0 && (length < 0 || offset < 0)) || offset > this.length) {
+        throw new RangeError('Attempt to write outside buffer bounds')
+    }
+
+    if (!encoding) encoding = 'utf8'
+
+    var loweredCase = false
+    for (;;) {
+        switch (encoding) {
+            case 'hex':
+                return hexWrite(this, string, offset, length)
+
+            case 'utf8':
+            case 'utf-8':
+                return utf8Write(this, string, offset, length)
+
+            case 'ascii':
+                return asciiWrite(this, string, offset, length)
+
+            case 'latin1':
+            case 'binary':
+                return latin1Write(this, string, offset, length)
+
+            case 'base64':
+                // Warning: maxLength not taken into account in base64Write
+                return base64Write(this, string, offset, length)
+
+            case 'ucs2':
+            case 'ucs-2':
+            case 'utf16le':
+            case 'utf-16le':
+                return ucs2Write(this, string, offset, length)
+
+            default:
+                if (loweredCase) throw new TypeError('Unknown encoding: ' + encoding)
+                encoding = ('' + encoding).toLowerCase()
+                loweredCase = true
+        }
+    }
+}
+
+Buffer.prototype.toJSON = function toJSON () {
+    return {
+        type: 'Buffer',
+        data: Array.prototype.slice.call(this._arr || this, 0)
+    }
+}
+
+function base64Slice (buf, start, end) {
+    if (start === 0 && end === buf.length) {
+        return base64.fromByteArray(buf)
+    } else {
+        return base64.fromByteArray(buf.slice(start, end))
+    }
+}
+
+function utf8Slice (buf, start, end) {
+    end = Math.min(buf.length, end)
+    var res = []
+
+    var i = start
+    while (i < end) {
+        var firstByte = buf[i]
+        var codePoint = null
+        var bytesPerSequence = (firstByte > 0xEF) ? 4
+            : (firstByte > 0xDF) ? 3
+                : (firstByte > 0xBF) ? 2
+                    : 1
+
+        if (i + bytesPerSequence <= end) {
+            var secondByte, thirdByte, fourthByte, tempCodePoint
+
+            switch (bytesPerSequence) {
+                case 1:
+                    if (firstByte < 0x80) {
+                        codePoint = firstByte
+                    }
+                    break
+                case 2:
+                    secondByte = buf[i + 1]
+                    if ((secondByte & 0xC0) === 0x80) {
+                        tempCodePoint = (firstByte & 0x1F) << 0x6 | (secondByte & 0x3F)
+                        if (tempCodePoint > 0x7F) {
+                            codePoint = tempCodePoint
+                        }
+                    }
+                    break
+                case 3:
+                    secondByte = buf[i + 1]
+                    thirdByte = buf[i + 2]
+                    if ((secondByte & 0xC0) === 0x80 && (thirdByte & 0xC0) === 0x80) {
+                        tempCodePoint = (firstByte & 0xF) << 0xC | (secondByte & 0x3F) << 0x6 | (thirdByte & 0x3F)
+                        if (tempCodePoint > 0x7FF && (tempCodePoint < 0xD800 || tempCodePoint > 0xDFFF)) {
+                            codePoint = tempCodePoint
+                        }
+                    }
+                    break
+                case 4:
+                    secondByte = buf[i + 1]
+                    thirdByte = buf[i + 2]
+                    fourthByte = buf[i + 3]
+                    if ((secondByte & 0xC0) === 0x80 && (thirdByte & 0xC0) === 0x80 && (fourthByte & 0xC0) === 0x80) {
+                        tempCodePoint = (firstByte & 0xF) << 0x12 | (secondByte & 0x3F) << 0xC | (thirdByte & 0x3F) << 0x6 | (fourthByte & 0x3F)
+                        if (tempCodePoint > 0xFFFF && tempCodePoint < 0x110000) {
+                            codePoint = tempCodePoint
+                        }
+                    }
+            }
+        }
+
+        if (codePoint === null) {
+            // we did not generate a valid codePoint so insert a
+            // replacement char (U+FFFD) and advance only 1 byte
+            codePoint = 0xFFFD
+            bytesPerSequence = 1
+        } else if (codePoint > 0xFFFF) {
+            // encode to utf16 (surrogate pair dance)
+            codePoint -= 0x10000
+            res.push(codePoint >>> 10 & 0x3FF | 0xD800)
+            codePoint = 0xDC00 | codePoint & 0x3FF
+        }
+
+        res.push(codePoint)
+        i += bytesPerSequence
+    }
+
+    return decodeCodePointsArray(res)
+}
+
+// Based on http://stackoverflow.com/a/22747272/680742, the browser with
+// the lowest limit is Chrome, with 0x10000 args.
+// We go 1 magnitude less, for safety
+var MAX_ARGUMENTS_LENGTH = 0x1000
+
+function decodeCodePointsArray (codePoints) {
+    var len = codePoints.length
+    if (len <= MAX_ARGUMENTS_LENGTH) {
+        return String.fromCharCode.apply(String, codePoints) // avoid extra slice()
+    }
+
+    // Decode in chunks to avoid "call stack size exceeded".
+    var res = ''
+    var i = 0
+    while (i < len) {
+        res += String.fromCharCode.apply(
+            String,
+            codePoints.slice(i, i += MAX_ARGUMENTS_LENGTH)
+        )
+    }
+    return res
+}
+
+function asciiSlice (buf, start, end) {
+    var ret = ''
+    end = Math.min(buf.length, end)
+
+    for (var i = start; i < end; ++i) {
+        ret += String.fromCharCode(buf[i] & 0x7F)
+    }
+    return ret
+}
+
+function latin1Slice (buf, start, end) {
+    var ret = ''
+    end = Math.min(buf.length, end)
+
+    for (var i = start; i < end; ++i) {
+        ret += String.fromCharCode(buf[i])
+    }
+    return ret
+}
+
+function hexSlice (buf, start, end) {
+    var len = buf.length
+
+    if (!start || start < 0) start = 0
+    if (!end || end < 0 || end > len) end = len
+
+    var out = ''
+    for (var i = start; i < end; ++i) {
+        out += toHex(buf[i])
+    }
+    return out
+}
+
+function utf16leSlice (buf, start, end) {
+    var bytes = buf.slice(start, end)
+    var res = ''
+    for (var i = 0; i < bytes.length; i += 2) {
+        res += String.fromCharCode(bytes[i] + (bytes[i + 1] * 256))
+    }
+    return res
+}
+
+Buffer.prototype.slice = function slice (start, end) {
+    var len = this.length
+    start = ~~start
+    end = end === undefined ? len : ~~end
+
+    if (start < 0) {
+        start += len
+        if (start < 0) start = 0
+    } else if (start > len) {
+        start = len
+    }
+
+    if (end < 0) {
+        end += len
+        if (end < 0) end = 0
+    } else if (end > len) {
+        end = len
+    }
+
+    if (end < start) end = start
+
+    var newBuf = this.subarray(start, end)
+    // Return an augmented `Uint8Array` instance
+    newBuf.__proto__ = Buffer.prototype
+    return newBuf
+}
+
+/*
+ * Need to make sure that buffer isn't trying to write out of bounds.
+ */
+function checkOffset (offset, ext, length) {
+    if ((offset % 1) !== 0 || offset < 0) throw new RangeError('offset is not uint')
+    if (offset + ext > length) throw new RangeError('Trying to access beyond buffer length')
+}
+
+Buffer.prototype.readUIntLE = function readUIntLE (offset, byteLength, noAssert) {
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) checkOffset(offset, byteLength, this.length)
+
+    var val = this[offset]
+    var mul = 1
+    var i = 0
+    while (++i < byteLength && (mul *= 0x100)) {
+        val += this[offset + i] * mul
+    }
+
+    return val
+}
+
+Buffer.prototype.readUIntBE = function readUIntBE (offset, byteLength, noAssert) {
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) {
+        checkOffset(offset, byteLength, this.length)
+    }
+
+    var val = this[offset + --byteLength]
+    var mul = 1
+    while (byteLength > 0 && (mul *= 0x100)) {
+        val += this[offset + --byteLength] * mul
+    }
+
+    return val
+}
+
+Buffer.prototype.readUInt8 = function readUInt8 (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 1, this.length)
+    return this[offset]
+}
+
+Buffer.prototype.readUInt16LE = function readUInt16LE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 2, this.length)
+    return this[offset] | (this[offset + 1] << 8)
+}
+
+Buffer.prototype.readUInt16BE = function readUInt16BE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 2, this.length)
+    return (this[offset] << 8) | this[offset + 1]
+}
+
+Buffer.prototype.readUInt32LE = function readUInt32LE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 4, this.length)
+
+    return ((this[offset]) |
+        (this[offset + 1] << 8) |
+        (this[offset + 2] << 16)) +
+        (this[offset + 3] * 0x1000000)
+}
+
+Buffer.prototype.readUInt32BE = function readUInt32BE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 4, this.length)
+
+    return (this[offset] * 0x1000000) +
+        ((this[offset + 1] << 16) |
+            (this[offset + 2] << 8) |
+            this[offset + 3])
+}
+
+Buffer.prototype.readIntLE = function readIntLE (offset, byteLength, noAssert) {
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) checkOffset(offset, byteLength, this.length)
+
+    var val = this[offset]
+    var mul = 1
+    var i = 0
+    while (++i < byteLength && (mul *= 0x100)) {
+        val += this[offset + i] * mul
+    }
+    mul *= 0x80
+
+    if (val >= mul) val -= Math.pow(2, 8 * byteLength)
+
+    return val
+}
+
+Buffer.prototype.readIntBE = function readIntBE (offset, byteLength, noAssert) {
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) checkOffset(offset, byteLength, this.length)
+
+    var i = byteLength
+    var mul = 1
+    var val = this[offset + --i]
+    while (i > 0 && (mul *= 0x100)) {
+        val += this[offset + --i] * mul
+    }
+    mul *= 0x80
+
+    if (val >= mul) val -= Math.pow(2, 8 * byteLength)
+
+    return val
+}
+
+Buffer.prototype.readInt8 = function readInt8 (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 1, this.length)
+    if (!(this[offset] & 0x80)) return (this[offset])
+    return ((0xff - this[offset] + 1) * -1)
+}
+
+Buffer.prototype.readInt16LE = function readInt16LE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 2, this.length)
+    var val = this[offset] | (this[offset + 1] << 8)
+    return (val & 0x8000) ? val | 0xFFFF0000 : val
+}
+
+Buffer.prototype.readInt16BE = function readInt16BE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 2, this.length)
+    var val = this[offset + 1] | (this[offset] << 8)
+    return (val & 0x8000) ? val | 0xFFFF0000 : val
+}
+
+Buffer.prototype.readInt32LE = function readInt32LE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 4, this.length)
+
+    return (this[offset]) |
+        (this[offset + 1] << 8) |
+        (this[offset + 2] << 16) |
+        (this[offset + 3] << 24)
+}
+
+Buffer.prototype.readInt32BE = function readInt32BE (offset, noAssert) {
+    offset = offset >>> 0
+    if (!noAssert) checkOffset(offset, 4, this.length)
+
+    return (this[offset] << 24) |
+        (this[offset + 1] << 16) |
+        (this[offset + 2] << 8) |
+        (this[offset + 3])
+}
+
+function checkInt (buf, value, offset, ext, max, min) {
+    if (!Buffer.isBuffer(buf)) throw new TypeError('"buffer" argument must be a Buffer instance')
+    if (value > max || value < min) throw new RangeError('"value" argument is out of bounds')
+    if (offset + ext > buf.length) throw new RangeError('Index out of range')
+}
+
+Buffer.prototype.writeUIntLE = function writeUIntLE (value, offset, byteLength, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) {
+        var maxBytes = Math.pow(2, 8 * byteLength) - 1
+        checkInt(this, value, offset, byteLength, maxBytes, 0)
+    }
+
+    var mul = 1
+    var i = 0
+    this[offset] = value & 0xFF
+    while (++i < byteLength && (mul *= 0x100)) {
+        this[offset + i] = (value / mul) & 0xFF
+    }
+
+    return offset + byteLength
+}
+
+Buffer.prototype.writeUIntBE = function writeUIntBE (value, offset, byteLength, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    byteLength = byteLength >>> 0
+    if (!noAssert) {
+        var maxBytes = Math.pow(2, 8 * byteLength) - 1
+        checkInt(this, value, offset, byteLength, maxBytes, 0)
+    }
+
+    var i = byteLength - 1
+    var mul = 1
+    this[offset + i] = value & 0xFF
+    while (--i >= 0 && (mul *= 0x100)) {
+        this[offset + i] = (value / mul) & 0xFF
+    }
+
+    return offset + byteLength
+}
+
+Buffer.prototype.writeUInt8 = function writeUInt8 (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 1, 0xff, 0)
+    this[offset] = (value & 0xff)
+    return offset + 1
+}
+
+Buffer.prototype.writeUInt16LE = function writeUInt16LE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 2, 0xffff, 0)
+    this[offset] = (value & 0xff)
+    this[offset + 1] = (value >>> 8)
+    return offset + 2
+}
+
+Buffer.prototype.writeUInt16BE = function writeUInt16BE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 2, 0xffff, 0)
+    this[offset] = (value >>> 8)
+    this[offset + 1] = (value & 0xff)
+    return offset + 2
+}
+
+Buffer.prototype.writeUInt32LE = function writeUInt32LE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 4, 0xffffffff, 0)
+    this[offset + 3] = (value >>> 24)
+    this[offset + 2] = (value >>> 16)
+    this[offset + 1] = (value >>> 8)
+    this[offset] = (value & 0xff)
+    return offset + 4
+}
+
+Buffer.prototype.writeUInt32BE = function writeUInt32BE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 4, 0xffffffff, 0)
+    this[offset] = (value >>> 24)
+    this[offset + 1] = (value >>> 16)
+    this[offset + 2] = (value >>> 8)
+    this[offset + 3] = (value & 0xff)
+    return offset + 4
+}
+
+Buffer.prototype.writeIntLE = function writeIntLE (value, offset, byteLength, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) {
+        var limit = Math.pow(2, (8 * byteLength) - 1)
+
+        checkInt(this, value, offset, byteLength, limit - 1, -limit)
+    }
+
+    var i = 0
+    var mul = 1
+    var sub = 0
+    this[offset] = value & 0xFF
+    while (++i < byteLength && (mul *= 0x100)) {
+        if (value < 0 && sub === 0 && this[offset + i - 1] !== 0) {
+            sub = 1
+        }
+        this[offset + i] = ((value / mul) >> 0) - sub & 0xFF
+    }
+
+    return offset + byteLength
+}
+
+Buffer.prototype.writeIntBE = function writeIntBE (value, offset, byteLength, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) {
+        var limit = Math.pow(2, (8 * byteLength) - 1)
+
+        checkInt(this, value, offset, byteLength, limit - 1, -limit)
+    }
+
+    var i = byteLength - 1
+    var mul = 1
+    var sub = 0
+    this[offset + i] = value & 0xFF
+    while (--i >= 0 && (mul *= 0x100)) {
+        if (value < 0 && sub === 0 && this[offset + i + 1] !== 0) {
+            sub = 1
+        }
+        this[offset + i] = ((value / mul) >> 0) - sub & 0xFF
+    }
+
+    return offset + byteLength
+}
+
+Buffer.prototype.writeInt8 = function writeInt8 (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 1, 0x7f, -0x80)
+    if (value < 0) value = 0xff + value + 1
+    this[offset] = (value & 0xff)
+    return offset + 1
+}
+
+Buffer.prototype.writeInt16LE = function writeInt16LE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 2, 0x7fff, -0x8000)
+    this[offset] = (value & 0xff)
+    this[offset + 1] = (value >>> 8)
+    return offset + 2
+}
+
+Buffer.prototype.writeInt16BE = function writeInt16BE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 2, 0x7fff, -0x8000)
+    this[offset] = (value >>> 8)
+    this[offset + 1] = (value & 0xff)
+    return offset + 2
+}
+
+Buffer.prototype.writeInt32LE = function writeInt32LE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000)
+    this[offset] = (value & 0xff)
+    this[offset + 1] = (value >>> 8)
+    this[offset + 2] = (value >>> 16)
+    this[offset + 3] = (value >>> 24)
+    return offset + 4
+}
+
+Buffer.prototype.writeInt32BE = function writeInt32BE (value, offset, noAssert) {
+    value = +value
+    offset = offset >>> 0
+    if (!noAssert) checkInt(this, value, offset, 4, 0x7fffffff, -0x80000000)
+    if (value < 0) value = 0xffffffff + value + 1
+    this[offset] = (value >>> 24)
+    this[offset + 1] = (value >>> 16)
+    this[offset + 2] = (value >>> 8)
+    this[offset + 3] = (value & 0xff)
+    return offset + 4
+}
+
+
+Buffer.prototype.writeFloatLE = function writeFloatLE (value, offset, noAssert) {
+    return writeFloat(this, value, offset, true, noAssert)
+}
+
+Buffer.prototype.writeFloatBE = function writeFloatBE (value, offset, noAssert) {
+    return writeFloat(this, value, offset, false, noAssert)
+}
+
+Buffer.prototype.writeDoubleLE = function writeDoubleLE (value, offset, noAssert) {
+    return writeDouble(this, value, offset, true, noAssert)
+}
+
+Buffer.prototype.writeDoubleBE = function writeDoubleBE (value, offset, noAssert) {
+    return writeDouble(this, value, offset, false, noAssert)
+}
+
+// copy(targetBuffer, targetStart=0, sourceStart=0, sourceEnd=buffer.length)
+Buffer.prototype.copy = function copy (target, targetStart, start, end) {
+    if (!Buffer.isBuffer(target)) throw new TypeError('argument should be a Buffer')
+    if (!start) start = 0
+    if (!end && end !== 0) end = this.length
+    if (targetStart >= target.length) targetStart = target.length
+    if (!targetStart) targetStart = 0
+    if (end > 0 && end < start) end = start
+
+    // Copy 0 bytes; we're done
+    if (end === start) return 0
+    if (target.length === 0 || this.length === 0) return 0
+
+    // Fatal error conditions
+    if (targetStart < 0) {
+        throw new RangeError('targetStart out of bounds')
+    }
+    if (start < 0 || start >= this.length) throw new RangeError('Index out of range')
+    if (end < 0) throw new RangeError('sourceEnd out of bounds')
+
+    // Are we oob?
+    if (end > this.length) end = this.length
+    if (target.length - targetStart < end - start) {
+        end = target.length - targetStart + start
+    }
+
+    var len = end - start
+
+    if (this === target && typeof Uint8Array.prototype.copyWithin === 'function') {
+        // Use built-in when available, missing from IE11
+        this.copyWithin(targetStart, start, end)
+    } else if (this === target && start < targetStart && targetStart < end) {
+        // descending copy from end
+        for (var i = len - 1; i >= 0; --i) {
+            target[i + targetStart] = this[i + start]
+        }
+    } else {
+        Uint8Array.prototype.set.call(
+            target,
+            this.subarray(start, end),
+            targetStart
+        )
+    }
+
+    return len
+}
+
+// Usage:
+//    buffer.fill(number[, offset[, end]])
+//    buffer.fill(buffer[, offset[, end]])
+//    buffer.fill(string[, offset[, end]][, encoding])
+Buffer.prototype.fill = function fill (val, start, end, encoding) {
+    // Handle string cases:
+    if (typeof val === 'string') {
+        if (typeof start === 'string') {
+            encoding = start
+            start = 0
+            end = this.length
+        } else if (typeof end === 'string') {
+            encoding = end
+            end = this.length
+        }
+        if (encoding !== undefined && typeof encoding !== 'string') {
+            throw new TypeError('encoding must be a string')
+        }
+        if (typeof encoding === 'string' && !Buffer.isEncoding(encoding)) {
+            throw new TypeError('Unknown encoding: ' + encoding)
+        }
+        if (val.length === 1) {
+            var code = val.charCodeAt(0)
+            if ((encoding === 'utf8' && code < 128) ||
+                encoding === 'latin1') {
+                // Fast path: If `val` fits into a single byte, use that numeric value.
+                val = code
+            }
+        }
+    } else if (typeof val === 'number') {
+        val = val & 255
+    }
+
+    // Invalid ranges are not set to a default, so can range check early.
+    if (start < 0 || this.length < start || this.length < end) {
+        throw new RangeError('Out of range index')
+    }
+
+    if (end <= start) {
+        return this
+    }
+
+    start = start >>> 0
+    end = end === undefined ? this.length : end >>> 0
+
+    if (!val) val = 0
+
+    var i
+    if (typeof val === 'number') {
+        for (i = start; i < end; ++i) {
+            this[i] = val
+        }
+    } else {
+        var bytes = Buffer.isBuffer(val)
+            ? val
+            : Buffer.from(val, encoding)
+        var len = bytes.length
+        if (len === 0) {
+            throw new TypeError('The value "' + val +
+                '" is invalid for argument "value"')
+        }
+        for (i = 0; i < end - start; ++i) {
+            this[i + start] = bytes[i % len]
+        }
+    }
+
+    return this
+}
+
+// HELPER FUNCTIONS
+// ================
+
+var INVALID_BASE64_RE = /[^+/0-9A-Za-z-_]/g
+
+function base64clean (str) {
+    // Node takes equal signs as end of the Base64 encoding
+    str = str.split('=')[0]
+    // Node strips out invalid characters like \n and \t from the string, base64-js does not
+    str = str.trim().replace(INVALID_BASE64_RE, '')
+    // Node converts strings with length < 2 to ''
+    if (str.length < 2) return ''
+    // Node allows for non-padded base64 strings (missing trailing ===), base64-js does not
+    while (str.length % 4 !== 0) {
+        str = str + '='
+    }
+    return str
+}
+
+function toHex (n) {
+    if (n < 16) return '0' + n.toString(16)
+    return n.toString(16)
+}
+
+function utf8ToBytes (string, units) {
+    units = units || Infinity
+    var codePoint
+    var length = string.length
+    var leadSurrogate = null
+    var bytes = []
+
+    for (var i = 0; i < length; ++i) {
+        codePoint = string.charCodeAt(i)
+
+        // is surrogate component
+        if (codePoint > 0xD7FF && codePoint < 0xE000) {
+            // last char was a lead
+            if (!leadSurrogate) {
+                // no lead yet
+                if (codePoint > 0xDBFF) {
+                    // unexpected trail
+                    if ((units -= 3) > -1) bytes.push(0xEF, 0xBF, 0xBD)
+                    continue
+                } else if (i + 1 === length) {
+                    // unpaired lead
+                    if ((units -= 3) > -1) bytes.push(0xEF, 0xBF, 0xBD)
+                    continue
+                }
+
+                // valid lead
+                leadSurrogate = codePoint
+
+                continue
+            }
+
+            // 2 leads in a row
+            if (codePoint < 0xDC00) {
+                if ((units -= 3) > -1) bytes.push(0xEF, 0xBF, 0xBD)
+                leadSurrogate = codePoint
+                continue
+            }
+
+            // valid surrogate pair
+            codePoint = (leadSurrogate - 0xD800 << 10 | codePoint - 0xDC00) + 0x10000
+        } else if (leadSurrogate) {
+            // valid bmp char, but last char was a lead
+            if ((units -= 3) > -1) bytes.push(0xEF, 0xBF, 0xBD)
+        }
+
+        leadSurrogate = null
+
+        // encode utf8
+        if (codePoint < 0x80) {
+            if ((units -= 1) < 0) break
+            bytes.push(codePoint)
+        } else if (codePoint < 0x800) {
+            if ((units -= 2) < 0) break
+            bytes.push(
+                codePoint >> 0x6 | 0xC0,
+                codePoint & 0x3F | 0x80
+            )
+        } else if (codePoint < 0x10000) {
+            if ((units -= 3) < 0) break
+            bytes.push(
+                codePoint >> 0xC | 0xE0,
+                codePoint >> 0x6 & 0x3F | 0x80,
+                codePoint & 0x3F | 0x80
+            )
+        } else if (codePoint < 0x110000) {
+            if ((units -= 4) < 0) break
+            bytes.push(
+                codePoint >> 0x12 | 0xF0,
+                codePoint >> 0xC & 0x3F | 0x80,
+                codePoint >> 0x6 & 0x3F | 0x80,
+                codePoint & 0x3F | 0x80
+            )
+        } else {
+            throw new Error('Invalid code point')
+        }
+    }
+
+    return bytes
+}
+
+function asciiToBytes (str) {
+    var byteArray = []
+    for (var i = 0; i < str.length; ++i) {
+        // Node's code seems to be doing this and not & 0x7F..
+        byteArray.push(str.charCodeAt(i) & 0xFF)
+    }
+    return byteArray
+}
+
+function utf16leToBytes (str, units) {
+    var c, hi, lo
+    var byteArray = []
+    for (var i = 0; i < str.length; ++i) {
+        if ((units -= 2) < 0) break
+
+        c = str.charCodeAt(i)
+        hi = c >> 8
+        lo = c % 256
+        byteArray.push(lo)
+        byteArray.push(hi)
+    }
+
+    return byteArray
+}
+
+function base64ToBytes (str) {
+    return base64.toByteArray(base64clean(str))
+}
+
+function blitBuffer (src, dst, offset, length) {
+    for (var i = 0; i < length; ++i) {
+        if ((i + offset >= dst.length) || (i >= src.length)) break
+        dst[i + offset] = src[i]
+    }
+    return i
+}
+
+// ArrayBuffer or Uint8Array objects from other contexts (i.e. iframes) do not pass
+// the `instanceof` check but they should be treated as of that type.
+// See: https://github.com/feross/buffer/issues/166
+function isInstance (obj, type) {
+    return obj instanceof type ||
+        (obj != null && obj.constructor != null && obj.constructor.name != null &&
+            obj.constructor.name === type.name)
+}
+function numberIsNaN (obj) {
+    // For IE11 support
+    return obj !== obj // eslint-disable-line no-self-compare
+};
+
+class Base64Tools
+{
+    constructor()
+    {
+        this.BASE64_PADDING = '===';
+    }
+
+    transformBase64UrlSafe2Base64(base64)
+    {
+        return base64.replace(/-/g, '+').replace(/_/g, '/') + this.BASE64_PADDING.substr(0, 3 - (base64.length % 3));
+    }
+
+    encodeBase64UrlSafe(base64)
+    {
+        return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    }
+}
+const MacaroonsConstants = {
+    MACAROON_MAX_STRLEN: 32768,
+    MACAROON_MAX_CAVEATS: 65536,
+    MACAROON_SUGGESTED_SECRET_LENGTH: 32,
+    MACAROON_HASH_BYTES: 32,
+    PACKET_PREFIX_LENGTH: 4,
+    PACKET_MAX_SIZE: 65535,
+    MACAROON_SECRET_KEY_BYTES: 32,
+    MACAROON_SECRET_NONCE_BYTES: 24,
+    MACAROON_SECRET_TEXT_ZERO_BYTES: 32,
+    /**
+     * The number of zero bytes placed by crypto_secretbox
+     * before the ciphertext
+     */
+    MACAROON_SECRET_BOX_ZERO_BYTES: 16,
+    LOCATION: "location",
+    IDENTIFIER: "identifier",
+    SIGNATURE: "signature",
+    CID: "cid",
+    VID: "vid",
+    CL: "cl",
+    LINE_SEPARATOR_STR: '\n',
+    LINE_SEPARATOR_LEN: 1,
+    KEY_VALUE_SEPARATOR_STR: ' ',
+    KEY_VALUE_SEPARATOR_LEN: 1,
+    IDENTIFIER_CHARSET: "utf8",
+};
+MacaroonsConstants.SECRET_BOX_OVERHEAD =
+    MacaroonsConstants.MACAROON_SECRET_TEXT_ZERO_BYTES - MacaroonsConstants.MACAROON_SECRET_BOX_ZERO_BYTES;
+MacaroonsConstants.VID_NONCE_KEY_SZ =
+    MacaroonsConstants.MACAROON_SECRET_NONCE_BYTES + MacaroonsConstants.MACAROON_HASH_BYTES
+    + MacaroonsConstants.SECRET_BOX_OVERHEAD;
+MacaroonsConstants.LOCATION_BYTES = new Buffer(MacaroonsConstants.LOCATION, 'ascii');
+MacaroonsConstants.IDENTIFIER_BYTES = new Buffer(MacaroonsConstants.IDENTIFIER, 'ascii');
+MacaroonsConstants.SIGNATURE_BYTES = new Buffer(MacaroonsConstants.SIGNATURE, 'ascii');
+MacaroonsConstants.CID_BYTES = new Buffer(MacaroonsConstants.CID, 'ascii');
+MacaroonsConstants.VID_BYTES = new Buffer(MacaroonsConstants.VID, 'ascii');
+MacaroonsConstants.CL_BYTES = new Buffer(MacaroonsConstants.CL, 'ascii');
+MacaroonsConstants.LINE_SEPARATOR = MacaroonsConstants.LINE_SEPARATOR_STR.charCodeAt(0);
+MacaroonsConstants.KEY_VALUE_SEPARATOR = MacaroonsConstants.KEY_VALUE_SEPARATOR_STR.charCodeAt(0);
+
+const CaveatPacketType = (function () {
+    const CaveatPacketType = {};
+    CaveatPacketType[CaveatPacketType['location'] = 0] = 'location';
+    CaveatPacketType[CaveatPacketType['identifier'] = 1] = 'identifier';
+    CaveatPacketType[CaveatPacketType['signature'] = 2] = 'signature';
+    CaveatPacketType[CaveatPacketType['cid'] = 3] = 'cid';
+    CaveatPacketType[CaveatPacketType['vid'] = 4] = 'vid';
+    CaveatPacketType[CaveatPacketType['cl'] = 5] = 'cl';
+    return CaveatPacketType;
+}());
+class CaveatPacket
+{
+    constructor(type, value)
+    {
+        if (typeof value === 'undefined') {
+            throw new Error("Missing second parameter 'value' from type 'string' or 'Buffer'");
+        }
+        this.type = type;
+        if (typeof value === 'string') {
+            this.rawValue = new Buffer(value, MacaroonsConstants.IDENTIFIER_CHARSET); //Buffer needs to implemented
+        } else {
+            this.rawValue = value;
+        }
+    }
+    getValueAsText()
+    {
+        if (this.valueAsText == null) {
+            this.valueAsText = (this.type === CaveatPacketType.vid)
+                ? new Base64Tools().encodeBase64UrlSafe(this.rawValue.toString('base64'))
+                : this.rawValue.toString(MacaroonsConstants.IDENTIFIER_CHARSET);
+        }
+        return this.valueAsText;
+    }
+}
+class Macaroon
+{
+    constructor(location, identifier, signature, caveats)
+    {
+        this.caveatPackets = [];
+        this.identifier = identifier;
+        this.location = location;
+        this.signature = signature ? signature.toString('hex') : undefined; //needs implementing
+        this.signatureBuffer = signature;
+        this.caveatPackets = caveats ? caveats : [];
+    }
+    inspect()
+    {
+        return this.createKeyValuePacket(CaveatPacketType.location, this.location)
+            + this.createKeyValuePacket(CaveatPacketType.identifier, this.identifier)
+            + this.createCaveatsPackets(this.caveatPackets)
+            + this.createKeyValuePacket(CaveatPacketType.signature, this.signature);
+    }
+    createKeyValuePacket(type, value)
+    {
+        return value != null ?
+            CaveatPacketType[type] + MacaroonsConstants.KEY_VALUE_SEPARATOR_STR
+            + value + MacaroonsConstants.LINE_SEPARATOR_STR : "";
+    }
+    createCaveatsPackets(caveats)
+    {
+        if (caveats == null)
+            return "";
+        let text = "";
+        for (var i = 0; i < caveats.length; i++) {
+            var packet = caveats[i];
+            text += this.createKeyValuePacket(packet.type, packet.getValueAsText());
+        }
+        return text;
+    }
+}
+class StatefulPacketReader
+{
+    constructor(buffer)
+    {
+        this.seekIndex = 0;
+        this.buffer = buffer;
+        this.HEX_ALPHABET = [
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 0, 0, 0, 0, 0,
+            0, 10, 11, 12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 10, 11, 12, 13, 14, 15, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+        ]
+    }
+    read(data)
+    {
+        const len = Math.min(data.length, this.buffer.length - this.seekIndex);
+        if (len > 0) {
+            this.buffer.copy(data, 0, this.seekIndex, this.seekIndex + len);
+            this.seekIndex += len;
+            return len;
+        }
+        return -1;
+    }
+    readPacketHeader()
+    {
+        return (this.HEX_ALPHABET[this.buffer[this.seekIndex++]] << 12)
+            | (this.HEX_ALPHABET[this.buffer[this.seekIndex++]] << 8)
+            | (this.HEX_ALPHABET[this.buffer[this.seekIndex++]] << 4)
+            | this.HEX_ALPHABET[this.buffer[this.seekIndex++]];
+    }
+    isPacketHeaderAvailable()
+    {
+        return this.seekIndex <= (this.buffer.length - MacaroonsConstants.PACKET_PREFIX_LENGTH);
+    }
+    isEOF()
+    {
+        return !(this.seekIndex < this.buffer.length);
+    }
+}
+class Packet
+{
+    constructor(size, data)
+    {
+        this.size = size;
+        this.data = data;
+    }
+}
+class MacaroonsDeSerialiser
+{
+    deserialise(serialisedMacaroon)
+    {
+        const data = new Buffer(new Base64Tools().transformBase64UrlSafe2Base64(serialisedMacaroon), 'base64');
+        const minLength = MacaroonsConstants.MACAROON_HASH_BYTES
+            + MacaroonsConstants.KEY_VALUE_SEPARATOR_LEN + MacaroonsConstants.SIGNATURE.length;
+        if (data.length < minLength) {
+            throw new Error("Couldn't deserialise macaroon. Not enough bytes " +
+                "for signature found. There have to be at least " + minLength + " bytes");
+        }
+        return this.deserialiseStream(new StatefulPacketReader(data));
+    }
+    deserialiseStream(packetReader)
+    {
+        let location = null;
+        let identifier = null;
+        const caveats = [];
+        let signature = null;
+        let s;
+        let raw;
+
+        for (let packet; (packet = this.readPacket(packetReader)) != null;) {
+            if (this.bytesStartWith(packet.data, MacaroonsConstants.LOCATION_BYTES)) {
+                location = this.parsePacket(packet, MacaroonsConstants.LOCATION_BYTES);
+            } else if (this.bytesStartWith(packet.data, MacaroonsConstants.IDENTIFIER_BYTES)) {
+                identifier = this.parsePacket(packet, MacaroonsConstants.IDENTIFIER_BYTES);
+            } else if (this.bytesStartWith(packet.data, MacaroonsConstants.CID_BYTES)) {
+                s = this.parsePacket(packet, MacaroonsConstants.CID_BYTES);
+                caveats.push(new CaveatPacket(CaveatPacketType.cid, s));
+            } else if (this.bytesStartWith(packet.data, MacaroonsConstants.CL_BYTES)) {
+                s = this.parsePacket(packet, MacaroonsConstants.CL_BYTES);
+                caveats.push(new CaveatPacket(CaveatPacketType.cl, s));
+            } else if (this.bytesStartWith(packet.data, MacaroonsConstants.VID_BYTES)) {
+                raw = this.parseRawPacket(packet, MacaroonsConstants.VID_BYTES);
+                caveats.push(new CaveatPacket(CaveatPacketType.vid, raw));
+            } else if (this.bytesStartWith(packet.data, MacaroonsConstants.SIGNATURE_BYTES)) {
+                signature = this.parseSignature(packet, MacaroonsConstants.SIGNATURE_BYTES);
+            }
+        }
+        return new Macaroon(location, identifier, signature, caveats);
+    }
+    parseSignature(packet, signaturePacketData)
+    {
+        const headerLen = signaturePacketData.length + MacaroonsConstants.KEY_VALUE_SEPARATOR_LEN;
+        const len = Math.min(packet.data.length - headerLen, MacaroonsConstants.MACAROON_HASH_BYTES);
+        const signature = new Buffer(len);
+        packet.data.copy(signature, 0, headerLen, headerLen + len); //copy needs to be implemented - Hence buffer needs to implement copy
+        return signature;
+    }
+    parsePacket(packet, header)
+    {
+        const headerLen = header.length + MacaroonsConstants.KEY_VALUE_SEPARATOR_LEN;
+        let len = packet.data.length - headerLen;
+        if (packet.data[headerLen + len - 1] === MacaroonsConstants.LINE_SEPARATOR)
+            len--;
+        return packet.data.toString(MacaroonsConstants.IDENTIFIER_CHARSET, headerLen, headerLen + len);
+    }
+    parseRawPacket(packet, header)
+    {
+        const headerLen = header.length + MacaroonsConstants.KEY_VALUE_SEPARATOR_LEN;
+        const len = packet.data.length - headerLen - MacaroonsConstants.LINE_SEPARATOR_LEN;
+        const raw = new Buffer(len);
+        packet.data.copy(raw, 0, headerLen, headerLen + len);
+        return raw;
+    }
+    bytesStartWith(bytes, startBytes)
+    {
+        if (bytes.length < startBytes.length)
+            return false;
+        for (let i = 0, len = startBytes.length; i < len; i++) {
+            if (bytes[i] !== startBytes[i])
+                return false;
+        }
+        return true;
+    }
+    readPacket(stream)
+    {
+        if (stream.isEOF())
+            return null;
+        if (!stream.isPacketHeaderAvailable()) {
+            throw new Error("Not enough header bytes available. Needed " + MacaroonsConstants.PACKET_PREFIX_LENGTH + " bytes.");
+        }
+        var size = stream.readPacketHeader();
+        //assert size <= PACKET_MAX_SIZE;
+        var data = new Buffer(size - MacaroonsConstants.PACKET_PREFIX_LENGTH);
+        var read = stream.read(data);
+        if (read < 0)
+            return null;
+        if (read !== data.length) {
+            throw new Error("Not enough data bytes available. Needed " + data.length + " bytes, but was only " + read);
+        }
+        return new Packet(size, data);
+    }
+}

--- a/src/scripts/tasks/macaroon-deserialise-task.js
+++ b/src/scripts/tasks/macaroon-deserialise-task.js
@@ -1,0 +1,33 @@
+"use strict";
+/**
+ * @param {
+ *     macaroon: @type {String}
+ * }
+ */
+self.importScripts('../lazy-loads/macaroon-deserialiser.js');
+self.addEventListener('message', function(e) {
+    const list = e.data.macaroons;
+    const len = list.length;
+    const sharedFileslist = [];
+    for (let i = 0; i<len; i++) {
+        const macaroon = new MacaroonsDeSerialiser().deserialise(list[i]);
+        const sharedFile = {"fileMetaData" : {}, "selected": false};
+        for (let ai of macaroon.caveatPackets) {
+            const caveat = ai.getValueAsText();
+            const o = caveat.indexOf(":");
+            if (caveat.substring(0, o) === "id") {
+                const sharerInfo = caveat.substring(o + 1).trim().split(";");
+                sharedFile["owner"] = {"uid": sharerInfo[0], "gid": sharerInfo[1], "name": sharerInfo[2]}
+            } else if (caveat.substring(0, o) === "path") {
+                const a =caveat.substring(o + 1).trim();
+                sharedFile["fileName"] = a === "/" ? "Root" : a.substring(a.lastIndexOf("/") + 1);
+                sharedFile["filePath"] = caveat.substring(o + 1).trim();
+            } else {
+                sharedFile[caveat.substring(0, o)] = caveat.substring(o + 1).trim();
+            }
+            sharedFile["macaroon"] = list[i];
+        }
+        sharedFileslist.push(sharedFile);
+    }
+    self.postMessage(sharedFileslist);
+}, false);


### PR DESCRIPTION
Motivation:

A recently added patch (see https://rb.dcache.org/r/10953/) make it
possible for dcache-view users to share a file. User can either share
the macaroon or a shareable link corresponding to a file.

What is current missing is the ability to view a shared file, hence this
patch added this capability.

Modification:

- create a new routing and section for viewing shared files.
- create new set of elements specifically to be used in the shared-files.
    The elements are: shared-files-page, shared-file-list-contextual-
    content, add-macaroon-form, shared-directory-view and shared-file-list).
- covert nodejs library to a usable macaroon deserialiser for dcache-view.
    This library (called macaroon-deserialiser) will be lazy-loaded by
    macaroon-deserialise-task. The macaroon-deserialise-task is a worker
    script used to deserialise macaroon and to returned a modified response.
- modify app shell script to recognise the new routing. The modifcations
    were done in these following event-listners/methods/functions:
    findViewFile, dv-namespace-open-filemetadata-panel and app.ls
- add a title bar for shared-files inside  the selected-title element.
- get a parent path from the file path (inside the rename element) provided
    the supplied file-metadata does not contain the parent path. And if
    both are missing, then abort the renaming.

Result:

End user can view shared files.

Target: master
Request: 1.5
Require-notes: yes
Require-book: yes
Acked-by: Albert Rossi
Fixes: https://github.com/dCache/dcache-view/issues/97

Reviewed at https://rb.dcache.org/r/11413/

(cherry picked from commit e0ff52b84f81a3df28119ca1beab903e2ad2e8e9)