### PR TITLE
dcache-view (sse): make a stat call on a new entry

### DIFF
--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -869,7 +869,7 @@
                     if (mask.indexOf("IN_CREATE") > -1) {
                         this._inotifyCreate(ev);
                     } else if (mask.indexOf("IN_ATTRIB") > -1) {
-                        this._inotifyAttrib(ev)
+                        this._inotifyAttrib(ev.name)
                     } else if (mask.indexOf("IN_DELETE") > -1) {
                         this._inotifyDelete(ev);
                     } else if (mask.indexOf("IN_MOVED_FROM") > -1) {
@@ -927,11 +927,11 @@
                 }
             }
 
-            _inotifyAttrib(event)
+            _inotifyAttrib(name)
             {
-                this._getFileAttribute(event.name).then(metadata => {
-                    metadata["fileName"] = event.name;
-                    const index = this.__getItemCurrentIndex({"fileName": event.name});
+                this._getFileAttribute(name).then(metadata => {
+                    metadata["fileName"] = name;
+                    const index = this.__getItemCurrentIndex({"fileName": name});
                     this.$.feList.set(`items.${index}`, metadata);
                 });
             }
@@ -1003,6 +1003,7 @@
             _inotifyAddEntry(event)
             {
                 this._inotifyCreate(event);
+                this._inotifyAttrib(event.newName);
                 this._removeEntryFromInotifyArrays(event)
             }
         }


### PR DESCRIPTION
Motivation:

When a new entry is created through file move operation, the
displayed file information is very limited.

Modification:

- change the argument of `_inotifyAttrib` to file's name and
    adjust the usage.
- make a stat call by adding `_inotifyAttrib` to `_inotifyAddEntry`

Result:

Full file information is displayed when a new entry is added.

Target: master
Request: 1.6
Requires-notes: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/12198/

(cherry picked from commit cf2b19c88d509e4c347f38db9d9459e0a790812a)