### PR TITLE
dcache-view (shell): fix type-error when switching between routes

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -235,8 +235,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                               selected="[[route]]">
                                     <template is="dom-if" if="[[config.isSomebody]]">
                                         <paper-item>
-                                            <a data-route="home" href$="{{baseUrl}}"
-                                               on-tap="lsHomeDir">
+                                            <a data-route="home" on-tap="lsHomeDir">
                                                 <paper-fab icon="home"
                                                            title="Your home directory" class="red" mini></paper-fab>
                                             </a>

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -64,6 +64,7 @@
 
     app.lsHomeDir = function()
     {
+        app.route = "home";
         app.ls(sessionStorage.homeDirectory);
     };
 


### PR DESCRIPTION
Motivation:

dCache view have different page routes; for the listing of
directories - this belong to the home route. The home route
is divided into two sections, one list the root directory
and the other is for the user home directory.

When switching from other sections (like user-profile, admin,
etc.) to the later (the user home directory), an uncaught
error reported in the log console saying: "TypeError: Cannot
read property 'parentNode' of undefined".

Modification:

Remove the href attribute in the user home directory section
and explicitly set the route to home.

Result:

This fix will ensure that when the findViewFile function is
called in the app.ls method, the proper view-file element
is queried for, hence no type-error will be logged.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11445/

(cherry picked from commit d3a65dbe0ff6510d5ad5c5e75844d2b846352b6b)