### PR TITLE
dcache-view (webdav): improve webdav door selection

### DIFF
--- a/src/scripts/tasks/request-webdav-endpoints.js
+++ b/src/scripts/tasks/request-webdav-endpoints.js
@@ -13,7 +13,7 @@ self.addEventListener('message', function(e) {
             const write = [];
             const webdav = [];
             doors.forEach((door) => {
-                if (door.tags && door.tags.includes("dcache-view")) {
+                if (door.tags && door.tags.includes("dcache-view") && door.root === "/") {
                     webdav.push(door);
                 }
             });


### PR DESCRIPTION
Motivation:

dCache-view uses the dchahe restful api to get list of webdav
doors that can be use to read or write a file. This list is
sorted and ranked based on their availability. Unfornately,
the root of these doors are not never considered as criteria
and this can lead to writing a file into the wrong path.

Modification:

Add door root to selection criteria.

Result:

Read and write into the correct path.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Acked-by: Albert Rossi
Acked-by: Paul Millar
Acked-by: Lea Morschel

Reviewed at https://rb.dcache.org/r/11756/

(cherry picked from commit 7ba0b867fd23e4376be9079550c2b70fda48fe14)
