### PR TITLE
Add support for OIDC names and Client-IDs with spaces

### DIFF
--- a/src/elements/dv-elements/user-authentication/forms/loginform-with-openid.html
+++ b/src/elements/dv-elements/user-authentication/forms/loginform-with-openid.html
@@ -235,7 +235,7 @@
                 const len = a.length;
                 let jsonArray = [];
                 for (let i=0; i<len; i++) {
-                    jsonArray.push({"name": `${a[i]}`, "id": `${b[i]}`, "endpoint": `${c[i]}`});
+                    jsonArray.push({"name": `${decodeURIComponent(a[i])}`, "id": `${decodeURIComponent(b[i])}`, "endpoint": `${c[i]}`});
                 }
                 this.openIDProviders = jsonArray;
             }


### PR DESCRIPTION
Motivation:

Identifiers (either for humans or for the OP) may have spaces.  This is
currently not supported, as the corresponding configuration options are a
space-separated list of IDs.

Modification:

Support URL/percent encoded items.  This brings no changes for most
characters in an identifier.  The exception is the '%' symbol, which
MUST be encoded as "%25".  I believe this character is very rare in
OP names and Client IDs.

Result:

The admin may now include spaces in the OP name or in the client ID.

Target: master
Request: 1.6
Request: 1.5
Patch: https://rb.dcache.org/r/12197/
Acked-by: Olufemi Adeyemi
