### PR TITLE
dcache-view (file-sharing): fix issue 189 and dcache/5036 (part 2)

### DIFF
--- a/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
+++ b/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
@@ -369,7 +369,7 @@
                 let noOfMovedItems = 1;
                 let fileType = "item";
                 const mv = document.createElement('move-file');
-                mv.auth = app.getAuthValue();
+                mv.auth = this.getAuthValue();
                 mv.currentPath = this.currentPath;
 
                 if (this.multipleSelection) {
@@ -441,7 +441,7 @@
                 const fullPath = this.currentPath.endsWith('/') ?
                     `${this.currentPath}${file.fileName}`: `${this.currentPath}/${file.fileName}`;
                 const namespace = document.createElement('dcache-namespace');
-                namespace.auth = app.getAuthValue();
+                namespace.auth = this.getAuthValue();
                 namespace.promise.then(()=>{
                     this.dispatchEvent(new CustomEvent('dv-namespace-remove-items', {
                         detail: {files: [file]},bubbles: true, composed: true
@@ -472,7 +472,7 @@
                 mkdir.header = false;
                 mkdir.addEventListener('create',(e) => {
                     const namespace = document.createElement('dcache-namespace');
-                    namespace.auth = app.getAuthValue();
+                    namespace.auth = this.getAuthValue();
 
                     namespace.promise.then(() => {
                         this.dispatchEvent(


### PR DESCRIPTION
Motivation:

See https://rb.dcache.org/r/12139/

Modification:

- use the elememt authentication value.

Result:

User can now delete, create new directory and move
file using the context menu without running into
401 (Unauthorized).

Target: master
Request: 1.5
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar
Fixes: https://github.com/dCache/dcache-view/issues/189
Fixes: https://github.com/dCache/dcache/issues/5036

Reviewed at https://rb.dcache.org/r/12166/

(cherry picked from commit 42451b500f36bb9213a37c6e3d40abe4191521c5)
