### PR TITLE
file-list: Also display unix mode/permissions

### DIFF
--- a/src/elements/dv-elements/file-metadata-dashboard/file-metadata-mapper.html
+++ b/src/elements/dv-elements/file-metadata-dashboard/file-metadata-mapper.html
@@ -310,7 +310,7 @@
                 }
 
                 if (metadata.mode) {
-                    metadata.mode = this.convertToUnixPermissions(metadata.mode);
+                    metadata.mode = this.convertToUnixPermissions(metadata.mode, metadata.fileType);
                 }
 
                 for (const objectKey in metadata) {

--- a/src/elements/dv-elements/list-view/list-row.html
+++ b/src/elements/dv-elements/list-view/list-row.html
@@ -82,6 +82,11 @@
                     flex: 1 1 auto;
                     max-width: calc(100% - 410px);
                 }
+                .mode {
+                    width: 12ex;
+                    max-width: 12ex;
+                    min-width: 12ex;
+                }
                 .ctime, .qos {
                     width: 150px;
                     max-width: 150px;
@@ -103,7 +108,7 @@
                     flex: 1 1 auto;
                     max-width: calc(100% - 50px);
                 }
-                .ctime, .qos, .size {
+                .mode, .ctime, .qos, .size {
                     display: none;
                 }
             }
@@ -121,6 +126,7 @@
                     <div id="rename" class="none"></div>
                 </div>
             </div>
+            <div class="cell mode">[[fileMode]]</div>
             <div class="cell ctime">[[creationTime]]</div>
             <div class="cell qos">
                 <iron-icon id="qos-transition-icon" class="none" icon="arrow-forward"></iron-icon>
@@ -160,6 +166,10 @@
                     filePath: {
                         type: String,
                         computed:'_computeFilePath(parentPath, fileMetaData.fileName)'
+                    },
+                    fileMode: {
+                        type: String,
+                        computed:'_computeFileMode(fileMetaData.mode, fileMetaData.fileType)'
                     },
                     qosValue: {
                         type: String,
@@ -277,6 +287,11 @@
             {
                 return parentPath.endsWith("/") ?
                     `${parentPath}${fileName}`: `${parentPath}/${fileName}`;
+            }
+
+            _computeFileMode(mode, type)
+            {
+                return this.convertToUnixPermissions(mode, type);
             }
 
             _fileCurrentQOSValue(qos)

--- a/src/elements/dv-elements/table-header/list-row-header.html
+++ b/src/elements/dv-elements/table-header/list-row-header.html
@@ -33,6 +33,11 @@
                     flex: 1 1 auto;
                     max-width: calc(100% - 418px); /*This is weird, I don't know where the 8px is coming from*/
                 }
+                .mode {
+                    width: 12ex;
+                    max-width: 12ex;
+                    min-width: 12ex;
+                }
                 .ctime, .qos {
                     width: 150px;
                     max-width: 150px;
@@ -51,7 +56,7 @@
                     flex: 1 1 auto;
                     max-width: calc(100% - 50px);
                 }
-                .ctime, .qos, .size {
+                .mode, .ctime, .qos, .size {
                     display: none;
                 }
             }
@@ -63,6 +68,7 @@
         <div class="row cell">
             <div class="cell file-icon">Type</div>
             <div class="cell name">Name</div>
+            <div class="cell mode">Mode</div>
             <div class="cell ctime">Creation time</div>
             <div class="cell qos">File location</div>
             <div class="cell size">Size</div>

--- a/src/elements/dv-elements/utils/mixins/commons.html
+++ b/src/elements/dv-elements/utils/mixins/commons.html
@@ -21,7 +21,7 @@
                     }
                 };
             }
-            convertToUnixPermissions(mode)
+            convertToUnixPermissions(mode, filetype)
             {
                 const S_IRUSR = 0o0400; // owner has read permission
                 const S_IWUSR = 0o0200; // owner has write permission
@@ -42,6 +42,20 @@
                 const S_IFCHR = 0o020000; // Character device
                 const S_IFIFO = 0o010000; // Named pipe
                 const F_TYPE = 0o170000;
+
+                /**
+                 * dCache doesn't have the file type in the mode flags, so
+                 * allow this to be injected separately.
+                 */
+                if(filetype === "REGULAR") {
+                    mode |= S_IFREG;
+                }
+                else if(filetype === "DIR") {
+                    mode |= S_IFDIR;
+                }
+                else if(filetype === "LINK") {
+                    mode |= S_IFLNK;
+                }
 
                 const modeChars = ['-', '-', '-', '-', '-', '-', '-', '-', '-', '-',];
                 const type = mode & F_TYPE;


### PR DESCRIPTION
Users sometimes wants to know the mode (permission) flags of objects without having to show the file details of each individual item.

This patch adds the familiar unix ls-style representation to the file listing.

In order to closer resemble the familiar/expected style, the common function convertToNameValueObject() is also augmented with an optional parameter that allows displaying the file type instead of ? since the mode bits available doesn't include this information.

Fixes: https://github.com/dCache/dcache-view/issues/202

