### PR TITLE
dcache-view (webdav): fix door selection

### DIFF
--- a/src/elements/dv-elements/utils/mixins/commons.html
+++ b/src/elements/dv-elements/utils/mixins/commons.html
@@ -177,8 +177,8 @@
                 } else {
                     throw new TypeError("Invalid path: only absolute path is accepted.");
                 }
-                const arr = window.CONFIG["webdav"] ?
-                    window.CONFIG["webdav"][operationType] : window.CONFIG["dcache-view.endpoints.webdav"] ?
+                const arr = window.CONFIG["webdav"][operationType].length > 0 ?
+                    window.CONFIG["webdav"][operationType] : window.CONFIG["dcache-view.endpoints.webdav"] !== "" ?
                         [window.CONFIG["dcache-view.endpoints.webdav"]] :
                         [`${window.location.protocol}//${window.location.hostname}:2880`];
                 const len = arr.length;

--- a/src/scripts/dv.js
+++ b/src/scripts/dv.js
@@ -478,8 +478,8 @@
         } else {
             throw new TypeError("Invalid path: only absolute path is accepted.");
         }
-        const arr = window.CONFIG["webdav"] ?
-            window.CONFIG["webdav"][operationType] : window.CONFIG["dcache-view.endpoints.webdav"] ?
+        const arr = window.CONFIG["webdav"][operationType].length > 0 ?
+            window.CONFIG["webdav"][operationType] : window.CONFIG["dcache-view.endpoints.webdav"] !== "" ?
                 [window.CONFIG["dcache-view.endpoints.webdav"]] :
                 [`${window.location.protocol}//${window.location.hostname}:2880`];
         const len = arr.length;


### PR DESCRIPTION
Motivation:

As raised https://github.com/dCache/dcache-view/issues/231, some sites
want to a particular dcache-view to use a particular webdav door. With
some configuration's twisting this is possible, however the functions
used to calculate the webdav file path hasn't factor-in this scenario.

Modification:

Adjust the webdav file path calculation to use the static value in
frontend configuration when the frontent api for door returns an
empty list.

Result:

Webdav door selection in dcache-view now work even when frontent api
returns an empty list.

Target: master
Request: 1.6
Request: 1.5
Requires-notes: no
Acked-by: Marina Sahakyan
Fixes: https://github.com/dCache/dcache-view/issues/231

Reviewed at https://rb.dcache.org/r/12252/

(cherry picked from commit a19e3ec4dbf585291b9723b42cf838d7640da6a6)