### PR TITLE
dcache-view (user-profile): make gravatar optional

### DIFF
--- a/src/elements/dv-elements/user-authentication/login-form.html
+++ b/src/elements/dv-elements/user-authentication/login-form.html
@@ -69,6 +69,22 @@
                     font-size: 0.71em;
                 }
             }
+            .checkbox-container {
+                display: flex;
+                align-items: center;
+            }
+            .flex {
+                flex: 1 1 auto;
+            }
+            .info-class {
+                display:inline-block;
+                padding-left: 5px;
+            }
+            .info-icon {
+                width:15px;
+                height:15px;
+                fill: #f2f4f4
+            }
         </style>
         <div id="container">
             <iron-a11y-keys keys="enter" on-keys-pressed="_login"></iron-a11y-keys>
@@ -87,8 +103,17 @@
                        name="password" id="password"
                        value="{{password::input}}" placeholder="password" type="password">
             </paper-input-container>
-            <div>
+            <div class="checkbox-container">
                 <paper-checkbox checked="{{assertionStatus}}">Assert all roles</paper-checkbox>
+                <span class="flex"></span>
+                <paper-checkbox checked="{{useGravatar}}">Use Gravatar </paper-checkbox>
+                <div class="info-class">
+                    <iron-icon icon="info" class="info-icon"></iron-icon>
+                    <paper-tooltip>
+                        A Gravatar is a Globally Recognized Avatar (See https://en.gravatar.com/).
+                        If this option is checked, a request will be sent to Gravatar.
+                    </paper-tooltip>
+                </div>
             </div>
             <div class$="[[_computedClass(errorMessage)]]">
                 <span class="error-message">[[errorMessage]]</span>
@@ -140,6 +165,14 @@
                         type: Boolean,
                         value: false,
                         notify: true
+                    },
+                    useGravatar: {
+                        type: Boolean,
+                        value: function () {
+                            return sessionStorage.useGravatar === "yes";
+                        },
+                        notify: true,
+                        observer: '_useGravatarChanged'
                     }
                 };
             }
@@ -178,6 +211,10 @@
                 classes = errMessage === undefined || errMessage === "" ? 'hide' : 'messageContainer show';
                 this.updateStyles();
                 return classes;
+            }
+            _useGravatarChanged(g)
+            {
+                sessionStorage.useGravatar = g === true ? "yes" : "no";
             }
         }
         window.customElements.define(LoginForm.is, LoginForm);

--- a/src/elements/dv-elements/user-profile/gravatar-request.html
+++ b/src/elements/dv-elements/user-profile/gravatar-request.html
@@ -3,11 +3,7 @@
 
 <dom-module id="gravatar-request">
     <template>
-        <iron-jsonp-library
-                id="jsonp"
-                library-url="[[libraryUrl]]"
-                library-loaded="{{loaded}}"
-                library-error-message="{{errorMessage}}"></iron-jsonp-library>
+        <div id="jsonp-holder"></div>
     </template>
     <script>
         class GravatarRequest extends Polymer.Element
@@ -39,13 +35,8 @@
                         notify: true,
                         observer: '_generateLibraryUrl'
                     },
-                    errorMessage: {
-                        type: String,
-                        observer: '_errorOccurred'
-                    },
-                    loaded: {
-                        type: Boolean,
-                        observer: '_generateGravatarSrc'
+                    _runningHash: {
+                        type: String
                     },
                     _counter: {
                         type: Number,
@@ -74,17 +65,26 @@
             }
             _generateLibraryUrl(hash)
             {
-                if (hash.length > 0 && this._counter < hash.length) {
-                    this.$.jsonp.libraryUrl =
-                        `https://en.gravatar.com/${hash[this._counter]}.json?callback=%%callback%%`;
-                    this._counter++;
-                } else {
-                    throw new Error("No associated Gravatar available with these emails.");
+                if (hash) {
+                    if (this._counter > hash.length) {
+                        throw new Error("No associated Gravatar available with these emails.");
+                    }
+                    if (hash.length > 0 && this._counter < hash.length) {
+                        app.removeAllChildren(this.$["jsonp-holder"]);
+                        const jsonp  = /** @type {!IronJsonpLibrary} */ (
+                            document.createElement('iron-jsonp-library'));
+                        jsonp.addEventListener('library-loaded-changed', this._generateGravatarSrc.bind(this));
+                        jsonp.addEventListener('library-error-message-changed', this._errorOccurred.bind(this));
+                        this.$['jsonp-holder'].appendChild(jsonp);
+                        this._runningHash = hash[this._counter];
+                        jsonp.libraryUrl = `https://en.gravatar.com/${this._runningHash}.json?callback=%%callback%%`;
+                        this._counter++;
+                    }
                 }
             }
-            _errorOccurred(err)
+            _errorOccurred(event)
             {
-                if (err !== null) {
+                if (event && !!(event.detail) && !!(event.detail.value)) {
                     try {
                         this._generateLibraryUrl(this.hash);
                     } catch (e) {
@@ -92,13 +92,13 @@
                     }
                 }
             }
-            _generateGravatarSrc(isSuccessful)
+            _generateGravatarSrc(event)
             {
-                if (isSuccessful) {
+                if (event.detail.value) {
                     window.CONFIG.avatarSrc =
-                        `https://secure.gravatar.com/avatar/${this.hash[+this._counter-1]}?s=${this.size}`;
+                        `https://secure.gravatar.com/avatar/${this._runningHash}?s=${this.size}`;
                     this.dispatchEvent(new CustomEvent('gravatar-request-successful', {detail: {
-                        link: `https://secure.gravatar.com/avatar/${this.hash[+this._counter-1]}?s=${this.size}`}}));
+                        link: `https://secure.gravatar.com/avatar/${this._runningHash}?s=${this.size}`}}));
                 }
             }
         }

--- a/src/elements/dv-elements/user-profile/user-image.html
+++ b/src/elements/dv-elements/user-profile/user-image.html
@@ -5,6 +5,11 @@
 <dom-module id="user-image">
     <template>
         <style>
+            :host {
+                --user-image-border-radius: 0;
+                --user-image-width: 60px;
+                --user-image-height: 60px;
+            }
             .container{
                 width: 100%;
                 height: 100%;
@@ -20,13 +25,18 @@
             .hide {
                 display: none !important;
             }
+            img {
+                border-radius: var(--user-image-border-radius);
+                width: var(--user-image-width);
+                height: var(--user-image-height);
+            }
         </style>
         <div class="container">
             <gravatar-request id="gravatar"
                               size="[[size]]"
                               on-gravatar-request-error="_gravatarResponseListener"
                               on-gravatar-request-successful="_gravatarResponseListener"></gravatar-request>
-            <img id="avatar" width="{{size}}" height="{{size}}">
+            <img id="avatar">
             <paper-spinner id="spinner" active="[[loading]]"></paper-spinner>
         </div>
     </template>
@@ -51,7 +61,7 @@
                     },
                     size: {
                         type: Number,
-                        Value: 60,
+                        value: 60,
                         notify: true
                     },
                     loading: {
@@ -68,7 +78,11 @@
                     link: {
                         type: String,
                         notify: true,
-                    }
+                    },
+                    gravatarSwitch: {
+                        type: Boolean,
+                        notify: true
+                    },
                 }
             }
             static get observers()
@@ -78,35 +92,53 @@
                     '_visibility(loading)'
                 ];
             }
+            constructor()
+            {
+                super();
+                this._requestNewImageListener = this._requestNewImage.bind(this)
+            }
             ready()
             {
                 super.ready();
                 Polymer.RenderStatus.afterNextRender(this, ()=> {
                     if (window.CONFIG.avatarSrc === undefined || window.CONFIG.avatarSrc === "") {
-                        if (this.email===undefined || this.email === null || this.email === "") {
-                            this.src = this._fallbackCall(this.fallbackValue);
-                            return;
-                        }
-                        const gravatar = this.$.gravatar;
-                        gravatar.request(this.email);
-
-                        /**
-                         * If no response is received from the request after 1.5 seconds,
-                         * use the fallback option.
-                         */
-                        setTimeout(()=>{
-                            if (!window.CONFIG.avatarSrc) {
+                        if (sessionStorage.getItem('useGravatar') === "yes") {
+                            if (this.email===undefined || this.email === null
+                                || this.email === "" || this.email === "not available") {
                                 this.src = this._fallbackCall(this.fallbackValue);
+                                return;
                             }
-                        }, 1500);
+                            this._gravatarRequestWithFallBack();
+                        } else {
+                            this.src = this._fallbackCall(this.fallbackValue);
+                        }
                     } else {
                         this.src = window.CONFIG.avatarSrc;
                     }
                 });
             }
+            connectedCallback()
+            {
+                super.connectedCallback();
+                window.addEventListener('dv-user-image-request', this._requestNewImageListener);
+            }
+            disconnectedCallback()
+            {
+                super.disconnectedCallback();
+                window.removeEventListener('dv-user-image-request', this._requestNewImageListener);
+            }
             _gravatarResponseListener(e)
             {
-                this.src = e.detail.link ? e.detail.link : this._fallbackCall(this.fallbackValue);
+                if (e.detail.link) {
+                    this.src = e.detail.link;
+                    sessionStorage.setItem('useGravatar', 'yes');
+                    this.gravatarSwitch = true;
+                } else {
+                    this.src = this._fallbackCall(this.fallbackValue);
+                    this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                        detail: {message: e.message}, bubbles: true, composed: true
+                    }));
+                }
             }
             _srcChanged(n)
             {
@@ -121,6 +153,8 @@
                 const uIcon = new IdenticonRequest(value);
                 uIcon.size = this.size;
                 window.CONFIG.avatarSrc = uIcon.generateSrc();
+                sessionStorage.setItem('useGravatar', 'no');
+                this.gravatarSwitch = false;
                 return uIcon.generateSrc();
             }
             _visibility(loading) {
@@ -130,6 +164,37 @@
                 } else {
                     this.$.avatar.classList.remove('hide');
                     this.$.spinner.classList.add('hide');
+                }
+            }
+            _gravatarRequestWithFallBack()
+            {
+                try {
+                    const gravatar = this.$.gravatar;
+                    gravatar._counter = 0;
+                    gravatar.request(this.email);
+                } catch (e) {
+                    this.src = this._fallbackCall(this.fallbackValue);
+                    this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                        detail: {message: `${e.message}`}, bubbles: true, composed: true
+                    }));
+                }
+
+                /**
+                 * If no response is received from the request after 1.5 seconds,
+                 * use the fallback option.
+                 */
+                setTimeout(()=>{
+                    if (!window.CONFIG.avatarSrc) {
+                        this.src = this._fallbackCall(this.fallbackValue);
+                    }
+                }, 1500);
+            }
+            _requestNewImage(e)
+            {
+                if (e.detail.type === "gravatar") {
+                    this._gravatarRequestWithFallBack();
+                } else if (e.detail.type === "identicon") {
+                    this.src = this._fallbackCall(this.fallbackValue);
                 }
             }
         }

--- a/src/elements/dv-elements/user-profile/user-profile.html
+++ b/src/elements/dv-elements/user-profile/user-profile.html
@@ -65,6 +65,8 @@
             .label {
                 min-width: 150px;
                 max-width: 150px;
+            }
+            .bold {
                 font-weight: bold;
             }
             .value {
@@ -118,15 +120,27 @@
                 letter-spacing: -.012em;
                 line-height: 20px;
             }
-            .warning {
-                color: rgb(221, 44, 0) !important;
+            .header-container {
+                padding-left: 10px;
+            }
+            .flex-centre {
+                justify-content: center
+            }
+            .small {
+                color: #1c7cf1;
+                font-size: 0.67em;
+            }
+            .red {
+                color: rgb(221, 44, 0);
             }
         </style>
         <div class="display-flex column">
             <paper-material elevation="2">
                 <div class="paper-material-inner display-flex border-top" style="background: #f5f5f5">
                     <div class="display-flex vertically-align image-holder">
-                        <user-image fallback-value="[[username]]" email="[[email]]"></user-image>
+                        <user-image email="[[email]]" size="60"
+                                    fallback-value="[[username]]"
+                                    gravatar-switch="{{gravatarSwitch}}"></user-image>
                     </div>
 
                     <div class="display-flex column flex"
@@ -142,40 +156,80 @@
             <paper-material>
                 <div class="paper-material-inner display-flex column">
                     <div class="display-flex row vertically-align">
-                        <div class="label">Home directory path</div>
+                        <div class="label bold">Home directory path</div>
                         <div class="value flex">
                             [[homeDir]]
                         </div>
                         <paper-button class="btn" on-tap="_view" data-path$="[[homeDir]]">view</paper-button>
                     </div>
                     <div class="display-flex row vertically-align">
-                        <div class="label">Root directory path</div>
+                        <div class="label bold">Root directory path</div>
                         <div class="value flex">
                             [[rootDir]]
                         </div>
                         <paper-button class="btn" on-tap="_view" data-path$="[[rootDir]]">view</paper-button>
                     </div>
                     <div class="display-flex row vertically-align">
-                        <div class="label">Email address</div>
+                        <div class="label bold">Email address</div>
                         <div class$="[[_computedEmailCss(email)]]">[[email]]</div>
                     </div>
                     <div class="display-flex row vertically-align">
-                        <div class="label">User identifier (UID)</div>
+                        <div class="label bold">User identifier (UID)</div>
                         <div class="value">[[uid]]</div>
                     </div>
                     <div class="display-flex row vertically-align">
-                        <div class="label">Group identifier (GID)</div>
+                        <div class="label bold">Group identifier (GID)</div>
                         <div class="value">[[gids]]</div>
                     </div>
                 </div>
             </paper-material>
 
             <paper-material>
-                <div style="padding-left: 10px;">
+                <div class="header-container">
+                    <div class="header">
+                        Profile Image
+                    </div>
+                    <small class="small">
+                        Choose which profile image to use.
+                    </small>
+                </div>
+                <div class="paper-material-inner display-flex column">
+                    <div class="display-flex row vertically-align">
+                        <div class="value flex">
+                            Available options:
+                        </div>
+                    </div>
+                    <div class="display-flex row vertically-align">
+                        <div class="bold label-addPadding">Identicon -</div>
+                        <div class="value flex">
+                            <small class="small">&nbsp;generated based on username</small>
+                        </div>
+                        <paper-toggle-button id="identicon"
+                                             checked="[[!gravatarSwitch]]"
+                                             on-change="_requestIdenticonImage"
+                                             data-id="identicon"
+                                             class="toggleBtn"></paper-toggle-button>
+                    </div>
+                    <div class="display-flex row vertically-align">
+                        <div class="bold label-addPadding">Gravatar -</div>
+                        <div class="value flex">
+                            <small class="small">&nbsp;see https://en.gravatar.com/ for detail</small>
+                        </div>
+                        <paper-toggle-button id="gravatar"
+                                             checked="[[gravatarSwitch]]"
+                                             on-change="_requestGravatarImage"
+                                             data-id="gravatar"
+                                             class="toggleBtn"></paper-toggle-button>
+                    </div>
+                </div>
+            </paper-material>
+
+            <paper-material>
+                <div class="header-container">
                     <div class="header">
                         Roles
                     </div>
-                    <small style="color: #1c7cf1; font-size: 0.67em;">
+                    <small class="small">
                         These are optional switch that affect how dCache behaves
                     </small>
                 </div>
@@ -191,29 +245,34 @@
                         </paper-toggle-button>
                     </div>
 
-                    <div class$="[[_computedClass('no-roles')]]" style="justify-content: center">
-                        <div style="color: rgb(221, 44, 0);">
+                    <div class$="[[_computedClass('no-roles')]]" class="flex-centre">
+                        <div class="red">
                             <iron-icon icon="visibility-off"></iron-icon>
                             <span> No roles to assert</span>
                         </div>
                     </div>
-                    <template is="dom-repeat" items="[[listOfAllRoles]]">
-                        <div class="display-flex row vertically-align">
-                            <div class="label label-addPadding">[[item]]</div>
-                            <div class="value flex"></div>
-                            <paper-toggle-button on-change="_roleAssertion"
-                                                 data-roles="[[item]]"
-                                                 checked="[[_currentStatus(item)]]"
-                                                 class="toggleBtn"></paper-toggle-button>
-                        </div>
-                    </template>
                 </div>
+                <template is="dom-repeat" items="[[listOfAllRoles]]">
+                    <div class="display-flex row vertically-align">
+                        <div class="label bold label-addPadding">[[item]]</div>
+                        <div class="value flex"></div>
+                        <paper-toggle-button on-change="_roleAssertion"
+                                             data-roles="[[item]]"
+                                             checked="[[_currentStatus(item)]]"
+                                             class="toggleBtn"></paper-toggle-button>
+                    </div>
+                </template>
             </paper-material>
         </div>
     </template>
     <script>
         class UserProfile extends Polymer.Element
         {
+            constructor()
+            {
+                super();
+                this.gravatarSwitch = sessionStorage.useGravatar === "yes";
+            }
             static get is()
             {
                 return 'user-profile';
@@ -232,7 +291,7 @@
                         type: String,
                         notify: true,
                         value: function () {
-                            return sessionStorage.getItem("email");
+                            return !!sessionStorage.getItem("email") ? sessionStorage.getItem("email"): 'not available';
                         }
                     },
                     uid: {
@@ -284,6 +343,11 @@
                                 return x.indexOf(item) < 0;
                             }));
                         }
+                    },
+                    gravatarSwitch: {
+                        type: Boolean,
+                        notify: true,
+                        observer: '_imageSwitchChange'
                     }
                 }
             }
@@ -317,7 +381,7 @@
             {
                 let classes = 'value flex';
                 if (email === "not available") {
-                    classes += ' warning';
+                    classes += ' red';
                 }
                 return classes;
             }
@@ -382,6 +446,42 @@
                 });
                 rr.assert(roles, redirectTo);
             }
+            _requestIdenticonImage(e)
+            {
+                if (this.$['identicon'].checked === true) {
+                    this.dispatchEvent(new CustomEvent('dv-user-image-request', {
+                        detail: {type: "identicon"}, bubbles: true, composed: true
+                    }));
+                } else {
+                    this._requestGravatar();
+                }
+            }
+            _requestGravatarImage(e)
+            {
+                if (this.$['gravatar'].checked === true) {
+                    this._requestGravatar();
+                } else {
+                    this.dispatchEvent(new CustomEvent('dv-user-image-request', {
+                        detail: {type: "identicon"}, bubbles: true, composed: true
+                    }));
+                }
+            }
+            _requestGravatar()
+            {
+                const email = sessionStorage["email"];
+                if (!!email) {
+                    this.dispatchEvent(new CustomEvent('dv-user-image-request', {
+                        detail: {type: "gravatar"}, bubbles: true, composed: true
+                    }));
+                } else {
+                    this.$['gravatar'].checked = false;
+                    this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                        detail: {message: "To use Gravatar image, a valid and registered email " +
+                                "must be associated with this account."}, bubbles: true, composed: true
+                    }));
+                }
+            }
+
         }
         window.customElements.define(UserProfile.is, UserProfile);
     </script>

--- a/src/elements/routing.html
+++ b/src/elements/routing.html
@@ -135,7 +135,7 @@
             }
 
             let up = new UserProfile();
-            app.$.userProfileContainer.innerHTML = "";
+            app.removeAllChildren(app.$.userProfileContainer);
             app.$.userProfileContainer.appendChild(up);
             app.route = 'user-profile';
             app.params = "";


### PR DESCRIPTION
Motivation:

If a user account have an email associated with it, a request
is sent to check if the email is registered with the Gravatar,
and if it is, the image from gravatar is used by dcache-view
as the user profile.

Since this is the current default behaviour of dcache-view,
some sites are not happy with this and the preferred behaviour
will to make gravatar optional for users.

Modification:

1. properly remove all node inside the user profile section.
2. add a checkbox in the login form. This enable users to
    choose whether to use a gravatar or not. By default,
    the checkbox is unchecked. This means that users will
    have to specfically check the checkbox to indicate that
    dcache-view can make a request to the Gravatar
3. adjust the user-image element
4. update user-profile and user-profile-dropdown element to
    use the adjusted user-image element.
5. add a section in the user-profile for user to see and sel-
    ect the preferred user profile image. There are only two
    options (identicon and gravatar) available at this time.

Result:

User can now opt-in or out of gravatar.

Target: master
Request: 1.5
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan
Fixes: https://github.com/dCache/dcache-view/issues/135

Reviewed at https://rb.dcache.org/r/11450/

(cherry picked from commit 89eab84fe9f06de030179ffab946d590d95257eb)