### PR TITLE
file share: Display direct link and rclone config snippet

### DIFF
--- a/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
+++ b/src/elements/dv-elements/contextual-content/namespace-contextual-content.html
@@ -340,7 +340,8 @@
                     this.currentPath.endsWith('/') ?
                     `${this.currentPath}${this.targetNode.fileMetaData.fileName}`:
                     `${this.currentPath}/${this.targetNode.fileMetaData.fileName}`,
-                    this.authenticationParameters);
+                    this.authenticationParameters,
+                    this.targetNode.fileMetaData.fileType);
                 this.dispatchEvent(
                     new CustomEvent('dv-namespace-open-central-dialogbox', {
                         detail: {node: fileSharingForm}, bubbles: true, composed: true})

--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-file-generation.html
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-file-generation.html
@@ -13,8 +13,8 @@
                 display: flex;
                 flex-direction: column;
                 margin: 0 -24px !important;
-                width: 450px;
-                height: 340px;
+                width: 80vw;
+                height: 80vh;
                 font-size: 0.8em;
                 background: #fff;
                 box-sizing: border-box;
@@ -71,7 +71,7 @@
         <div id="content" class$="[[_computedClass(loading)]]">
             <shareable-request-form id="form"
                                     loading="{{loading}}"
-                                    file-path="[[fullPath]]" file-name="[[fileName]]"></shareable-request-form>
+                                    file-path="[[fullPath]]" file-name="[[fileName]]" file-type="[[fileType]]"></shareable-request-form>
         </div>
         <div class="loading" is-loading$="[[loading]]">
             <paper-spinner alt="waiting for response" active="{{loading}}"></paper-spinner>

--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-file-generation.js
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-file-generation.js
@@ -1,6 +1,6 @@
 class ShareableFileGeneration extends DcacheViewMixins.Commons(Polymer.Element)
 {
-    constructor(fn,fp,auth)
+    constructor(fn,fp,auth,ft)
     {
         super();
         this.fileName = fn;
@@ -8,6 +8,7 @@ class ShareableFileGeneration extends DcacheViewMixins.Commons(Polymer.Element)
         if (auth) {
             this.authenticationParameters = auth;
         }
+        this.fileType = ft;
 
         this._generateListener = this._generateResponseListener.bind(this)
     }
@@ -67,7 +68,7 @@ class ShareableFileGeneration extends DcacheViewMixins.Commons(Polymer.Element)
     {
         let contentChild;
         if (type === "successful") {
-            contentChild = new ShareableSuccessfulPage(this.fileName, this.fullPath, payload.macaroon);
+            contentChild = new ShareableSuccessfulPage(this.fileName, this.fullPath, this.fileType, payload);
         } else {
             console.error(payload);
             contentChild = new ShareableErrorPage(payload);

--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-request-form/shareable-request-form.html
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-request-form/shareable-request-form.html
@@ -89,7 +89,7 @@
         <div class="container">
             <div class="description">
                 <span>
-                    Generate a sharable link with macaroon for the file named: <b>[[fileName]]</b>
+                    Generate a shareable link for the [[dirOrFile]]: <b>[[filePath]]</b>
                 </span>
             </div>
             <div class="form">

--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-request-form/shareable-request-form.js
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-request-form/shareable-request-form.js
@@ -1,5 +1,13 @@
 class ShareableRequestForm extends Polymer.Element
 {
+    constructor(fn,fp,ft)
+    {
+        super();
+        this.fileName = fn;
+        this.filePath = fp;
+        this.fileType = ft;
+        this.dirOrFile = this.typeChanged(this.fileType);
+    }
     static get is()
     {
         return "shareable-request-form";
@@ -8,6 +16,19 @@ class ShareableRequestForm extends Polymer.Element
     {
         return {
             fileName: {
+                type: String,
+                notify: true
+            },
+            filePath: {
+                type: String,
+                notify: true
+            },
+            fileType: {
+                type: String,
+                observer: 'typeChanged',
+                notify: true
+            },
+            dirOrFile: {
                 type: String,
                 notify: true
             },
@@ -28,6 +49,9 @@ class ShareableRequestForm extends Polymer.Element
                 notify: true
             },
         }
+    }
+    typeChanged(fileType) {
+        this.dirOrFile = fileType === 'DIR' ? 'directory' : 'file';
     }
     _getLink()
     {

--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-successful-page/shareable-successful-page.html
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-successful-page/shareable-successful-page.html
@@ -32,7 +32,6 @@
                 padding-right: 10px;
             }
             .qr-container {
-                width: 190px;
                 margin-left: 10px;
                 box-sizing: border-box;
                 display: flex;
@@ -41,16 +40,13 @@
             .image-container {
                 flex: 1 1 auto;
                 box-sizing: border-box;
-                padding: 5%;
-            }
-            .image-container > img {
-                width: 100%;
+                text-align: center;
             }
 
             .link, .macaroon {
                 display: flex;
                 flex-direction: column;
-                height: 48%;
+                height: 20%;
                 box-sizing: border-box;
             }
             .link {
@@ -75,6 +71,7 @@
             .txt {
                 flex: 1 1 auto;
                 word-wrap: break-word;
+                word-break: break-all;
                 text-align: justify;
                 text-justify: inter-word;
                 text-indent: 0;
@@ -86,6 +83,16 @@
                 width: 100%;
                 margin: 0;
             }
+            .help-icon {
+                width:15px;
+                height:15px;
+                fill: #828282
+            }
+            .help-icon-container {
+                display:inline-block;
+                padding-left: 5px;
+            }
+
             .blue {
                 background: #03a9f4;
                 color: white;
@@ -102,29 +109,79 @@
         </style>
         <div class="description">
             <p>
-                File name: <b>[[fileName]]</b>. Copy the generated shareable link or download the QR code.
+                [[dirOrFile]] name: <b>[[fullPath]]</b>
             </p>
         </div>
         <div class="result">
             <div class="text-container">
                 <div class="link">
                     <div class="top">
-                        <span><b>Shareable Link:</b></span>
+                        <span>
+                            <b>Shareable Link:</b>
+                            <div class="help-icon-container">
+                                <iron-icon icon="help" class="help-icon"></iron-icon>
+                                <paper-tooltip>Shareable link with the [[dirOrFile]] shown on a landing page. Requires a web browser for access.</paper-tooltip>
+                            </div>
+                        </span>
                     </div>
                     <div class="body">
-                        <textarea id="linkText" class="txt" readonly title="">[[generatedLink]]</textarea>
+                        <textarea id="linkText" class="txt" rows="1" readonly title="">[[generatedLink]]</textarea>
                     </div>
                     <div class="button">
                         <paper-button class="blue" on-tap="_copyLink" raised>
                             <iron-icon icon="link"> </iron-icon>&nbsp;Copy link</paper-button>
                     </div>
                 </div>
-                <div class="macaroon">
+                <div class="link">
                     <div class="top">
-                        <span><b>Macaroon:</b></span>
+                        <span>
+                            <b>Direct Link:</b>
+                            <div class="help-icon-container">
+                                <iron-icon icon="help" class="help-icon"></iron-icon>
+                                <paper-tooltip>Direct link to the [[dirOrFile]] for access. Suitable for use with non-browser tools like curl, wget, rclone, download managers, etc.</paper-tooltip>
+                            </div>
+                        </span>
                     </div>
                     <div class="body">
-                        <textarea id="macaroonText" class="txt" readonly title="">[[macaroon]]</textarea>
+                        <textarea id="linkDirect" class="txt" rows="1" readonly title="">[[directLink]]</textarea>
+                    </div>
+                    <div class="button">
+                        <paper-button class="blue" on-tap="_copyDirect" raised>
+                            <iron-icon icon="link"> </iron-icon>&nbsp;Copy link</paper-button>
+                    </div>
+                </div>
+                    <div class="link">
+                        <div class="top">
+                            <span>
+                                <b><a href="https://rclone.org/webdav/#dcache">Rclone</a> config:</b>
+                                <template is="dom-if" if="[[_equal(fileType, 'DIR')]]">
+                                    <div class="help-icon-container">
+                                        <iron-icon icon="help" class="help-icon"></iron-icon>
+                                        <paper-tooltip>Configuration snippet for the rclone utility to add a remote named <b>[[fileName]]</b> with access using the generated token. Typically added to your <tt>.config/rclone/rclone.conf</tt> file.</paper-tooltip>
+                                    </div>
+                                </template>
+                            </span>
+                        </div>
+                        <div class="body">
+                            <textarea id="rcloneConf" class="txt" readonly title="">[[rcloneRC]]</textarea>
+                        </div>
+                        <div class="button">
+                            <paper-button class="green" on-tap="_copyRclone" raised>
+                                <iron-icon icon="content-copy"> </iron-icon>&nbsp;Copy Rclone config</paper-button>
+                        </div>
+                    </div>
+                <div class="macaroon">
+                    <div class="top">
+                        <span>
+                            <b>Macaroon:</b>
+                            <div class="help-icon-container">
+                                <iron-icon icon="help" class="help-icon"></iron-icon>
+                                <paper-tooltip>The actual access token (only).</paper-tooltip>
+                            </div>
+                        </span>
+                    </div>
+                    <div class="body">
+                        <textarea id="macaroonText" class="txt" rows="1" readonly title="">[[macaroon]]</textarea>
                     </div>
                     <div class="button">
                         <paper-button class="green" on-tap="_copyMacaroon" raised>
@@ -133,14 +190,28 @@
                 </div>
             </div>
             <div class="qr-container">
-                <div class="top">
-                    <span><b>QR Code for the shareable link:</b></span>
+                <div class="qr">
+                    <div class="top">
+                        <span><b>QR Code for the shareable link:</b></span>
+                    </div>
+                    <div class="image-container paper-material" elevation="1">
+                        <img src$="[[generatedQR]]">
+                        <div class="button">
+                            <paper-button on-tap="_downloadGenQR">
+                                <iron-icon icon="file-download"></iron-icon>Download QR code</paper-button>
+                        </div>
+                    </div>
                 </div>
-                <div class="image-container paper-material" elevation="1">
-                    <img src$="[[src]]">
-                    <div class="button">
-                        <paper-button on-tap="_downloadQR">
-                            <iron-icon icon="file-download"></iron-icon>Download the QR code</paper-button>
+                <div class="qr">
+                    <div class="top">
+                        <span><b>QR Code for the direct link:</b></span>
+                    </div>
+                    <div class="image-container paper-material" elevation="1">
+                        <img src$="[[directQR]]">
+                        <div class="button">
+                            <paper-button on-tap="_downloadDirectQR">
+                                <iron-icon icon="file-download"></iron-icon>Download QR code</paper-button>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-successful-page/shareable-successful-page.js
+++ b/src/elements/dv-elements/file-sharing/shareable-file-generation/shareable-successful-page/shareable-successful-page.js
@@ -1,20 +1,44 @@
 class ShareableSuccessfulPage extends Polymer.Element
 {
-    constructor(fn, fp, m)
+    constructor(fn, fp, ft, p)
     {
         super();
         this.fileName = fn;
         this.fullPath = fp;
-        this.macaroon = m;
+        this.fileType = ft;
+        this.payload = p;
 
+        this.macaroon = this.payload.macaroon;
         this.generatedLink = `${window.location.origin}/#!/shared-link?m=${this.macaroon}`;
-        this.src = QRCode.generatePNG(this.generatedLink, {
-            modulesize: 5,
+        this.directLink = `${this.payload.uri.targetWithMacaroon}`;
+        this.dirOrFile = this.fileType === 'DIR' ? 'Directory' : 'File';
+        this.generatedQR = QRCode.generatePNG(this.generatedLink, {
+            modulesize: 2,
             margin: 4,
             version: -1,
             ecclevel: "L",
             mask: -1,
         });
+        this.directQR = QRCode.generatePNG(this.directLink, {
+            modulesize: 2,
+            margin: 4,
+            version: -1,
+            ecclevel: "L",
+            mask: -1,
+        });
+        if(this.fileType === 'DIR') {
+            this.rcloneRC = `[${this.fileName}]
+type = webdav
+url = ${this.payload.uri.target}
+vendor = other
+user =
+pass =
+bearer_token = ${this.macaroon}
+`;
+        }
+        else {
+            this.rcloneRC = "Only applicable to directories.";
+        }
     }
     static get is()
     {
@@ -31,7 +55,11 @@ class ShareableSuccessfulPage extends Polymer.Element
                 type: String,
                 notify: true
             },
-            src: {
+            generatedQR: {
+                type: String,
+                notify: true
+            },
+            directQR: {
                 type: String,
                 notify: true
             },
@@ -43,6 +71,18 @@ class ShareableSuccessfulPage extends Polymer.Element
                 type: String,
                 notify: true
             },
+            directLink: {
+                type: String,
+                notify: true
+            },
+            dirOrFile: {
+                type: String,
+                notify: true
+            },
+            rcloneRC: {
+                type: String,
+                notify: true
+            },
         }
     }
     _copy(id)
@@ -51,10 +91,9 @@ class ShareableSuccessfulPage extends Polymer.Element
         copiedLink.select();
         try {
             const successful = document.execCommand('copy');
-            const msg = successful ? 'successful' : 'unsuccessful';
-            const linkOrMacaroon = id === "linkText"? 'Shareable link' : 'Macaroon';
+            const msg = successful ? 'Copied to clipboard' : 'Failed copy';
             window.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast',
-                {detail: {message: `${linkOrMacaroon} copied ${msg}`}}
+                {detail: {message: `${msg}.`}}
             ));
         } catch (err) {
             window.dispatchEvent(new CustomEvent('dv-namespace-show-message-toast',
@@ -66,16 +105,34 @@ class ShareableSuccessfulPage extends Polymer.Element
     {
         this._copy("linkText");
     }
+    _copyDirect()
+    {
+        this._copy("linkDirect");
+    }
+    _copyRclone()
+    {
+        this._copy("rcloneConf");
+    }
     _copyMacaroon()
     {
         this._copy("macaroonText");
     }
-    _downloadQR()
+    _downloadGenQR()
     {
         const a = document.createElement('a');
-        a.href = this.src;
-        a.download = `${this.fileName}_qrcode.png`;
+        a.href = this.generatedQR;
+        a.download = `${this.fileName}_share_qr.png`;
         a.click();
+    }
+    _downloadDirectQR()
+    {
+        const a = document.createElement('a');
+        a.href = this.directQR;
+        a.download = `${this.fileName}_direct_qr.png`;
+        a.click();
+    }
+    _equal(a, b) {
+        return a === b;
     }
 }
 window.customElements.define(ShareableSuccessfulPage.is, ShareableSuccessfulPage);

--- a/src/elements/dv-elements/file-sharing/shared-files-page/context-menu/shared-file-list-contextual-content.js
+++ b/src/elements/dv-elements/file-sharing/shared-files-page/context-menu/shared-file-list-contextual-content.js
@@ -127,7 +127,7 @@ class SharedFileListContextualContent extends Polymer.Element
             bubbles: true, composed: true
         }));
         const fileSharingForm =
-            new ShareableRequestForm(this.targetNode.fileMetaData.fileName, this.targetNode.filePath);
+            new ShareableRequestForm(this.targetNode.fileMetaData.fileName, this.targetNode.filePath, this.targetNode.fileMetaData.fileType);
         this.dispatchEvent(
             new CustomEvent('dv-namespace-open-central-dialogbox', {
                 detail: {node: fileSharingForm}, bubbles: true, composed: true})


### PR DESCRIPTION
Display direct link (including QR code) to shared object.

If the shared object is a directory, also includes an rclone config snippet for easy access using the rclone utility, as documented on https://rclone.org/webdav/#dcache

QR codes are now generated in a more proper size instead of being scaled down, this makes it easier for QR reader apps to parse them.

*NOTE:* The related layout fixes are very crude, and likely needs to be reworked by someone more proficient in the framework and HTML/CSS interaction.

In order to give the user more context, the share dialogs print the complete object name together with information on whether it's a file or directory.

Also, help tooltips are added to the success dialog.

In addition there are also minor fixes related to spelling/layout etc.

Fixes: https://github.com/dCache/dcache-view/issues/246
