### PR TITLE
dcache-view (webdav): re-request webdav door information

### DIFF
--- a/src/scripts/discover-webdav-doors.js
+++ b/src/scripts/discover-webdav-doors.js
@@ -10,8 +10,19 @@ webdavWorker.addEventListener('error', function(e) {
     webdavWorker.terminate()
 }, false);
 
+const getAuthValue = function (){
+    if (!!sessionStorage.getItem("hasAuthClientCertificate")) {
+        return "";
+    }
+    if (sessionStorage.upauth !== undefined) {
+        return `${sessionStorage.authType} ${sessionStorage.upauth}`;
+    }
+    return "";
+};
 webdavWorker.postMessage({
     "apiEndpoint": `${window.CONFIG["dcache-view.endpoints.webapi"]}`,
+    "auth": getAuthValue(),
     "protocol":
-        `${window.location.protocol.endsWith(":") ? window.location.protocol.slice(0, -1): window.location.protocol}`
+        `${window.location.protocol.endsWith(":") ?
+            window.location.protocol.slice(0, -1): window.location.protocol}`
 });

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -678,6 +678,27 @@
         app.notifyPath('config.isSomebody');
         app.notifyPath('config.isAdmin');
         app.getQosInformation();
+        if (window.CONFIG['webdav'] === undefined) {
+            const webdavWorker = new Worker('scripts/tasks/request-webdav-endpoints.js');
+
+            webdavWorker.addEventListener('message', function(e) {
+                window.CONFIG["webdav"] = e.data;
+                webdavWorker.terminate();
+            }, false);
+
+            webdavWorker.addEventListener('error', function(e) {
+                console.info(e);
+                webdavWorker.terminate()
+            }, false);
+
+            webdavWorker.postMessage({
+                "apiEndpoint": `${window.CONFIG["dcache-view.endpoints.webapi"]}`,
+                "auth": app.getAuthValue(),
+                "protocol":
+                    `${window.location.protocol.endsWith(":") ?
+                        window.location.protocol.slice(0, -1): window.location.protocol}`
+            });
+        }
     });
     window.addEventListener('dv-namespace-open-upload-toast', (e) => {
         app.$.uploadToast.close();

--- a/src/scripts/tasks/request-webdav-endpoints.js
+++ b/src/scripts/tasks/request-webdav-endpoints.js
@@ -1,7 +1,14 @@
 self.addEventListener('message', function(e) {
     const endpoint = e.data.apiEndpoint.endsWith("/") ? e.data.apiEndpoint : `${e.data.apiEndpoint}/`;
-    fetch(`${endpoint}doors`, {headers: {"accept": "application/json",
-            "suppress-www-authenticate": "Suppress"}})
+    const header = new Headers({
+        "accept": "application/json",
+        "content-type": "application/json",
+        "suppress-www-authenticate": "Suppress"
+    });
+    if (e.data.auth && e.data.auth !== "") {
+        header.append('Authorization', e.data.auth);
+    }
+    fetch(`${endpoint}doors`, {headers: header})
         .then((response) => {
             if (!(response.status >= 200 && response.status < 300)) {
                 throw new Error("Network problem.");


### PR DESCRIPTION
Motivation:

When a site does not allow anonymous operation, all information
through the restful api including the ones that doesn't need to
be protect will not be available, (e.g. webdav door api) if the
user does not supply a known credentials.

Modification:

- include authentication header to the webdav door information
request (if authentication credentials are available).
- after successfully authentication, check if it is neccessary
to make request for webdav door info.

Result:

Webdav door information will be requested again after a successful
authentication provided this request failed initially during page
load.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/11863/

(cherry picked from commit d63973f5e17c227b6994e24f3f9e5dd9c4c32fe4)