### PR TITLE
dcache-view (context-menu): fix incorrectly positioned context-menu

### DIFF
--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -131,7 +131,7 @@
          */
         const vf = findViewFile(e);
         if (vf) {
-            let h = 110, cc;
+            let h = 160, cc;
             if (e.screenX === 0 && e.screenY === 0) {
                 const arr = e.path || (e.composedPath && e.composedPath());
                 const lr = arr.find(function (el) {
@@ -143,7 +143,7 @@
                 } else {
                     cc = new NamespaceContextualContent(lr, 0, vf.authenticationParameters);
                 }
-                h = 245;
+                h = 310;
             } else {
                 cc = new NamespaceContextualContent(vf.currentDirMetaData, 2, vf.authenticationParameters);
             }


### PR DESCRIPTION
Motivation:

dCache View uses custom context menu in the directory listing and
file sharing section to provide user with available functionality
that can be performed in the current state. The height and width
of the content of the context menu must be known to determine the
most logical postion to display or show the context menu.

Since the set of choices that are available through the context
menu have increased over time, the height of the content of the
context menu were not adjusted to reflect this changes. Hence,
when user now hit a certain threshold, the context menu will be
incorrectly positioned.

Modification:

Adjust the height of the context menu to reflect the current
available choices.

Result:

The context menu is now correctly positioned.

Target: master
Request: 1.5
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11477/

(cherry picked from commit be09b0a428ea88592e41d01ef90b479d88dfcebf)