### PR TITLE
dcache-view (upload): fix dcache issue 3011

### DIFF
--- a/src/elements/dv-elements/upload-files/upload-files-button.html
+++ b/src/elements/dv-elements/upload-files/upload-files-button.html
@@ -20,7 +20,7 @@
             }
         </style>
         <div>
-            <input id="files" type="file" multiple>
+            <input id="files" on-tap="_resetValue" type="file" multiple>
             <label for="files">
                 <paper-icon-button icon="icons:cloud-upload"></paper-icon-button>
                 <paper-tooltip>upload files</paper-tooltip>
@@ -159,6 +159,10 @@
             _setCurrentPath(e)
             {
                 this.currentPath = e.detail.currentPath;
+            }
+            _resetValue(e)
+            {
+                this.$["files"].value = null;
             }
         }
         window.customElements.define(UploadFilesButton.is, UploadFilesButton);


### PR DESCRIPTION
Motivation:

When a user upload a file and the re-uploaded it (for whatever
reason), the browser always prevent this kind of re-upload.
This is mainly because the value of the input element have
not changed and the on-change event is not triggered.

Modification:

Set the input value to null when the tag is clicked.

Result:

Fixed the reported issue.

Target: master
Request: 1.5
Request: 1.4
Request: 1.3
Require-notes: no
Require-book: no
Acked-by: Paul Millar
Fixes: https://github.com/dCache/dcache/issues/3011

Reviewed at https://rb.dcache.org/r/11434/

(cherry picked from commit 3e98ab8dec68cbe8049810a92f9c6622be7789de)