### PR TITLE
dcache-view (dv.js): use findViewFile method

### DIFF
--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -381,7 +381,7 @@
 
     app.dragNdropMoveFiles = function (destinationPath, dropFlag)
     {
-        const currentViewPath = app.$.homedir.querySelector('view-file').path;
+        const currentViewPath = findViewFile().path;
         const sourcePath = ((app.mvObj.source).length > 1  && (app.mvObj.source).endsWith("/")) ?
             (app.mvObj.source).slice(0, -1) : app.mvObj.source;
 
@@ -485,7 +485,7 @@
                 status.constructor === Array ? `in transition to ${status[0]}` : status ;
         }
         //FIXME: use event
-        const vf = app.$.homedir.querySelector('view-file');
+        const vf = findViewFile();
         vf.shadowRoot.querySelector('#feList')
             .set(`items.${itemIndex}.currentQos`, status);
         vf.shadowRoot.querySelector('#feList').notifyPath(`items.${itemIndex}.currentQos`);
@@ -553,7 +553,7 @@
     });
 
     window.addEventListener('iron-overlay-canceled', ()=> {
-        const vf = app.$.homedir.querySelector('view-file');
+        const vf = findViewFile();
         vf.$.feList.selectionEnabled = false;
         setTimeout(() => {
             vf.$.feList.selectionEnabled = true;


### PR DESCRIPTION
Motivation:

Intially, view-file element is used in just one route but
since introduction of file-sharing section, this has no
been the case. We have a method called `findViewFile` which
main task is to find view-file element in the current
route that the user is viewing.

Noticeable errors was observed because of the fact that
view-file element was searched for in a different route
than the currently viewed one.

Modification:

Use `findViewFile` method in all obvious part of the code.

Result:

Reduce `Uncaught TypeError` due to undefined value.

Target: master
Request: 1.5
Requires-notes: no
Requires-book: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/12171/

(cherry picked from commit e7c69af7150c494c360f56b34d2666417994bf71)