### PR TITLE
dcache-view (dv.js): fix TypeError issue

### DIFF
--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -58,8 +58,19 @@
     app.ls = function(path, auth)
     {
         const currentVF = findViewFile();
-        const parent = currentVF.parentNode;
-        parent.removeChild(currentVF);
+        let parent;
+        if (currentVF) {
+            parent = currentVF.parentNode;
+            parent.removeChild(currentVF);
+        } else {
+            if (app.route === "home") {
+                parent = app.$["homedir"];
+            }
+            if (app.route === "shared-file") {
+                parent = app.$["shared-with-me"].$["shared-directory-view"].$["container"];
+            }
+        }
+
         const newVF = new ViewFile(path);
         if (auth) {
             newVF.authenticationParameters = auth;


### PR DESCRIPTION
Motivation:

When listing the content of a directory, the element
responsible for file listing is created dynamically
and appended to the right parent. The parent node
depends on whether the route is home or shared-file.

Previously, the method responsible for dir listing,
will just search for the view-file in the current view.
This is then removed and new one is append based on
the new path. Unfortunately, the search can return null
hence resulting to TypeError.

Modification:

If the view-file search return null, use a different
strategy for finding the parent node.

Result:

Avoid TypeError

Target: master
Request: 1.5
Requires-notes: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/12179/

(cherry picked from commit e520768297a9f73d6f5f494c64a350a42900a5f9)