### PR TITLE
dcache-view (npm-package): add bower to list of dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1508,6 +1508,11 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.12.0.tgz",
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
     },
+    "bower": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.4.tgz",
+      "integrity": "sha1-54dqB23rgTf30GUl3F6MZtuC8oo="
+    },
     "boxen": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "author": "dCache Team <support@dcache.org>",
   "dependencies": {
+    "bower": "1.8.4",
     "del": "3.0.0",
     "gulp": "4.0.0",
     "merge-stream": "1.0.1",


### PR DESCRIPTION
Motivation:

For anybody to build dcache-view from scratch, this requires that
the user independently install maven and bower. Although the number
of dependencies needed by dcahe-view is more than those two but
these dependencies have been added to the one that will be instal-
led by npm. By using a maven plug-in, npm and node are installed
automatically and locally. Hence, making it easy to install any
third party dependency.

To install bower, this requires node and npm. Since bower is one
of the required dependencies for dcache-view and the maven plugin
already have node and npm running locally for the project, it is
not neccessary to install this bower independently.

Modification:

Add bower to the list of dependencies that will be required in the
package.json file.

Result:

Make dcache-view much more easy to build by reducing the amount of
independent dependencies required to only maven.

Target: master
Request: 1.5
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11485/

(cherry picked from commit b81ce89145c17d8e0cba242f0384eeac0625b8a5)