### PR TITLE
dcache-view (download): show useful error message

### DIFF
--- a/src/scripts/tasks/download-task.js
+++ b/src/scripts/tasks/download-task.js
@@ -14,13 +14,16 @@ self.addEventListener('message', function(e) {
     });
 
     fetch(request).then(file => {
-        switch (e.data.return) {
-            case 'json':
-                return file.json();
-            default:
-                return file.blob();
+        if (file.ok) {
+            return e.data.return === 'json' ? file.json() : file.blob();
+        }
+        if (file.status >= 400 && file.status < 500) {
+            throw new TypeError(`Request failed with response status code ${file.status}.`);
+        }
+        if (file.status >= 500) {
+            throw new Error(`Status code ${file.status} - dCache Internal Server Error. Please contact the admin.`);
         }
     }).then(data => {
         self.postMessage(data);
-    }).catch(err => {setTimeout(function(){throw error;});})
+    }).catch(error => {setTimeout(function(){throw error;});})
 }, false);


### PR DESCRIPTION
Motivation:

If an error occur when a user request to download a file,
the correct error message is not shown to the user.

Modification:

Check if the response for the request is succeful and if
not propagate the useful error message.

Result:

Show useful error messages are shown to the end user.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Fixes: https://github.com/dCache/dcache-view/issues/159
Acked-by: Lea Morschel

Reviewed at https://rb.dcache.org/r/11752/

(cherry picked from commit 5652a8d3f4915d4ccdebaccf258708e019ca5e8c)