### PR TITLE
dcache-view (authentication): prevent browser login pop-up

### DIFF
--- a/src/scripts/tasks/authentication-task.js
+++ b/src/scripts/tasks/authentication-task.js
@@ -1,4 +1,8 @@
-fetch('/api/v1/user')
+fetch('/api/v1/user', {
+    headers: {
+        "Suppress-WWW-Authenticate": "Suppress",
+        "Accept": "Application/json"
+    }})
     .then(function(response) {
         if (response.status !== 200) {
             throw new Error(`Looks like there was a problem. Status Code: ${response.status}`);
@@ -11,5 +15,5 @@ fetch('/api/v1/user')
         }
     })
     .catch(function (err) {
-        throw new Error(err.message);
+        setTimeout(function(){throw new Error(err.message);});
     });


### PR DESCRIPTION
Motivation:

When user status is requested in other to determined whether the
user is a known user or not and if the request to doesn't include
the header to supress www-authenticate header; this will return a
401 response with www-authenticate included in the header. This
might cause the browser to show a login pop-up which dcache-view
doesn't use. And if the user use this login pop-up, this causes dv
to misbehave, as reported here:
https://github.com/dCache/dcache-view/issues/183.

Modification:

Add the custom header to the request to supress www-authenticate
header

Result:

Prevent browser login pop-up to show when user status is requested.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Acked-by: Albert Rossi
Fixes: https://github.com/dCache/dcache-view/issues/183

Reviewed at https://rb.dcache.org/r/11864/

(cherry picked from commit 3da32602f406a2d99dbe52a614d06c2d91843aed)