### PR TITLE
Make file sharing work using cert auth and / served by static file

### DIFF
--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-file-generation.js
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-file-generation.js
@@ -53,11 +53,10 @@ class ShareableFileGeneration extends DcacheViewMixins.Commons(Polymer.Element)
             this._handleResponse(e)
         }, false);
         shareableLinkWorker.postMessage({
-            "url": this.getFileWebDavUrl("/", "read")[0],
+            "url": this.getFileWebDavUrl(this.fullPath, "read")[0],
             "body": {
                 "caveats": event.detail.activitiesList.length > 0 ?
-                    [`path:${this.fullPath}`, `activity: ${event.detail.activitiesList.join()}`] :
-                    [`path:${this.fullPath}`],
+                    [`activity: ${event.detail.activitiesList.join()}`] : [],
                 "validity":`${event.detail.validity}`
             },
             'upauth' : this.getAuthValue(),

--- a/src/scripts/tasks/macaroon-request-task.js
+++ b/src/scripts/tasks/macaroon-request-task.js
@@ -27,13 +27,14 @@ self.addEventListener('message', function(e) {
     fetch(e.data.url, {
         method: 'POST',
         mode: "cors",
+        credentials: "include",
         body: body,
         headers: headers
     }).then((response) => {
         if(response.ok) {
             return response.json();
         }
-        throw new Error('Network response was not ok.');
+        throw new Error('Network response was not ok: ' + response.statusText);
     }).then((rep) => {
         self.postMessage(rep);
     }).catch(function(err) {


### PR DESCRIPTION
For file share Macaroon requests to work with sessions using certificate
authentication, the credentials needs to be explicitly included in the
request.

Also, for setups where / is served by a static file doing POST to / returns an error.

In both cases, a generic error is returned to the user making it hard for a dCache admin reacting to an error report.

These patches addresses the above issues.

Fixes: https://github.com/dCache/dcache-view/issues/286
Fixes: https://github.com/dCache/dcache-view/issues/287