### PR TITLE
dcache-view (file-sharing): fix macaroon generation

### DIFF
--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-file-generation.js
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-file-generation.js
@@ -53,7 +53,7 @@ class ShareableFileGeneration extends DcacheViewMixins.Commons(Polymer.Element)
             this._handleResponse(e)
         }, false);
         shareableLinkWorker.postMessage({
-            "url": this.getFileWebDavUrl(this.fullPath, "read")[0],
+            "url": this.getFileWebDavUrl("/", "read")[0],
             "body": {
                 "caveats": event.detail.activitiesList.length > 0 ?
                     [`path:${this.fullPath}`, `activity: ${event.detail.activitiesList.join()}`] :


### PR DESCRIPTION
Motivation:

dcache-view can be use to generate macaroon, this is
currently done by making a POST request to the webdav
door url plus the file path, something like:
    `https://webdav-door-url:[port-number]/file-path`
At the same time, inside the body of the request,
the path variable is also set to the file path. The
genrated macaroon as a result of this request will
contain two `cid path` hence the macaroon not to
function properly or as expected.

Modification:

Set the url to `/`

Result:

The macaroon generated now works as intended.

Target: master
Request: 1.6
Request: 1.5
Requires-notes: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/12199/

(cherry picked from commit e5a586359fd69bbc41c4930139cd9c626cdd234c)