### PR TITLE
dcache-view (view-file): fix issue 215

### DIFF
--- a/src/elements/dv-elements/directory-ls-message/directory-ls-error.html
+++ b/src/elements/dv-elements/directory-ls-message/directory-ls-error.html
@@ -6,8 +6,8 @@
     <template>
         <style>
             main {
-                height: 200px;
-                width: 70%;
+                height: 300px;
+                width: 75%;
                 margin: 0 auto;
                 padding: 20px;
                 display: flex;
@@ -24,25 +24,44 @@
                 padding: 20px;
                 text-align: center;
             }
+            .warning-icon {
+                color: #f50303;
+                height:4em;
+                width:4em;
+            }
+            h3 {
+                font-size: 1.2em;
+                font-weight: 300;
+                line-height: 24px;
+            }
+            .loginBtn {
+                color: #f50303;
+                border: 1px solid #f50303;
+            }
         </style>
         <main id="main">
             <div>
                 <iron-icon icon="icons:warning"
-                           style="color: #f50303; height:4em; width:4em;">
-                </iron-icon>
-                <p>{{code}}</p>
-                <h3>{{message}}</h3>
+                           class="warning-icon"></iron-icon>
+                <p>[[code]]</p>
+                <h3>[[message]]</h3>
+                <template is="dom-if" if="[[showLoginBtn]]">
+                    <paper-button class="loginBtn"
+                                  on-click="_login">Login</paper-button>
+                </template>
             </div>
         </main>
     </template>
     <script>
         class DirectoryLsError extends Polymer.Element
         {
-            constructor(message, code)
+            constructor(message, code, path)
             {
                 super();
                 this.code = code;
                 this.message = message;
+                if (path) this.path = path;
+                this.showLoginBtn = (page.current === "/" || page.current.startsWith("/?")) && code === 401;
             }
 
             static get is()
@@ -57,12 +76,15 @@
                         type: String,
                         notify:true
                     },
-
+                    path: {
+                        type: String,
+                        notify: true
+                    },
                     code: {
                         type: String,
                         notify:true
                     },
-                    showLoginForm: {
+                    showLoginBtn: {
                         type: Boolean,
                         notify: true
                     }
@@ -72,9 +94,9 @@
             connectedCallback()
             {
                 super.connectedCallback();
-                const content = (app.$.homedir.querySelector('view-file')).$.content;
-                if (this.parentNode === content) {
-                    app.$.listTableHeader.querySelector('list-row-header').classList.add('hidden');
+                if (app.$["listTableHeader"]) {
+                    const lrh = app.$["listTableHeader"].querySelector("list-row-header");
+                    if (lrh) lrh.classList.add('hidden');
                 }
                 this.$.main.addEventListener('contextmenu', (e)=>{this._openContextMenu(e)});
             }
@@ -82,10 +104,20 @@
             disconnectedCallback()
             {
                 super.disconnectedCallback();
-                setTimeout(()=>{
-                    const content = (app.$.homedir.querySelector('view-file')).$.content;
-                    if (this.parentNode.id === content.id) {
-                        app.$.listTableHeader.querySelector('list-row-header').classList.remove('hidden');
+                setTimeout(() => {
+                    /**
+                     * FIXME: Since view-file is used in two different routes -
+                     * a further issue still needs to be addressed which this c
+                     * ode below does not cover
+                     * TODO: the findViewFile function in dv.js should be made available
+                     * for use here.
+                     */
+                    const vf = app.$["homedir"].querySelector('view-file');
+                    if (vf) {
+                        if (this.parentNode.id === vf.$["content"].id && app.$["listTableHeader"]) {
+                            const lrh = app.$["listTableHeader"].querySelector("list-row-header");
+                            if (lrh && lrh.classList.contains("hidden")) lrh.classList.remove('hidden');
+                        }
                     }
                 },10);
                 this.$.main.removeEventListener('contextmenu', (e)=>{this._openContextMenu(e)});
@@ -108,6 +140,11 @@
                     screenX: event.screenX,
                     screenY: event.screenY
                 }));
+            }
+            _login()
+            {
+                const a = `"page":"home","path":"${this.path}"`;
+                page.redirect(`/user-login?r=${encodeURIComponent(a)}`);
             }
         }
         window.customElements.define(DirectoryLsError.is, DirectoryLsError);

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -330,6 +330,25 @@
 
                 switch (parseInt(code)) {
                     case 401:
+                        if (window.CONFIG.isSomebody || !!sessionStorage.upauth) {
+                            //something is wrong with the credential
+                            const x = page.current;
+                            if (x === "/" || x.startsWith("/?")) {
+                                this._namespaceRequestMessage = "Please login again - your credential is no longer valid.";
+                                window.CONFIG.isSomebody = false;
+                                break;
+                            }
+                            if (x.startsWith("/shared-files")) {
+                                this._namespaceRequestMessage = "Something is wrong with the sharing credential " +
+                                    "you are using to view this file. Most likely this credential has expired. " +
+                                    "Request for a new one.";
+                                const macaroonList = sessionStorage.getItem("macaroonList");
+                                const macaroonArray = macaroonList.split(" ");
+                                macaroonArray.filter(macaroon => macaroon !== this.authenticationParameters.value).join(" ");
+                                this.authenticationParameters = {};
+                                break;
+                            }
+                        }
                         const a = `"page":"home","path":"${this.path}"`;
                         page.redirect(`/user-login?r=${encodeURIComponent(a)}`);
                         break;
@@ -340,7 +359,7 @@
                         this._namespaceRequestMessage = this._namespaceRequestMessage === undefined ?
                             "Something is terribly wrong! Please contact your admin.": msg;
                 }
-                const dle = new DirectoryLsError(this._namespaceRequestMessage, code);
+                const dle = new DirectoryLsError(this._namespaceRequestMessage, code, this.path);
                 this.$.content.appendChild(dle);
                 this.currentDirMetaData = {"fileName": this.currentDirName, "fileType": "DIR", "size" : 512};
                 Polymer.dom.flush();


### PR DESCRIPTION
Motivation:

https://github.com/dCache/dcache-view/issues/215

Modification:

- view-file:
    differentiate between the possible causes of the 401.
- directory-ls-error:
    redesign to allow user to login if they hit 401,
    especially when it cause by expired or invalid
    credential.

Result:

Issue #215 fixed.

Target: master
Request: 1.5
Requires-notes: no
Acked-by: Albert Rossi
Fixes: https://github.com/dCache/dcache-view/issues/215

Reviewed at https://rb.dcache.org/r/12180/

(cherry picked from commit 1ae4f00156ef0cab0bfb6424bf0ce4c79c6e65d5)