### PR TITLE
dcache-view (download and upload): fix issue with certifcate

### DIFF
--- a/src/elements/dv-elements/utils/dcache-view-uploader/dcache-view-uploader.js
+++ b/src/elements/dv-elements/utils/dcache-view-uploader/dcache-view-uploader.js
@@ -47,6 +47,7 @@ UploadHandler.prototype.upload = function()
     const content = this.file;
     const xhr = new XMLHttpRequest();
     xhr.open(this.httpMethod, this.url, true);
+    xhr.withCredentials = true;
     xhr.setRequestHeader('Content-Type', this.contentType);
     if (this.upauth && this.upauth !=="") {
         xhr.setRequestHeader('Authorization', this.upauth);

--- a/src/scripts/tasks/download-task.js
+++ b/src/scripts/tasks/download-task.js
@@ -10,7 +10,8 @@ self.addEventListener('message', function(e) {
     const request = new Request(e.data.url, {
         headers: headers,
         mode: "cors",
-        redirect: "follow"
+        redirect: "follow",
+        credentials: "include"
     });
 
     fetch(request).then(file => {


### PR DESCRIPTION
Motivation:

User's certificate are not forwarded to webdav door
because we didn't specifically tell the browser to
do so.

Modification:

Allow request to be send with neccessary credential.

Result:

Certificate are now forwarded with the request hence,
user with certificate can now download and upload.

Target: master
Request: 1.5
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar
Fixes: https://github.com/dCache/dcache-view/issues/209

Reviewed at https://rb.dcache.org/r/12137/

(cherry picked from commit c5ea6a8ae8d1734ac9ca806b878576abc923a992)