### PR TITLE
dcache-view (file-sharing): fix issue 189 and dcache/5036

### DIFF
--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -84,7 +84,8 @@
                                   class$="[[_computedClass(selected,item.pnfsId)]]"
                                   x-selected$="[[__computedXselected(item.xSelected)]]"
                                   file-meta-data="{{item}}" parent-path="[[parent]]"
-                                  draggable="[[_computedDraggable(item.xSelected)]]"></list-row>
+                                  draggable="[[_computedDraggable(item.xSelected)]]"
+                                  authentication-parameters="[[authenticationParameters]]"></list-row>
                     </div>
                 </template>
             </iron-list>

--- a/src/elements/routing.html
+++ b/src/elements/routing.html
@@ -135,6 +135,7 @@
         });
 
         page('/shared-link', function (dt) {
+            app.route = 'shared-link';
             if (dt.querystring) {
                 const arr = dt.querystring.split('&');
                 if (arr.length === 0 || !dt.querystring.includes("m=")) {

--- a/src/index.html
+++ b/src/index.html
@@ -242,7 +242,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                         </paper-item>
                                     </template>
                                     <paper-item>
-                                        <a data-route="home" href$="{{baseUrl}}">
+                                        <a data-route="home" on-tap="namespaceView">
                                             <paper-fab icon="device:storage"
                                                        title="Namespace view" class="blue" mini></paper-fab>
                                         </a>
@@ -294,11 +294,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                                         <list-row-header slot="top"></list-row-header>
                                                     </paper-toolbar>
                                                     <div class="fit" id="homedir" style="padding: 0 30px;"
-                                                         on-contextmenu="currentDirContext" on-drop="drop"
-                                                         on-dragenter="dragenter" on-dragleave="dragleave"
-                                                         on-dragend="dragend" on-dragexit="dragexit" on-click="click">
-                                                        <view-file id="homeDir"></view-file>
-                                                    </div>
+                                                         on-contextmenu="currentDirContext"
+                                                         on-drop="drop" on-dragenter="dragenter"
+                                                         on-dragleave="dragleave" on-dragend="dragend"
+                                                         on-dragexit="dragexit" on-click="click"></div>
                                                 </paper-header-panel>
                                             </section>
 

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -18,6 +18,16 @@
     window.addEventListener('WebComponentsReady', function() {
         // imports are loaded and elements have been registered
         app.getQosInformation();
+        if (app.route === "home" || !(app.route)) {
+            const currentVF = app.$["homedir"].querySelector('view-file');
+            if (!!currentVF) {
+                const parent = currentVF.parentNode;
+                parent.removeChild(currentVF);
+            }
+            const newVF = new ViewFile("/");
+            app.$["homedir"].appendChild(newVF);
+            newVF.__listDirectory();
+        }
     });
 
     app.getQosInformation = function()
@@ -60,6 +70,16 @@
         }
         parent.appendChild(newVF);
         newVF.__listDirectory();
+    };
+
+    app.namespaceView = function () {
+        page("/");
+        const currentVF = app.$["homedir"].querySelector('view-file');
+        if (!currentVF) {
+            const newVF = new ViewFile("/");
+            app.$["homedir"].appendChild(newVF);
+            newVF.__listDirectory();
+        }
     };
 
     app.lsHomeDir = function()


### PR DESCRIPTION
Motivation:

File sharing in dcache-view have some few issues, like the shared file
cannot be download and to upload into a shared directory result in 401
http status code. Also, it was reported that when share link is use,
the user is redirected to the login page when the site forbid anonymous
operation.

Modification:

- propagate the authentication value to the list-row element; this
    ensure that user can download and upload with the shared macaroon.
- set the value for the page route for the share-link
- remove the view-file tag from the index.html and create and append it
    programmatically provided the user is in the "home" route.

Result:

User can now view, upload and download file. Also the share link is
now working without redirecting the user.

Target: master
Request: 1.5
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar
Fixes: https://github.com/dCache/dcache-view/issues/189
Fixes: https://github.com/dCache/dcache/issues/5036

Reviewed at https://rb.dcache.org/r/12139/

(cherry picked from commit 2b2ec66dccd5ba44ffb697c4ee368f6457e33255)
