### PR TITLE
dcache-view (file-metadata): fix issue 225

### DIFF
--- a/src/elements/dv-elements/file-metadata-dashboard/file-metadata-dashboard.html
+++ b/src/elements/dv-elements/file-metadata-dashboard/file-metadata-dashboard.html
@@ -428,21 +428,16 @@
             }
             _requestFileMetadataWithPnfsId(pnfsId)
             {
-                if (pnfsId !== "0") {
-                    if (this.knownMetadata.acl) {
-                        this.setProperties({metadata: this._filterMetadata(this.knownMetadata)});
-                        return;
-                    }
-                    this._requestFileMetadata({'scope': 'full'}).then(data => {
-                        this.setProperties({metadata: this._filterMetadata(data)});
-                    }).catch(err => {
-                        //Fail Quietly
-                        this.setProperties({metadata: this._filterMetadata(this.knownMetadata)});
-                    })
-                } else {
-                    // TODO: user should never hit this block but if they do, make a request for the pnfsID
-                    console.info('waiting for pnfsId value');
+                if (pnfsId !== "0" && this.knownMetadata.acl) {
+                    this.setProperties({metadata: this._filterMetadata(this.knownMetadata)});
+                    return;
                 }
+                this._requestFileMetadata({'scope': 'full'}).then(data => {
+                    this.setProperties({metadata: this._filterMetadata(data)});
+                }).catch(err => {
+                    //Fail Quietly
+                    this.setProperties({metadata: this._filterMetadata(this.knownMetadata)});
+                })
             }
             _filterMetadata(metadata)
             {


### PR DESCRIPTION
Motivation:

https://github.com/dCache/dcache-view/issues/225

Modification:

Request full file metadata provided the known one
    doesn't contain all necessary information.

Result:

User won't need to refresh a page before they can see
file's details, that is, file metadata when a file is
uploaded.

Target: master
Request: 1.6
Request: 1.5
Require-notes: no
Fixes: https://github.com/dCache/dcache-view/issues/225
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/12203/

(cherry picked from commit 6961ba431f276e86ba45e0cf6bec6607f6786561)