### PR TITLE
dcache-view: fix sorting on numerical fields converted to format with…

### DIFF
--- a/src/elements/dv-elements/admin/dialogs/pools-of-group-dialog.html
+++ b/src/elements/dv-elements/admin/dialogs/pools-of-group-dialog.html
@@ -421,7 +421,7 @@
                             <vaadin-grid-column width="150px">
                                 <template class="header">
                                 </template>
-                                <template>[[item.total]]</template>
+                                <template>[[item.total-text]]</template>
                             </vaadin-grid-column>
                         </vaadin-grid-column-group>
                         <vaadin-grid-column-group>
@@ -433,7 +433,7 @@
                             <vaadin-grid-column width="150px">
                                 <template class="header">
                                 </template>
-                                <template>[[item.free]]</template>
+                                <template>[[item.free-text]]</template>
                             </vaadin-grid-column>
                         </vaadin-grid-column-group>
                         <vaadin-grid-column-group>
@@ -445,7 +445,7 @@
                             <vaadin-grid-column width="150px">
                                 <template class="header">
                                 </template>
-                                <template>[[item.precious]]</template>
+                                <template>[[item.precious-text]]</template>
                             </vaadin-grid-column>
                         </vaadin-grid-column-group>
                         <vaadin-grid-column-group>
@@ -796,9 +796,6 @@
                         delete restore.maxActive;
 
                         const space = poolData.detailsData.costData.space;
-                        const total = this.convertBytesToNearestBinaryPrefix(space.total);
-                        const free = this.convertBytesToNearestBinaryPrefix(space.free);
-                        const precious = this.convertBytesToNearestBinaryPrefix(space.precious);
 
                         pool = {
                             'cell': poolData.cellData.cellName,
@@ -810,9 +807,12 @@
                             'version': poolData.cellData.version,
                             'mode': poolData.detailsData.poolMode,
                             'status': this._status(poolData.detailsData.poolMode),
-                            'total': total,
-                            'free': free,
-                            'precious': precious,
+                            'total': space.total,
+                            'total-text': this.convertBytesToNearestBinaryPrefix(space.total),
+                            'free': space.free,
+                            'free-text': this.convertBytesToNearestBinaryPrefix(space.free),
+                            'precious': space.precious,
+                            'precious-text': this.convertBytesToNearestBinaryPrefix(space.precious),
                             'movers': poolData.detailsData.costData.mover,
                             'stores': store,
                             'restores': restore,

--- a/src/elements/dv-elements/admin/views/pool-group-view.html
+++ b/src/elements/dv-elements/admin/views/pool-group-view.html
@@ -121,7 +121,7 @@
                     </template>
                     <vaadin-grid-column width="150px">
                         <template class="header"></template>
-                        <template>[[item.total]]</template>
+                        <template>[[item.total-text]]</template>
                     </vaadin-grid-column>
                 </vaadin-grid-column-group>
                 <vaadin-grid-column-group>
@@ -132,7 +132,7 @@
                     </template>
                     <vaadin-grid-column width="150px">
                         <template class="header"></template>
-                        <template>[[item.free]]</template>
+                        <template>[[item.free-text]]</template>
                     </vaadin-grid-column>
                 </vaadin-grid-column-group>
                 <vaadin-grid-column-group>
@@ -143,7 +143,7 @@
                     </template>
                     <vaadin-grid-column width="150px">
                         <template class="header"></template>
-                        <template>[[item.precious]]</template>
+                        <template>[[item.precious-text]]</template>
                     </vaadin-grid-column>
                 </vaadin-grid-column-group>
                 <vaadin-grid-column-group>
@@ -213,9 +213,12 @@
 
                 this.incoming.push({
                     'group': 'all-pools',
-                    'total': this.convertBytesToNearestBinaryPrefix(total),
-                    'precious': this.convertBytesToNearestBinaryPrefix(precious),
-                    'free': this.convertBytesToNearestBinaryPrefix(free),
+                    'total': total,
+                    'total-text': this.convertBytesToNearestBinaryPrefix(total),
+                    'precious': precious,
+                    'precious-text': this.convertBytesToNearestBinaryPrefix(precious),
+                    'free': free,
+                    'free-text': this.convertBytesToNearestBinaryPrefix(free),
                     'disk': {
                         'total': total,
                         'precious': precious,
@@ -269,23 +272,26 @@
                 if (!result.groupSpaceData || !this.isNumber(result.groupSpaceData.total)) {
                     this.incoming.push({
                         'group': group,
-                        'total': "0 bytes",
-                        'precious': "0 bytes",
-                        'free': "0 bytes",
+                        'total': 0,
+                        'total-text': this.convertBytesToNearestBinaryPrefix(0),
+                        'precious': 0,
+                        'precious-text': this.convertBytesToNearestBinaryPrefix(0),
+                        'free': 0,
+                        'free-text': this.convertBytesToNearestBinaryPrefix(0),
                         'disk': {
                             'total': 0, 'precious': 0,
                             'free': 0, 'removable': 0
                         }
                     });
                 } else {
-                    const total = this.convertBytesToNearestBinaryPrefix(result.groupSpaceData.total);
-                    const free = this.convertBytesToNearestBinaryPrefix(result.groupSpaceData.free);
-                    const precious = this.convertBytesToNearestBinaryPrefix(result.groupSpaceData.precious);
                     this.incoming.push({
                         'group': group,
-                        'total': total,
-                        'precious': precious,
-                        'free': free,
+                        'total': result.groupSpaceData.total,
+                        'total-text': this.convertBytesToNearestBinaryPrefix(result.groupSpaceData.total),
+                        'precious': result.groupSpaceData.precious,
+                        'precious-text': this.convertBytesToNearestBinaryPrefix(result.groupSpaceData.precious),
+                        'free': result.groupSpaceData.free,
+                        'free-text': this.convertBytesToNearestBinaryPrefix(result.groupSpaceData.free),
                         'disk': {
                             'total': result.groupSpaceData.total,
                             'precious': result.groupSpaceData.precious,

--- a/src/elements/dv-elements/admin/views/space-management-view.html
+++ b/src/elements/dv-elements/admin/views/space-management-view.html
@@ -253,7 +253,7 @@
                     </template>
                     <vaadin-grid-column width="50px">
                         <template class="header"></template>
-                        <template>[[item.availableSpace]]</template>
+                        <template>[[item.availableSpaceText]]</template>
                     </vaadin-grid-column>
                 </vaadin-grid-column-group>
                 <vaadin-grid-column-group>
@@ -264,7 +264,7 @@
                     </template>
                     <vaadin-grid-column width="50px">
                         <template class="header"></template>
-                        <template>[[item.reservedSpace]]</template>
+                        <template>[[item.reservedSpaceText]]</template>
                     </vaadin-grid-column>
                 </vaadin-grid-column-group>
                 <vaadin-grid-column-group>
@@ -275,7 +275,7 @@
                     </template>
                     <vaadin-grid-column width="50px">
                         <template class="header"></template>
-                        <template>[[item.totalSpace]]</template>
+                        <template>[[item.totalSpaceText]]</template>
                     </vaadin-grid-column>
                 </vaadin-grid-column-group>
             </vaadin-grid>
@@ -465,7 +465,7 @@
                     </template>
                     <vaadin-grid-column width="50px">
                         <template class="header"></template>
-                        <template>[[item.sizeInBytes]]</template>
+                        <template>[[item.sizeInBytesText]]</template>
                     </vaadin-grid-column>
                 </vaadin-grid-column-group>
                 <vaadin-grid-column-group>
@@ -476,7 +476,7 @@
                     </template>
                     <vaadin-grid-column width="50px">
                         <template class="header"></template>
-                        <template>[[item.usedSizeInBytes]]</template>
+                        <template>[[item.usedSizeInBytesText]]</template>
                     </vaadin-grid-column>
                 </vaadin-grid-column-group>
                 <vaadin-grid-column-group>
@@ -487,7 +487,7 @@
                     </template>
                     <vaadin-grid-column width="50px">
                         <template class="header"></template>
-                        <template>[[item.allocatedSpaceInBytes]]</template>
+                        <template>[[item.allocatedSpaceInBytesText]]</template>
                     </vaadin-grid-column>
                 </vaadin-grid-column-group>
                 <vaadin-grid-column-group>
@@ -769,9 +769,10 @@
             _handleLinkGroupResponse(groups) {
                 groups.forEach((g) => {
                     const total = g.availableSpace + g.reservedSpace;
-                    g.availableSpace = this.convertBytesToNearestBinaryPrefix(g.availableSpace);
-                    g.reservedSpace = this.convertBytesToNearestBinaryPrefix(g.reservedSpace);
-                    g.totalSpace = this.convertBytesToNearestBinaryPrefix(total);
+                    g.availableSpaceText = this.convertBytesToNearestBinaryPrefix(g.availableSpace);
+                    g.reservedSpaceText = this.convertBytesToNearestBinaryPrefix(g.reservedSpace);
+                    g.totalSpace = total;
+                    g.totalSpaceText = this.convertBytesToNearestBinaryPrefix(total);
 
                     g.allowed = '';
 
@@ -825,9 +826,9 @@
 
             _handleSpaceTokenResponse(tokens) {
                 tokens.forEach((t) => {
-                    t.sizeInBytes = this.convertBytesToNearestBinaryPrefix(t.sizeInBytes);
-                    t.usedSizeInBytes = this.convertBytesToNearestBinaryPrefix(t.usedSizeInBytes);
-                    t.allocatedSpaceInBytes = this.convertBytesToNearestBinaryPrefix(t.allocatedSpaceInBytes);
+                    t.sizeInBytesText = this.convertBytesToNearestBinaryPrefix(t.sizeInBytes);
+                    t.usedSizeInBytesText = this.convertBytesToNearestBinaryPrefix(t.usedSizeInBytes);
+                    t.allocatedSpaceInBytesText = this.convertBytesToNearestBinaryPrefix(t.allocatedSpaceInBytes);
                     if (t.expirationTime) {
                         t.expirationTime = this.convertDatestampToObject(t.expirationTime);
                     } else {


### PR DESCRIPTION
… byte size suffixes

Motivation:

Bug/Issue #170

Poolgroups list: sorting by size works alphabetically, should be numerically.

Modification:

Create a separate attribute for text; sort on the numerical value,
but display the text.

Result:

Correct sorting behavior.

Target: master
Bug: #170
Request: 1.5
Request: 1.4
Requires-notes: yes
Requires-book: no
Acked-by: Paul

See [here](CONTRIBUTING.md#Submitting-Pull-Requests) for how to summit a pull 
request and the sample template for the commit message.
