### PR TITLE
dcache-view: increase display time of the notification message

### DIFF
--- a/src/elements/dv-elements/admin/dv-admin-mixins.html
+++ b/src/elements/dv-elements/admin/dv-admin-mixins.html
@@ -286,8 +286,8 @@
             }
 
             handleError(error) {
-                app.$.toast.text = error;
-                app.$.toast.show();
+                this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                    detail: {message: error}, bubbles: true, composed: true}));
             }
 
             /**

--- a/src/elements/dv-elements/admin/dv-vaadin-provider-decorator.html
+++ b/src/elements/dv-elements/admin/dv-vaadin-provider-decorator.html
@@ -232,8 +232,8 @@
                     this.currentOffset = -1;
                     this._notifyTableSizeChanged(this.currentItems.length);
                     this._notifyTimeoutReset();
-                    app.$.toast.text = error;
-                    app.$.toast.show();
+                    this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                        detail: {message: error}, bubbles: true, composed: true}));
                 });
             }
 

--- a/src/elements/routing.html
+++ b/src/elements/routing.html
@@ -205,8 +205,8 @@
                     sessionStorage.removeItem('nonce');
                     const searchParams = `"page":"${redirectInfoObj.page}","path":"${redirectInfoObj.path}"`;
                     page(`/user-login?r=${encodeURIComponent(searchParams)}`);
-                    app.$.toast.text = e.detail.message + " ";
-                    app.$.toast.show();
+                    this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                        detail: {message: e.detail.message}, bubbles: true, composed: true}));
                 });
 
                 userAuth.send("Bearer");
@@ -217,8 +217,8 @@
                 return;
             }
 
-            app.$.toast.text = `Can't find: ${url}. Redirected you to Home Page`;
-            app.$.toast.show();
+            this.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast', {
+                detail: {message: `Can't find: ${url}. Redirected you to Home Page`}, bubbles: true, composed: true}));
             page.redirect(app.baseUrl);
         });
 

--- a/src/index.html
+++ b/src/index.html
@@ -399,7 +399,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                 </paper-dialog>
 
                 <!-- HERE IS A CENTRAL TOAST -->
-                <paper-toast id="toast">
+                <paper-toast id="toast" duration="60000">
                     <paper-icon-button icon="close" title="close"
                                        class="toast-button" tabindex="0"
                                        onclick="app.$.toast.hide()"></paper-icon-button>

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -393,18 +393,14 @@
                 }
                 return file;
             }).then((file) => {
-                app.$.toast.text = ``;
                 if (i+1 === len) {
-                    app.$.toast.text = `Done. ${len} files moved from source path ${sourcePath} to ${destinationPath}. `;
-                    app.$.toast.show();
+                    openToast(`Done. ${len} files moved from source path ${sourcePath} to ${destinationPath}.`)
                 }
                 if (i+1 > len) {
-                    app.$.toast.text = `${file.fileName} moved from source path ${sourcePath} to ${destinationPath}. `;
-                    app.$.toast.show();
+                    openToast(`${file.fileName} moved from source path ${sourcePath} to ${destinationPath}.`);
                 }
             }).catch((err)=>{
-                app.$.toast.text = err.toString();
-                app.$.toast.show();
+                openToast(err.toString());
             });
             namespace.mv({
                 url: "/api/v1/namespace",
@@ -455,7 +451,11 @@
         }
         return url;
     }
-
+    function openToast(message) {
+        app.$.toast.close();
+        app.$.toast.text = `${message} `;
+        app.$.toast.show()
+    }
     function updateFeListAndMetaDataDrawer(status, itemIndex)
     {
         if (app.$.metadata.selected === 'drawer') {
@@ -480,21 +480,19 @@
                 switch (e.data.status) {
                     case "successful":
                         updateFeListAndMetaDataDrawer(e.data.file.currentQos, event.detail.options.itemIndex);
-                        app.$.toast.text = "Transition complete! ";
+                        openToast("Transition complete!");
                         break;
                     case "error":
                         updateFeListAndMetaDataDrawer(event.detail.options.currentQos, event.detail.options.itemIndex);
-                        app.$.toast.text = "Transition terminated. ";
+                        openToast("Transition terminated!");
                         break;
                 }
                 qosWorker.terminate();
-                app.$.toast.show();
             }, false);
 
             qosWorker.addEventListener('error', function(e) {
                 console.info(e);
-                app.$.toast.text = e.message + " ";
-                app.$.toast.show();
+                openToast(e.message);
                 qosWorker.terminate()
             }, false);
 
@@ -618,8 +616,7 @@
             }, false);
             worker.addEventListener('error', (err)=> {
                 worker.terminate();
-                app.$.toast.text = `${err.message} `;
-                app.$.toast.show()
+                openToast(`${err.message}`);
             }, false);
             worker.postMessage({
                 'url' : fileURL,
@@ -695,8 +692,7 @@
         app.$.uploadToast.querySelector("#uploadList").appendChild(child);
     });
     window.addEventListener('dv-namespace-show-message-toast', (e) => {
-        app.$.toast.text = `${e.detail.message} `;
-        app.$.toast.show()
+        openToast(`${e.detail.message}`);
     });
     window.addEventListener('dv-namespace-ls-path', (e) => {
         if (app.route !== "home") page("/");


### PR DESCRIPTION
Motivation:

When the notification message is displayed it is shown for
a very short time and at times the user were not able to
read the message before it is close.

Modification:

- increase the display time for the toast
- create a function that close the current displayed toast
    before showing a new one.
- centralise how the toast is open by relying on
    dispatchEvent which make dcache-view behaviour consistent

Result:

display notification message for a longer period of time.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Acked-by: Paul Millar
Acked-by: Albert Rossi
Acked-by: Lea Morschel

Reviewed at https://rb.dcache.org/r/11792/

(cherry picked from commit 5915f9f29dfcbf23d078782a6a5c8ca69726a69b)