### PR TITLE
dcache-view (gulpfile): add missing webcomponents.js polyfills

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -16,7 +16,7 @@ const copyAllArray = [
     {"source" : "./target/elements/src/elements/elements.html", "destination": `${buildDirectory}/elements`},
     {"source" : "./src/scripts/**/*", "destination": `${buildDirectory}/scripts`, "exclude": ["./src/scripts/config.js"]},
     {"source" : "./src/bower_components/pdfjs-dist/build/**/*", "destination": `${buildDirectory}/bower_components/pdfjs-dist/build`},
-    {"source" : "./src/bower_components/webcomponentsjs/webcomponents-loader.js", "destination": `${buildDirectory}/bower_components/webcomponentsjs`}
+    {"source" : "./src/bower_components/webcomponentsjs/**/*", "destination": `${buildDirectory}/bower_components/webcomponentsjs`}
 ];
 
 function waitFor(stream) {


### PR DESCRIPTION
Modification:

Firefox and some other browsers failed to load dCache View because
of the missing polyfills.

Modification:

Copy all the content of webcomponentsjs into the build directory

Result:

Firefox and any other browsers that depends on webcomponents
polyfills now load.

Target: master
Request: 1.5
Request: 1.4
Require-notes: no
Require-book: no
Fixes: https://github.com/dCache/dcache-view/issues/157
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11495/

(cherry picked from commit 7af7d9100fd177450710dee2ad6313898d4b9537)