### PR TITLE
dcache-view (file-sharing): add missing parameter

### DIFF
--- a/src/elements/dv-elements/selected-title/selected-title.html
+++ b/src/elements/dv-elements/selected-title/selected-title.html
@@ -157,7 +157,7 @@
                     <paper-tooltip>create new folder</paper-tooltip>
                 </div>
                 <div>
-                    <upload-files-button></upload-files-button>
+                    <upload-files-button authentication-parameters="[[authenticationParameters]]"></upload-files-button>
                 </div>
                 <div>
                     <paper-icon-button class="info"


### PR DESCRIPTION
Motivation:

The upload button for the file-sharing is missing
authentication parameter.

Modification:

Add the missing parameter.

Result:

User can now upload files using macaroon.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan

Reviewed at https://rb.dcache.org/r/11427/

(cherry picked from commit 97d5158f74a64a414df203cb07e690ffc75a9d7d)