### PR TITLE
Default to Upload/Delete unchecked in Share dialog

### DIFF
--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-request-form/shareable-request-form.js
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-request-form/shareable-request-form.js
@@ -16,8 +16,8 @@ class ShareableRequestForm extends Polymer.Element
                 value: function () {
                     return [
                         {name: 'Download', description: '', checked: true},
-                        {name: 'Upload', description: '', checked: true},
-                        {name: 'Delete', description: '', checked: true},
+                        {name: 'Upload', description: '', checked: false},
+                        {name: 'Delete', description: '', checked: false},
                         {name: 'List', description: '', checked: true},
                     ];
                 },


### PR DESCRIPTION
Try to be safe by default.

Instead of requiring users to uncheck the dangerous upload/delete options each time they create a share, change the defaults so the user has to explicitly choose to create a share that allows upload/delete.

Fixes: https://github.com/dCache/dcache-view/issues/289
