### PR TITLE
dcache-view (admim): fix persistence authentication issue

### DIFF
--- a/src/elements/dv-elements/admin/dv-admin-mixins.html
+++ b/src/elements/dv-elements/admin/dv-admin-mixins.html
@@ -405,8 +405,10 @@
              * Common to all RESTful admin service calls.
              */
             setXHRHeaders(xhr) {
+                const authParameter = sessionStorage.upauth !== undefined ?
+                    {"scheme": sessionStorage.authType, "value": sessionStorage.upauth} : undefined;
                 xhr.setRequestHeader('Content-Type', this.contentType);
-                xhr.setRequestHeader('Authorization', app.getAuthValue());
+                xhr.setRequestHeader('Authorization', app.getAuthValue(authParameter));
                 xhr.setRequestHeader('Suppress-WWW-Authenticate', "Suppress");
             }
 


### PR DESCRIPTION
Motivation:

The app.getAuthValue method that the admin uses to get the
authorization credential's value. This method was modified
to allow certificate usage but one method in the admin mixin
class was not adjusted appropriately.

Modification:

Adjust the setXHRHeaders method to use the app.getAuthValue
correctly.

Result:

Fix issue 169 hopefull for the last time and make Al happy.

Target: master
Request: 1.5
Require-notes: no
Require-book: no
Fixes: https://github.com/dCache/dcache-view/issues/169
Acked-by: ALbert Rossi
Acked-by: Lea Morschel

Reviewed at https://rb.dcache.org/r/11947/

(cherry picked from commit 141c754057f3cbc90923f8890243b91051ef8d7e)