### PR TITLE
dcache-view (upload): fix a typo error

### DIFF
--- a/src/elements/dv-elements/utils/dcache-view-uploader/dcache-view-uploader.js
+++ b/src/elements/dv-elements/utils/dcache-view-uploader/dcache-view-uploader.js
@@ -48,7 +48,7 @@ UploadHandler.prototype.upload = function()
     const xhr = new XMLHttpRequest();
     xhr.open(this.httpMethod, this.url, true);
     xhr.setRequestHeader('Content-Type', this.contentType);
-    if (this.auth && this.auth !=="") {
+    if (this.upauth && this.upauth !=="") {
         xhr.setRequestHeader('Authorization', this.upauth);
     }
     xhr.setRequestHeader('Suppress-WWW-Authenticate', "Suppress");


### PR DESCRIPTION
Motivation:

Patch https://rb.dcache.org/r/11388/ introduce a typo
in upload handler script. Accidentally typed `this.auth`
instead of `this.upauth`.

Modification:

Correct the typographical error.

Result:

Upload now works.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan

Reviewed at https://rb.dcache.org/r/11426/

(cherry picked from commit 8fbdc5cb6ebc5034a53ac4445e3f1c92f4849648)