### PR TITLE
dcache-view (filemetadata-dashboard): show correct information

### DIFF
--- a/src/elements/dv-elements/file-metadata-dashboard/file-metadata-dashboard.html
+++ b/src/elements/dv-elements/file-metadata-dashboard/file-metadata-dashboard.html
@@ -144,17 +144,17 @@
                             <small>&nbsp;based on MIME Type</small>
                         </p>
                     </div>
-                    <div id="previewContainer" class="preview-container">
+                    <div id="preview-container" class="preview-container">
                         <google-chart
                                 type='pie'
                                 data="[[_data]]"
                                 class="children-count"
                                 options="[[_options]]"></google-chart>
                     </div>
-                    <div id="empty" class="none">
-                        <iron-icon class="empty-icon" icon="[[icon]]"></iron-icon>
+                    <div id="message-container" class="none">
+                        <iron-icon class$="[[messageIconClass]]" icon="[[messageIcon]]"></iron-icon>
                         <small>No data to analyse</small>
-                        <b>[[errorMessage]]</b>
+                        <b>[[message]]</b>
                     </div>
                 </div>
             </app-header>
@@ -188,7 +188,9 @@
                 this._setChildren_ = this._setChildren.bind(this);
                 this._close_ = this._close.bind(this);
                 this._rawOrFormatted_ = this._rawOrFormatted.bind(this);
-
+                if (!file.fileMimeType && file.fileType === "DIR") {
+                    file.fileMimeType = "application/vnd.dcache.folder";
+                }
                 this.knownMetadata = file;
                 this.path = path === "" ? "/": path;
 
@@ -200,12 +202,10 @@
                 if (idx === 1) {
                     this.index = -10;
                     window.addEventListener('dv-namespace-receive-children', this._setChildren_);
-
                     window.dispatchEvent(
                         new CustomEvent('dv-namespace-request-children', {bubbles: true, composed: true}));
                 } else {
                     window.addEventListener('dv-namespace-receive-item-index', this._setIndexListener_);
-
                     window.dispatchEvent(
                         new CustomEvent('dv-namespace-request-item-index', {
                             detail: {item: file}, bubbles: true, composed: true}));
@@ -285,12 +285,12 @@
                         },
                         notify: true
                     },
-                    icon: {
+                    messageIcon: {
                         type: String,
                         value: 'icons:announcement',
                         notify: true
                     },
-                    errorMessage: {
+                    message: {
                         type: String,
                         value: 'Empty Directory',
                         notify: true
@@ -299,19 +299,18 @@
                         type: Boolean,
                         value: true,
                         notify: true
+                    },
+                    messageIconClass: {
+                        type: String,
+                        value: "empty-icon",
+                        notify: true
                     }
                 }
             }
             ready()
             {
                 super.ready();
-                Polymer.RenderStatus.afterNextRender(this, function() {
-                    if (this.formatStatus) {
-                        this.__formatStyleSwitch(true);
-                    } else {
-                        this.__formatStyleSwitch(false);
-                    }
-                });
+                Polymer.RenderStatus.afterNextRender(this, () => this.__formatStyleSwitch(this.formatStatus));
             }
             _indexChanged(idx)
             {
@@ -323,8 +322,8 @@
             {
                 const len = children.length;
                 if (len > 0) {
-                    this.$.empty.classList.replace('empty', 'none');
-                    this.$.previewContainer.classList.replace('none', 'preview-container');
+                    this.$['message-container'].classList.replace('empty', 'none');
+                    this.$['preview-container'].classList.replace('none', 'preview-container');
                     if (len >= 100) {
                         if (this.refreshRequire) {
                             this._requestAllChildren();
@@ -335,8 +334,8 @@
 
                     this._setPieChartData(children, len);
                 } else {
-                    this.$.empty.classList.replace('none', 'empty');
-                    this.$.previewContainer.classList.replace('preview-container', 'none');
+                    this.$['message-container'].classList.replace('none', 'empty');
+                    this.$['preview-container'].classList.replace('preview-container', 'none');
                 }
             }
             _requestAllChildren()
@@ -345,9 +344,9 @@
                     this.refreshRequire = false;
                     this.setProperties({children: data.children});
                 }).catch(err => {
-                    this.errorMessage = err.message;
-                    this.icon = 'icons:warning';
-                    this.$.empty.querySelector('iron-icon').classList.replace('empty-icon', 'warning-icon');
+                    this.message = err.message;
+                    this.messageIcon = 'icons:warning';
+                    this.messageIconClass = 'warning-icon';
                 })
             }
             _setPieChartData(children, len)
@@ -393,7 +392,13 @@
             }
             _setChildren(e)
             {
-                this.children = e.detail.children;
+                if (e.detail.message === "successful") {
+                    this.children = e.detail.children;
+                } else {
+                    this.message = e.detail.message;
+                    this.messageIcon = 'icons:warning';
+                    this.messageIconClass = 'warning-icon';
+                }
             }
             _close()
             {

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -248,6 +248,9 @@
                     _temporarySelectedItemsHolder: {
                         type: Array,
                         value: ()=>{return [];}
+                    },
+                    _namespaceRequestMessage: {
+                        type: String
                     }
                 }
             }
@@ -303,7 +306,7 @@
             handleResponse(response)
             {
                 const children = response.children;
-
+                this._namespaceRequestMessage = "successful";
                 if (!(children.length === 0 && this.__counter__ === 0)) {
                     children.forEach((child) => {
                         this.$.feList.push('items', child)
@@ -326,7 +329,7 @@
             handleError(error)
             {
                 const err = JSON.parse(error.substr(error.indexOf("{")));
-                let msg = err.message;
+                this._namespaceRequestMessage = err.message;
                 const code = err.status ? err.status: 500;
                 this.$.content.setAttribute("elevation", 0);
 
@@ -336,18 +339,15 @@
                         page.redirect(`/user-login?r=${encodeURIComponent(a)}`);
                         break;
                     case 403:
-                        msg = "Access Denied! Please login using a credentials with the right permission.";
+                        this._namespaceRequestMessage = "Access Denied! Please login using a credentials with the right permission.";
                         break;
                     default:
-                        msg = msg === undefined ?
+                        this._namespaceRequestMessage = this._namespaceRequestMessage === undefined ?
                             "Something is terribly wrong! Please contact your admin.": msg;
                 }
-
-                let dle = new DirectoryLsError(msg, code);
+                const dle = new DirectoryLsError(this._namespaceRequestMessage, code);
                 this.$.content.appendChild(dle);
-
                 this.currentDirMetaData = {"fileName": this.currentDirName, "fileType": "DIR", "size" : 512};
-
                 Polymer.dom.flush();
                 this.updateStyles();
             }
@@ -760,7 +760,8 @@
             {
                 this.dispatchEvent(
                     new CustomEvent('dv-namespace-receive-children', {
-                        detail: {children: this.$.feList.items}, bubbles: true, composed: true}));
+                        detail: {message: this._namespaceRequestMessage,
+                            children: this.$.feList.items}, bubbles: true, composed: true}));
             }
         }
         window.customElements.define(ViewFile.is, ViewFile);


### PR DESCRIPTION
Motivation:

When a directory listing is requested and if an error ocurred
(this might be error due to client side or server side error),
this is usually display on the directory listing page. If a
user should open the file-metadata dashboard (either through
context menu or by clicking the file metadata button at the top
right corner of dcache-view page), a misleading information is
show, which doesn't reflect the error shown in the directory
listing page.

Modification:

Add a message to the data of the custom event object dispatched
(the event is called `dv-namespace-receive-children`) in view-file
element. This message is set based on the response of the server
regarding the request of currently viewed directory. This enable
file-metadata-dashboard element (which listen to this event) to
display appropriate information corresponding to currently viewed
directory.

Result:

Correct metadata information is shown.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Acked-by: Tigran Mkrtchyan

Reviewed at https://rb.dcache.org/r/11478/

(cherry picked from commit 83c2a3bcbc22307fd9e2800abc5210aa6d254160)