### PR TITLE
Fix file listing sort regression

### DIFF
--- a/src/elements/dv-elements/utils/ajax-ls/view-file.html
+++ b/src/elements/dv-elements/utils/ajax-ls/view-file.html
@@ -344,7 +344,7 @@
                 this._updateContentElevationAttribute();
             }
             _fileNameCompare(a, b) {
-                b.fileName.localeCompare(a.fileName);
+                return a.fileName.localeCompare(b.fileName);
             }
 
             handleError(error)


### PR DESCRIPTION
Motivation:

File list sorting was merged in 52537862fa7a37f5ea7f78693461148abe5954e2 but promptly broken in 81abbc9ef12fa4157b882da90632f857c32382f2 with a partial fix in 51726b4d35932ae941989f09e33c80c198b11304, that fix was however incomplete and behavior regressed into showing unsorted file listings.

Modification:

Return the actual value from the localeCompare() operation, and apply arguments in the correct order to get ascending order sort.

Result:

Sorted file listings, ascending.

Target: master

Request: 3.0

Signed-off-by: Niklas Edmundsson <nikke@hpc2n.umu.se>

Fixes: https://github.com/dCache/dcache-view/issues/299
