### PR TITLE
dcache-view (upload): fix issue 113

### DIFF
--- a/src/elements/dv-elements/upload-files/error/upload-error-dialog.html
+++ b/src/elements/dv-elements/upload-files/error/upload-error-dialog.html
@@ -1,0 +1,89 @@
+<link rel="import" href="../../../../bower_components/polymer/polymer-element.html">
+<link rel="import" href="../../../../bower_components/app-layout/app-toolbar/app-toolbar.html">
+<link rel="import" href="../../../../bower_components/paper-icon-button/paper-icon-button.html">
+<dom-module id="upload-error-dialog">
+    <template>
+        <style>
+            :host {
+                display: flex;
+                flex-direction: column;
+                margin: 0 -24px !important;
+                width: 450px;
+                height: 240px;
+                background: #fff;
+                box-sizing: border-box;
+                padding: 0 !important;
+            }
+            app-toolbar {
+                height: 40px;
+                min-height: 40px;
+                letter-spacing: .0125em;
+                -webkit-font-smoothing: antialiased;
+                background: #fff;
+                color: #222;
+                font-weight: normal;
+                line-height: 24px;
+                font-size: 20px;
+                padding: 0 10px;
+                border-bottom: 1px solid rgba(208,208,208,.87);
+            }
+            app-toolbar paper-icon-button {
+                color: rgba(0,0,0,.87);
+                padding: 0;
+                width: 20px;
+                height: 20px;
+            }
+            #content {
+                flex: 1 1 auto;
+                display: flex;
+                flex-direction: column;
+                padding: 0 10px;
+            }
+            p {
+                font-size: 0.93em;
+                margin-bottom: 0;
+            }
+            .reason {
+                padding: 10px 15px;
+                font-size: 0.8em;
+            }
+            .reason + .reason {
+                border-top: 1px solid #d4d4d4;
+            }
+            .reason div {
+                padding: 0 15px;
+                text-align: justify;
+            }
+        </style>
+        <app-toolbar>
+            <div main-title>File Upload Error</div>
+            <paper-icon-button icon="close" dialog-dismiss></paper-icon-button>
+        </app-toolbar>
+        <div id="content">
+            <div>
+                <p>
+                    The upload failed due to an unknown error. Below are couple of reason and suggestion:
+                </p>
+            </div>
+            <div class="reason">
+                <span>
+                    <b>1. </b>You might not have the permission to upload into this directory.
+                </span>
+                <div>
+                    <i>Please check if you have the write access to the directory you are
+                        trying to upload file into.</i>
+                </div>
+            </div>
+            <div class="reason">
+                <span>
+                    <b>2. </b>Your site WebDav door might be offline, not well configured or broken.
+                </span>
+                <div>
+                    <i>Please check the WebDav door or contact your admin.</i>
+                </div>
+            </div>
+        </div>
+    </template>
+    <script src="upload-error-dialog.js">
+    </script>
+</dom-module>

--- a/src/elements/dv-elements/upload-files/error/upload-error-dialog.js
+++ b/src/elements/dv-elements/upload-files/error/upload-error-dialog.js
@@ -1,0 +1,8 @@
+class UploadErrorDialog extends Polymer.Element
+{
+    static get is()
+    {
+        return "upload-error-dialog";
+    }
+}
+window.customElements.define(UploadErrorDialog.is, UploadErrorDialog);

--- a/src/elements/dv-elements/upload-files/upload-toast-file.html
+++ b/src/elements/dv-elements/upload-files/upload-toast-file.html
@@ -4,7 +4,7 @@
 <link rel="import" href="../../../bower_components/iron-flex-layout/iron-flex-layout.html">
 <link rel="import" href="../../../bower_components/iron-label/iron-label.html">
 <link rel="import" href="../../../bower_components/file-icon/file-icon.html">
-
+<link rel="import" href="./error/upload-error-dialog.html">
 <dom-module id="upload-toast-file">
     <template>
         <style>
@@ -114,6 +114,18 @@
                 color:#fff;
                 font-size: 1em !important;
             }
+            .none {
+                display: none;
+            }
+            .button-container {
+                display: inline;
+            }
+            .button-container paper-button {
+                text-transform: none;
+                color: #674c4f;
+                padding: 0;
+                margin: 0;
+            }
         </style>
         <div class="main">
             <div id="fileStatusInfo">
@@ -123,28 +135,31 @@
                     </div>
                     <div id="fileInfo">
                         <div id="fileName">
-                            <div id="fileNameHolder">
-                                {{fileName}}
-                            </div>
+                            <div id="fileNameHolder">[[fileName]]</div>
                         </div>
                         <div id="statusMessage">
                             <span>Status:</span>
-                            <label class$="[[_computedClass(hasError,isComplete,inProgress)]]"> {{message}}</label>
+                            <label id="message"
+                                   class$="[[_computedClass(hasError,isComplete,inProgress)]]">[[message]]</label>
+                            <label id="button-container" class="none">
+                                <paper-button on-tap="_detailError">
+                                    File upload failed! Click here for details.</paper-button>
+                            </label>
                         </div>
                     </div>
                     <div id="statusIcon">
-                        <template is="dom-if" if="{{isComplete}}" restamp>
+                        <template is="dom-if" if="[[isComplete]]" restamp>
                             <div class="statusContent">
                                 <iron-icon icon="icons:check-circle" class="completeIcon"></iron-icon>
                             </div>
                         </template>
-                        <template is="dom-if" if="{{hasError}}" restamp>
+                        <template is="dom-if" if="[[hasError]]" restamp>
                             <div class="statusContent">
                                 <iron-icon icon="icons:warning" class="errorIcon"></iron-icon>
                             </div>
                         </template>
-                        <template is="dom-if" if="{{inProgress}}" restamp>
-                            <div class="statusContent"><b class="progressIcon">{{progressValue}}</b></div>
+                        <template is="dom-if" if="[[inProgress]]" restamp>
+                            <div class="statusContent"><b class="progressIcon">[[progressValue]]</b></div>
                         </template>
                     </div>
                 </div>
@@ -203,7 +218,8 @@
                     message: {
                         type: String,
                         value: "uploading...",
-                        notify: true
+                        notify: true,
+                        observer: '_messageChanged'
                     },
                     progressValue: {
                         type: String,
@@ -226,6 +242,24 @@
                 this.updateStyles();
 
                 return classes;
+            }
+            _messageChanged(message)
+            {
+                if (message === "") {
+                    this.$['button-container'].classList.replace('none', 'button-container');
+                    this.$['message'].style.display = 'none';
+                } else {
+                    this.$['button-container'].classList.add('none');
+                    this.$['message'].style.display = 'inline';
+                }
+            }
+            _detailError()
+            {
+                const content = new UploadErrorDialog();
+                this.dispatchEvent(
+                    new CustomEvent('dv-namespace-open-central-dialogbox', {
+                        detail: {node: content}, bubbles: true, composed: true})
+                );
             }
         }
         window.customElements.define(UploadToastFile.is, UploadToastFile)


### PR DESCRIPTION
Motivation:

Sometimes if user doesn't have the right permission or the
webdav is not trusted by the browser. If this user perform
a write operation with dcache-view upload handler, the ajax
request will return an empty `statusText` with zero `Status`
code number but with `readyState` set to 4. This implied that
the request was sent and error occured but with no error me-
ssage. For the end-user, this is not very helpful.

Modification:

- adjust upload-toast-file, by first using the one-way
    binding. And second, when the error message is empty,
    a button will be shown. If clicked, this will show a
    dialog box that contain information concerning the
    possible cause of the error.
- create an element that will serve as a dialog content
    for the upload failure.

Result:

Provide some possible cause of the upload failure.

Target: master
Request: 1.5
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Albert Rossi
Fixes: https://github.com/dCache/dcache-view/issues/113

Reviewed at https://rb.dcache.org/r/11440/

(cherry picked from commit 1aa9d9c6f66bb41433c98989372af7e1d2fce504)