### PR TITLE
dcache-view (rename): fix rename operation handling

### DIFF
--- a/src/elements/dv-elements/list-view/list-row.html
+++ b/src/elements/dv-elements/list-view/list-row.html
@@ -55,7 +55,6 @@
                 padding-left:5px;
             }
             #nameContainer {
-                display: flex;
                 align-items: center;
                 padding-right: 24px;
             }
@@ -119,6 +118,7 @@
             <div class="cell name">
                 <div id="nameContainer">
                     <span id="fileName">[[fileMetaData.fileName]]</span>
+                    <div id="rename" class="none"></div>
                 </div>
             </div>
             <div class="cell ctime">[[creationTime]]</div>
@@ -336,6 +336,19 @@
                     clientX: event.clientX,
                     clientY: event.clientY
                 }));
+            }
+            manualRenameStart(file, auth)
+            {
+                const input = new RenameInput(file, auth);
+                this.$["fileName"].classList.add("none");
+                this.$["rename"].classList.remove("none");
+                this.$["rename"].appendChild(input);
+            }
+            manualRenameEnd()
+            {
+                this.$["fileName"].classList.remove("none");
+                this.$["rename"].classList.add("none");
+                this.removeAllChildren(this.$["rename"]);
             }
         }
         window.customElements.define(ListRow.is, ListRow);

--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -386,24 +386,16 @@
             {
                 const listRow =
                     this.$.feList.querySelector(`._dv${e.detail.file.fileMetaData.pnfsId}`);
-                const input = new RenameInput(e.detail.file, this.getAuthValue());
-                this.removeAllChildren(listRow.$.nameContainer);
-                listRow.$.nameContainer.appendChild(input);
+                listRow.manualRenameStart(e.detail.file, this.getAuthValue());
             }
 
             _renameInputEnd(e)
             {
                 const listRow = this.$.feList.querySelector(`._dv${e.detail.pnfsId}`);
-                const span = document.createElement('span');
-                span.setAttribute("id", "fileName");
-                const t = document.createTextNode(`${e.detail.newFileName}`);
-                span.appendChild(t);
-                this.removeAllChildren(listRow.$.nameContainer);
-                listRow.$.nameContainer.appendChild(span);
-
-                const index = this.__findItemIndexOnAList(this.$.feList.items, e.detail.pnfsId, "pnfsId");
-                this.$.feList.items[index].fileName = e.detail.newFileName;
-                this.$.feList.notifyPath(`items.${index}.fileName`);
+                const index = this.__findItemIndexOnAList(this.$["feList"].items, e.detail.pnfsId, "pnfsId");
+                this.$["feList"].items[index].fileName = e.detail.newFileName;
+                this.$["feList"].notifyPath(`items.${index}.fileName`);
+                listRow.manualRenameEnd();
             }
 
             _loadNamespaceData()


### PR DESCRIPTION
Motivation:

The implementation of event streaming in dcache-view expose
a long time bug in how the rename operation is handled. DV
dynamically create a `span` tag for the name after the rename
opereation is complete. This however create an artificial tag
that won't change position if another file is added to the
list and making it look like the new file has the same name
with the renamed file.

Modification:

- move the rename node handling out of view-file, only update
    the necessary metadata.
- let each list-row elements handle the rename operation as
    appropriate.

Result:

Proper handling of rename operation and no more flaky display.

Target: master
Request: 1.6
Request: 1.5
Requires-notes: no
Acked-by: Paul Millar

Reviewed at https://rb.dcache.org/r/12220/

(cherry picked from commit 7dd691f3bdbbab069cadda123cb545ed1dd0aa9b)
