### PR TITLE
dcache-view (shared-file): fix minor issue with drag and drop

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -304,7 +304,10 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
                                             <section data-route="shared-files"
                                                      class="fit" style="background-color:#ececec;">
                                                 <shared-files-page id="shared-with-me" on-click="click"
-                                                                   on-contextmenu="currentDirContext"></shared-files-page>
+                                                                   on-contextmenu="currentDirContext"
+                                                                   on-drop="drop" on-dragenter="dragenter"
+                                                                   on-dragleave="dragleave" on-dragend="dragend"
+                                                                   on-dragexit="dragexit"></shared-files-page>
                                             </section>
 
                                             <section data-route="admin" class="fit"

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -381,7 +381,8 @@
 
     app.dragNdropMoveFiles = function (destinationPath, dropFlag)
     {
-        const currentViewPath = findViewFile().path;
+        const vf = findViewFile();
+        const currentViewPath = vf.path;
         const sourcePath = ((app.mvObj.source).length > 1  && (app.mvObj.source).endsWith("/")) ?
             (app.mvObj.source).slice(0, -1) : app.mvObj.source;
 
@@ -389,10 +390,15 @@
         if (sourcePath === destinationPath) {
             return;
         }
+
+        let auth;
+        if (vf.authenticationParameters !== undefined) {
+            auth = vf.authenticationParameters;
+        }
         const len = app.mvObj.files.length;
         app.mvObj.files.forEach((file, i) => {
             let namespace = document.createElement('dcache-namespace');
-            namespace.auth = app.getAuthValue();
+            namespace.auth = app.getAuthValue(auth);
             namespace.promise.then( () => {
                 if (currentViewPath === sourcePath) {
                     window.dispatchEvent(new CustomEvent('dv-namespace-remove-items', {


### PR DESCRIPTION
Motivation:

Dnd in shared-files route is not working as expected
because the macaroon value is passed along and the
dnd listeners are not registered.

Modification:

- ensure that the macaroon auth value is propagated.
- add dnd event listners to shared-files route

Result:

Issue with dnd in the shared-files route is fixed and
it now work as expected.

Target: master
Request: 1.5
Requires-notes: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/12172/

(cherry picked from commit 2d89b848f7b140660f5a6fc743a49369888ed736)