### PR TITLE
dcache-view: fix off-by-one indexing error in pool plots*

### DIFF
--- a/src/elements/dv-elements/admin/charts/pool-info-chart.html
+++ b/src/elements/dv-elements/admin/charts/pool-info-chart.html
@@ -427,12 +427,12 @@
 
                 for (let t = (len/2).toFixed(0); t < len + 1; t++) {
                     tuple[0] = chartData[t][0];
-                    for (let j = 1; j < tuplen-1; j++) {
+                    for (let j = 1; j < tuplen; j++) {
                         tuple[j] += chartData[t][j];
                     }
 
                     if (t % 4 === 0) {
-                        for (let j = 1; j < tuplen-1; j++) {
+                        for (let j = 1; j < tuplen; j++) {
                             tuple[j] = (tuple[j]/4).toFixed(0)/1;
                         }
 


### PR DESCRIPTION
Motivation:

https://rb.dcache.org/r/10665
5f16b9113150c325b7fef01f74a758eb7d5bf26a

introduced the pool plots view components.
The original code included a method for
preprocessing data such that an excessive
number of data points was pruned down to
something manageable by the Google Charts
library (otherwise, rendering becomes
extremely slow).

That code, however, contained a bug which
has up to now gone unnoticed.  There
is an off-by-one iteration bound error
which prevents the last data series,
the queued restores, from being included
in the plot.

Modification:

Fix the boundary condition.

Result:

Queued restores are now visible (see attached).

Target: master
Request: 2.0
Request: 1.6
Requires-notes: yes
Requires-book: no
Patch: https://rb.dcache.org/r/13436/
Closes: #263
Acked-by: Dmitry

See [here](CONTRIBUTING.md#Submitting-Pull-Requests) for how to summit a pull 
request and the sample template for the commit message.
