### PR TITLE
Sort file view by file name

### DIFF
--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -321,10 +321,15 @@
                 const children = response.children;
                 this._namespaceRequestMessage = "successful";
                 if (!(children.length === 0 && this.__counter__ === 0)) {
+                    /* Kludge, iron-list relies on the input array to be
+                     * sorted it seems...
+                     */
+                    children.sort(this._fileNameCompare);
                     children.forEach((child) => {
                         this.$.feList.push('items', child)
                     });
                     this.$.threshold.clearTriggers();
+
                     if (children.length > 0) {
                         this.__counter__++;
                         this.$.feList.fire('iron-resize');
@@ -337,6 +342,13 @@
                     this.currentDirMetaData.fileName = this.currentDirName;
                 }
                 this._updateContentElevationAttribute();
+            }
+            _fileNameCompare(a, b) {
+                if (a.fileName < b.fileName)
+                    return -1;
+                if (a.fileName > b.fileName)
+                    return 1;
+                return 0;
             }
 
             handleError(error)
@@ -440,8 +452,8 @@
                     'file' : this.currentDirMetaData,
                     'filePath' : this.encodePath(this.path),
                     'scope' : 'partial',
-                    'limit' : 100,
-                    'offset' : this.__counter__ * 100,
+                    'limit' : 10000, // Each chunk is sorted in handleResponse()
+                    'offset' : this.__counter__ * 10000,
                     'upauth' : this.getAuthValue()
                 };
                 this.fileMetadataPromise(message).then(metadata => {


### PR DESCRIPTION
Currently the file view is unsorted, which causes great frustration among users even when dealing with a small amount of items.

Since the Polymer iron-list doesn't seem to have a built-in functionality the general method of tackling this seems to be to sort the input data, which matches badly with the chunked approach of obtaining the file listing from the webdav endpoint.  In order to quickly get a solution in place that placates users, this is a bare-minimum approach that increases the file listing chunk size from 100 to 10000 items, and sorts each chunk before adding it to the iron-list file listing.

The result of this being that file listings are sorted if they contain up to 10000 items, for listings larger than the file listings will look a bit weird with groupings of sorted chunks. Quick testing suggests that it's the listing operation that takes time and not the sorting, so the chunk size could likely be increased even more.

Fixes: https://github.com/dCache/dcache-view/issues/285
