### PR TITLE
dcache-view (admim): fix issue with authentication for admin page

### DIFF
--- a/src/elements/dv-elements/admin/dv-admin-mixins.html
+++ b/src/elements/dv-elements/admin/dv-admin-mixins.html
@@ -218,9 +218,11 @@
              *  includes the role (Authorization).
              */
             getHeaders() {
+                const authParameter = sessionStorage.upauth !== undefined ?
+                    {"scheme": sessionStorage.authType, "value": sessionStorage.upauth} : undefined;
                 return {
                     'Content-Type': this.contentType,
-                    'Authorization': app.getAuthValue(),
+                    'Authorization': app.getAuthValue(authParameter),
                     'Suppress-WWW-Authenticate': "Suppress"
                 }
             }


### PR DESCRIPTION
Motivation:

The app.getAuthValue method that the admin uses to get the
authorization credential's value. This method was modified
to allow certificate usage but the admin mixin class was not
adjusted accordingly.

Modification:

Adjust the getHeaders method to use the app.getAuthValue
correctly.

Result:

Fix issue 169 and make Al happy.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Fixes: https://github.com/dCache/dcache-view/issues/169
Acked-by: ALbert Rossi
Acked-by: Lea Morschel

Reviewed at https://rb.dcache.org/r/11759/

(cherry picked from commit 23d399fe46d12826789a7012fe7c21b45f7aba0d)