### PR TITLE
dcache-view: fix the drop-down qos transition choices

### DIFF
--- a/src/elements/dv-elements/contextual-content/change-qos-context-menu.html
+++ b/src/elements/dv-elements/contextual-content/change-qos-context-menu.html
@@ -141,16 +141,10 @@
                 } else {
                     for (let i=0; i<window.CONFIG.qos.length; i++) {
                         if (window.CONFIG.qos[i].backendCapability.name === currentQos) {
-                            if (window.CONFIG.qos[i].backendCapability.transition.length > 0) {
-                                for (let j=0; j < window.CONFIG.qos[i].backendCapability.transition.length; j++) {
-                                    return window.CONFIG.qos[i].backendCapability.transition[j] !== buttonName;
-                                }
-                            } else {
-                                return true;
-                            }
-                            break;
+                            return !window.CONFIG.qos[i].backendCapability.transition.includes(buttonName);
                         }
                     }
+                    return true;
                 }
             }
         }

--- a/src/elements/dv-elements/list-view/list-row.html
+++ b/src/elements/dv-elements/list-view/list-row.html
@@ -293,6 +293,9 @@
                     case "disk+tape":
                         this.qosValue = "Disk & Tape";
                         break;
+                    case "volatile":
+                        this.qosValue = "Volatile";
+                        break;
                     default:
                         this.qosValue = "unavailable";
                 }


### PR DESCRIPTION
Motivation:

A small bug in the way the drop-down choices
for possible transitions are activated.

Modification:

Instead of short-circuiting the 'true' return
value so that it returns true if the
first item in the list does not match, one should
return false if a match is found, and true
only if it has iterated through all without
a match.  Since that is essentially
the 'contains' loop, we have used the built-in
javascript Array.includes.

Also added 'Volatile' to the QoS choices for
the list-row qosValue.

Result:

Correct logic.

Target: master
Request: 1.5
Requires-notes: yes
Requires-book: no
Acked-by: Paul
Acked-by: Lea