### PR TITLE
dcache-view (npm-package): upgrade bower to the latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1509,9 +1509,9 @@
       "integrity": "sha512-DYWGk01lDcxeS/K9IHPGWfT8PsJmbXRtRd2Sx72Tnb8pcYZQFF1oSDb8hJtS1vhp212q1Rzi5dUf9+nq0o9UIg=="
     },
     "bower": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.4.tgz",
-      "integrity": "sha1-54dqB23rgTf30GUl3F6MZtuC8oo="
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.8.tgz",
+      "integrity": "sha512-1SrJnXnkP9soITHptSO+ahx3QKp3cVzn8poI6ujqc5SeOkg5iqM1pK9H+DSc2OQ8SnO0jC/NG4Ur/UIwy7574A=="
     },
     "boxen": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "author": "dCache Team <support@dcache.org>",
   "dependencies": {
-    "bower": "1.8.4",
+    "bower": "1.8.8",
     "del": "3.0.0",
     "gulp": "4.0.0",
     "merge-stream": "1.0.1",


### PR DESCRIPTION
Motivtation:

npm report security vulnerabilities in bower version 1.8.4.

Modification:

Upgrade bower to 1.8.8, which is the latest released version

Result:

Fixed npm security vulnerabilities.

Target: master
Request: 1.5
Request: 1.4
Require-notes: no
Require-book: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11519/

(cherry picked from commit 0773a089cee542a50bc17e7c4cffc9ceb3fed8f2)