### PR TITLE
dcache-view (rename): allow cert user to perform rename

### DIFF
--- a/src/elements/dv-elements/rename-input/rename-input.html
+++ b/src/elements/dv-elements/rename-input/rename-input.html
@@ -30,7 +30,7 @@
                 this._previousValue = file.fileMetaData.fileName;
                 this._pnfsId = file.fileMetaData.pnfsId;
                 this.value = file.fileMetaData.fileName;
-                if (auth) {
+                if (auth === "" || auth) {
                     this.auth = auth;
                 }
             }


### PR DESCRIPTION
Motivation:

When a user uses a certificate for authentication and
authourisation; rename operation is unsuccessful because
the auth value of the rename element is never set.

Modification:

Set the auth value for the rename element when the user
uses certificate.

Result:

Users with certificate can now perform rename operation

Target: master
Request: 1.5
Requires-notes: no
Requires-book: no
Acked-by: Albert Rossi

Reviewed at https://rb.dcache.org/r/11910/

(cherry picked from commit 4db44c7090771bd86b88f71d025adb2458f21593)